### PR TITLE
fix(review 2): metadata key ownership, independent deploy secrets, locked repair scripts

### DIFF
--- a/app/scripts/fly-secrets.sh
+++ b/app/scripts/fly-secrets.sh
@@ -1,32 +1,28 @@
 #!/usr/bin/env bash
-# Stage runtime secrets on Fly for this app. Values are read from ./.env.production (never printed,
-# never committed — see .env.example for the keys). DATABASE_URL is set by `fly postgres attach`.
+# Stage runtime secrets on Fly for this app, reading EVERY value independently from one env file
+# (default ./.env.production — see .env.example for the keys; never committed, never printed).
+# DATABASE_URL is set by `fly postgres attach`, the image bucket by `fly storage create` — not here.
 # Staged secrets apply on the next `fly deploy`. Re-runnable.
-#   FLY_APP     = Fly app name (default: basebid — the live openlaunch.lol app; set your own for a fork)
-#   SECRETS_ENV = file to read (default: .env.production)
+#   FLY_APP     = Fly app name            (default: basebid — the live openlaunch.lol app)
+#   SECRETS_ENV = file to read            (default: .env.production)
+#   --dry-run   = print what would be staged, do not call fly
 set -euo pipefail
 cd "$(dirname "$0")/.."
 APP=${FLY_APP:-basebid}
-WEB=${SECRETS_ENV:-.env.production}
-[ -f "$WEB" ] || { echo "missing $WEB — copy .env.example to $WEB and fill in the production values"; exit 1; }
-val() { grep -E "^$2=" "$1" | head -1 | cut -d= -f2- | sed 's/^"//;s/"$//'; }
-args=()
-add() { [ -n "${2:-}" ] && args+=("$1=$2") && echo "  staged $1" || echo "  SKIP $1 (empty)"; }
-# Token logo bucket: created by `fly storage create -a basebid -n openlaunch-images --public` (stages AWS_ACCESS_KEY_ID/
-# BASE_B20_RPC_URL (optional): Base node that executes B20 precompiles (Coinbase tokenized stocks). Alchemy answers
-#   "EVM error OpcodeNotFound" for those; default fallback is https://base-rpc.publicnode.com.
-#   AWS_SECRET_ACCESS_KEY/AWS_ENDPOINT_URL_S3/AWS_REGION/BUCKET_NAME itself) — not managed here.
+FILE=${SECRETS_ENV:-.env.production}
+DRY=0; [[ "${1:-}" == "--dry-run" ]] && DRY=1
+[ -f "$FILE" ] || { echo "missing $FILE — copy .env.example to $FILE and fill in the production values"; exit 1; }
 
-add BASE_RPC_URL "$(val $WEB BASE_RPC_URL)"
-add ROBINHOOD_RPC_URL "$(val $WEB BASE_RPC_URL | sed -E "s#base-mainnet#robinhood-mainnet#")"
-add NEXT_PUBLIC_CHAIN base
-add NEXT_PUBLIC_SITE_URL https://openlaunch.lol
-add NEXT_PUBLIC_LAUNCH_FACTORY "${NEXT_PUBLIC_LAUNCH_FACTORY:-}"
-add NEXT_PUBLIC_LAUNCH_LOCKER "${NEXT_PUBLIC_LAUNCH_LOCKER:-}"
-add LAUNCH_DEPLOY_BLOCK "${LAUNCH_DEPLOY_BLOCK:-}"
-add NEXT_PUBLIC_LAUNCH_FACTORY_ROBINHOOD "${NEXT_PUBLIC_LAUNCH_FACTORY_ROBINHOOD:-}"
-add NEXT_PUBLIC_LAUNCH_LOCKER_ROBINHOOD "${NEXT_PUBLIC_LAUNCH_LOCKER_ROBINHOOD:-}"
-add LAUNCH_DEPLOY_BLOCK_ROBINHOOD "${LAUNCH_DEPLOY_BLOCK_ROBINHOOD:-}"
+val() { { grep -E "^$1=" "$FILE" || true; } | head -1 | cut -d= -f2- | sed 's/^"//;s/"$//'; }
 
+REQUIRED=(BASE_RPC_URL ROBINHOOD_RPC_URL NEXT_PUBLIC_SITE_URL NEXT_PUBLIC_LAUNCH_FACTORY NEXT_PUBLIC_LAUNCH_LOCKER LAUNCH_DEPLOY_BLOCK NEXT_PUBLIC_LAUNCH_FACTORY_ROBINHOOD NEXT_PUBLIC_LAUNCH_LOCKER_ROBINHOOD LAUNCH_DEPLOY_BLOCK_ROBINHOOD)
+OPTIONAL=(BASE_B20_RPC_URL LAUNCH_SYNC_CONFIRMATIONS LAUNCH_SYNC_LOOP ADMIN_WALLETS IMAGE_PUBLIC_BASE)
+
+args=(); missing=()
+for k in "${REQUIRED[@]}"; do v=$(val "$k"); if [ -n "$v" ]; then args+=("$k=$v"); echo "  staged $k"; else missing+=("$k"); fi; done
+for k in "${OPTIONAL[@]}"; do v=$(val "$k"); if [ -n "$v" ]; then args+=("$k=$v"); echo "  staged $k"; else echo "  skip   $k (not set)"; fi; done
+if [ ${#missing[@]} -gt 0 ]; then echo "missing required keys in $FILE: ${missing[*]}"; exit 1; fi
+
+if [ $DRY -eq 1 ]; then echo "dry run: ${#args[@]} secrets would be staged on app '$APP' (values not shown)"; exit 0; fi
 fly secrets set -a "$APP" --stage "${args[@]}" >/dev/null
-echo "done. NEXT_PUBLIC_LAUNCH_FACTORY / _LOCKER are also BUILD args (see fly.toml header)."
+echo "done: ${#args[@]} secrets staged on '$APP'. NEXT_PUBLIC_LAUNCH_* are also BUILD args (see the fly.toml header)."

--- a/app/scripts/rebuild-holders.sql
+++ b/app/scripts/rebuild-holders.sql
@@ -2,6 +2,10 @@
 -- per-launch holders counters. Idempotent; safe to run any time (a few thousand rows).
 -- Usage: fly ssh console -a basebid-db -C "sh -c 'PGPASSWORD=$OPERATOR_PASSWORD psql -h localhost -p 5433 -U postgres -d basebid -f /tmp/rebuild-holders.sql'"
 BEGIN;
+-- serialize against the indexer: transfers cannot be ingested while balances are recomputed
+LOCK TABLE bb_token_transfers IN SHARE MODE;
+LOCK TABLE bb_token_holders IN EXCLUSIVE MODE;
+LOCK TABLE bb_launches IN EXCLUSIVE MODE;
 WITH legs AS (
   SELECT chain_id, token, from_addr AS holder, -value AS d, block_number FROM bb_token_transfers WHERE from_addr <> '0x0000000000000000000000000000000000000000'
   UNION ALL

--- a/app/scripts/rebuild-launch-totals.sql
+++ b/app/scripts/rebuild-launch-totals.sql
@@ -3,6 +3,14 @@
 -- "update totals" before those became one transaction). Prints a drift report first, then repairs.
 -- Usage: fly ssh sftp shell -a basebid-db <<< "put scripts/rebuild-launch-totals.sql /tmp/r.sql"
 --        fly ssh console -a basebid-db -C "sh -c 'PGPASSWORD=$OPERATOR_PASSWORD psql -h localhost -p 5433 -U postgres -d basebid -f /tmp/r.sql'"
+-- Concurrency: everything runs in ONE transaction that takes SHARE locks on the raw event tables and an
+-- EXCLUSIVE lock on bb_launches, so the indexer's ingestion transactions (INSERT event + UPDATE totals)
+-- block for the few seconds this takes and then apply on top of the recomputed values — nothing is lost.
+BEGIN;
+LOCK TABLE bb_launch_swaps IN SHARE MODE;
+LOCK TABLE bb_launch_fee_events IN SHARE MODE;
+LOCK TABLE bb_launches IN EXCLUSIVE MODE;
+
 WITH s AS (
   SELECT chain_id, token, count(*) FILTER (WHERE is_buy) AS buys, count(*) FILTER (WHERE NOT is_buy) AS sells,
          COALESCE(sum(abs(amount0)), 0) AS volume_quote, max(block_time) AS last_trade_at
@@ -13,7 +21,6 @@ SELECT 'drift before' AS what,
        count(*) FILTER (WHERE (l.buys + l.sells) > 0 AND s.token IS NULL) AS totals_without_swaps
   FROM bb_launches l LEFT JOIN s ON s.chain_id = l.chain_id AND s.token = l.token;
 
-BEGIN;
 -- swaps → buys / sells / volume / last trade
 UPDATE bb_launches l SET
   buys = COALESCE(s.buys, 0), sells = COALESCE(s.sells, 0), volume_quote = COALESCE(s.volume_quote, 0), last_trade_at = s.last_trade_at
@@ -39,7 +46,6 @@ UPDATE bb_launches l SET
                (SELECT COALESCE(sum(amount), 0) FROM bb_launch_fee_events e WHERE e.chain_id = l2.chain_id AND e.token = l2.token AND e.kind = 'burned' AND e.currency <> l2.quote) AS tb
           FROM bb_launches l2) f
  WHERE l.chain_id = f.chain_id AND l.token = f.token;
-COMMIT;
 
 WITH s AS (
   SELECT chain_id, token, count(*) FILTER (WHERE is_buy) AS buys, count(*) FILTER (WHERE NOT is_buy) AS sells, COALESCE(sum(abs(amount0)), 0) AS volume_quote
@@ -48,3 +54,4 @@ WITH s AS (
 SELECT 'drift after' AS what,
        count(*) FILTER (WHERE l.buys <> COALESCE(s.buys, 0) OR l.sells <> COALESCE(s.sells, 0) OR l.volume_quote <> COALESCE(s.volume_quote, 0)) AS launches_with_wrong_totals
   FROM bb_launches l LEFT JOIN s ON s.chain_id = l.chain_id AND s.token = l.token;
+COMMIT;

--- a/app/src/lib/launchpad/meta.ts
+++ b/app/src/lib/launchpad/meta.ts
@@ -39,20 +39,34 @@ export class MetaConflict extends Error {
  * launch params cannot overwrite. Returns the stable URI (keyed by meta_key) and the predicted token.
  */
 export async function saveMeta(m: Input): Promise<{ uri: string; token: Address }> {
-  const db = maybeDb();
-  if (!db) throw new Error("db unconfigured");
+  const pool = maybeDb();
+  if (!pool) throw new Error("db unconfigured");
   const uri = uriFor(m.launcher, m.meta_key);
   const token = (await predictToken(m, uri)).toLowerCase() as Address;
   const cid = chainIdOf(m.chain);
-  const inserted = await db`
-    INSERT INTO bb_launch_meta (chain_id, token, launcher, meta_key, name, symbol, description, image_url, website, x_handle)
-    VALUES (${cid}, ${token}, ${m.launcher.toLowerCase()}, ${m.meta_key}, ${m.name}, ${m.symbol}, ${m.description ?? null}, ${m.image_url ?? null}, ${m.website ?? null}, ${m.x_handle ?? null})
-    ON CONFLICT (chain_id, token) DO NOTHING RETURNING token`;
-  if (inserted.length === 0) {
-    const [existing] = await db<MetaRow[]>`SELECT launcher, name, symbol, description, image_url, website, x_handle FROM bb_launch_meta WHERE chain_id = ${cid} AND token = ${token}`;
-    if (metaWriteDecision(existing ?? null, m) === "conflict") throw new MetaConflict("metadata for this launch is already registered — edit it after launch from your dashboard, or pick a new salt");
-  }
-  return { uri, token };
+  const launcher = m.launcher.toLowerCase();
+  // Ownership is per (chain, launcher, meta_key) — the thing the public URI is keyed by — not just per
+  // token row: the salt search legitimately registers several token rows under one key, but they must
+  // all carry the content the FIRST registration set. Serialized with a transaction-scoped advisory
+  // lock so two concurrent first writes cannot both win.
+  return pool.begin(async (tx) => {
+    const db = tx as unknown as NonNullable<ReturnType<typeof maybeDb>>;
+    await db`SELECT pg_advisory_xact_lock(hashtext(${`meta:${cid}:${launcher}:${m.meta_key}`}))`;
+    const [owner] = await db<MetaRow[]>`
+      SELECT launcher, name, symbol, description, image_url, website, x_handle FROM bb_launch_meta
+       WHERE chain_id = ${cid} AND launcher = ${launcher} AND meta_key = ${m.meta_key}
+       ORDER BY created_at ASC, token ASC LIMIT 1`;
+    if (owner && metaWriteDecision(owner, m) === "conflict") throw new MetaConflict("this metadata key is already registered with different details — edit after launch from your dashboard, or start a new launch");
+    const inserted = await db`
+      INSERT INTO bb_launch_meta (chain_id, token, launcher, meta_key, name, symbol, description, image_url, website, x_handle)
+      VALUES (${cid}, ${token}, ${launcher}, ${m.meta_key}, ${m.name}, ${m.symbol}, ${m.description ?? null}, ${m.image_url ?? null}, ${m.website ?? null}, ${m.x_handle ?? null})
+      ON CONFLICT (chain_id, token) DO NOTHING RETURNING token`;
+    if (inserted.length === 0) {
+      const [existing] = await db<MetaRow[]>`SELECT launcher, name, symbol, description, image_url, website, x_handle FROM bb_launch_meta WHERE chain_id = ${cid} AND token = ${token}`;
+      if (metaWriteDecision(existing ?? null, m) === "conflict") throw new MetaConflict("metadata for this launch is already registered — edit it after launch from your dashboard, or pick a new salt");
+    }
+    return { uri, token };
+  }) as Promise<{ uri: string; token: Address }>;
 }
 
 export type MetaJson = { name: string; symbol: string; description?: string; image?: string; external_url?: string; x?: string; token?: string };
@@ -69,7 +83,7 @@ export async function readMeta(where: { chain?: ChainKey; token?: string; launch
         LEFT JOIN bb_launches l ON l.chain_id = m.chain_id AND l.token = m.token
         WHERE m.launcher = ${(where.launcher ?? "").toLowerCase()}
           AND (m.meta_key = ${(where.key ?? "").toLowerCase()} OR l.metadata_uri = ${uriFor(where.launcher ?? "", where.key ?? "0x")})
-        ORDER BY (l.token IS NOT NULL) DESC, m.created_at DESC LIMIT 1`; // prefer the row that actually launched; before indexing, the newest registration
+        ORDER BY (l.token IS NOT NULL) DESC, m.created_at ASC, m.token ASC LIMIT 1`; // the launched row wins; before indexing, the FIRST registration under the key (never a later one)
   const r = rows[0];
   if (!r) return null;
   return { name: r.name, symbol: r.symbol, description: r.description ?? undefined, image: canonicalImageUrl(r.image_url, imagePublicBase()) ?? undefined, external_url: r.website ?? undefined, x: r.x_handle ?? undefined, token: r.token };


### PR DESCRIPTION
- Metadata ownership is per (chain, launcher, meta_key), the thing the public URI is keyed by: the first registration under a key fixes its content; later rows under the same key must match exactly (the salt search) or get 409. Serialized with a transaction-scoped advisory lock so two concurrent first writes cannot both win (tested: 10/10 races → one 200, one 409). Reads prefer the launched row, then the FIRST registration, never a newer one.
- fly-secrets.sh reads every key independently from the secrets file (no RPC derivation), fails on missing required keys, supports --dry-run; verified against mocked files.
- rebuild-launch-totals.sql / rebuild-holders.sql run in one transaction holding SHARE locks on the raw event tables and EXCLUSIVE on the target table, so ingestion waits instead of racing (tested: an ingestion started mid-rebuild blocked 3s, then applied on top; totals consistent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metadata registration to prevent conflicting ownership records and ensure consistent selection of unlaunched metadata.
  - Improved holder balances and launch totals during maintenance operations by preventing concurrent updates from causing inconsistent results.
  - Improved deployment secret handling with required-value validation, optional configuration support, and a dry-run option.
  - Prevented unintended derivation or injection of network and site configuration values during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->