### PR TITLE
brand: official X account @openlaunch_lol; drop the Gitlawb footer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://openlaunch.lol">openlaunch.lol</a> ·
   <a href="https://openlaunch.lol/rules">how it works</a> ·
   <a href="https://openlaunch.lol/agents">for agents</a> ·
-  <a href="https://x.com/gitlawb">@gitlawb</a>
+  <a href="https://x.com/openlaunch_lol">@openlaunch_lol</a>
 </p>
 
 <p align="center">
@@ -114,7 +114,7 @@ on every pull request.
 - Tokenized stocks are securities issued by third parties under Regulation S and are not offered to US persons;
   the site only recognizes them from the issuers' own registries, never from on-chain names.
 
-Found something? Open an issue or reach out on X: [@gitlawb](https://x.com/gitlawb).
+Found something? Open an issue or reach out on X: [@openlaunch_lol](https://x.com/openlaunch_lol).
 
 ## License
 

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -78,9 +78,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <a href={`https://x.com/${BRAND_X}`} className="hover:text-ink" target="_blank" rel="noreferrer">
               @{BRAND_X}
             </a>
-            <a href="https://gitlawb.com" className="hover:text-ink" target="_blank" rel="noreferrer">
-              a gitlawb thing
-            </a>
           </footer>
           </LiveProvider>
         </Web3Provider>

--- a/app/src/lib/brand.ts
+++ b/app/src/lib/brand.ts
@@ -3,7 +3,7 @@ export const BRAND = "openlaunch";
 export const BRAND_TLD = ".lol";
 export const BRAND_DOMAIN = `${BRAND}${BRAND_TLD}`; // openlaunch.lol
 /** @openlaunchlol and the openlaunchlol GitHub org were squatted after the rename — never link them. */
-export const BRAND_X = "gitlawb";
+export const BRAND_X = "openlaunch_lol"; // the official account (never link the look-alike handles)
 export const BRAND_GITHUB = "https://github.com/Gitlawb/openlaunch"; // MIT, contracts + site
 export const TAGLINE = "launch a token. Free. Open source. On Base or Robinhood Chain.";
 /**


### PR DESCRIPTION
openlaunch is its own project now. The footer, twitter:site cards and README point at the official account; the "a gitlawb thing" link is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README contact and security links to reference the official OpenLaunch X/Twitter account.

- **Branding**
  - Updated the application’s social media account reference to `openlaunch_lol`.

- **UI Changes**
  - Removed the footer link labeled “a gitlawb thing.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->