### PR TITLE
chart + dashboard: use the launch row's stock-aware quote

### DIFF
--- a/app/src/components/launchpad/MeDashboard.tsx
+++ b/app/src/components/launchpad/MeDashboard.tsx
@@ -302,7 +302,7 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
                   </div>
                   <div className={styles.holdingValue}>
                     <div className="text-ink font-bold">{bal === undefined ? "Reading…" : bal === null ? "—" : fmtCompact(Number(bal) / 1e18)}</div>
-                    <div className="text-[11px] text-muted">{usd === null ? "USD unavailable" : fmtUsd(usd)}</div>
+                    <div className="text-[11px] text-muted">{bal === undefined ? "Reading…" : usd === null ? "USD unavailable" : fmtUsd(usd)}</div>
                   </div>
                 </Link>
               </li>

--- a/app/src/components/launchpad/MeDashboard.tsx
+++ b/app/src/components/launchpad/MeDashboard.tsx
@@ -13,7 +13,7 @@ import EditTokenSheet from "./EditTokenSheet";
 import { toast } from "./TxToasts";
 import { Tabs, TabsList, TabsPanel, TabsTab } from "@/components/vendor/tabs";
 import { LAUNCH_LOCKER_ABI, ERC20_MIN_ABI } from "@/lib/launchpad/abi";
-import { launchpad, quoteInfo } from "@/lib/launchpad/config";
+import { launchpad } from "@/lib/launchpad/config";
 import { earnedRaw, feeShareBps, holdingUsd, isBurnOnly } from "@/lib/launchpad/creator";
 import { fmtCompact, fmtQuote, fmtUsd } from "@/lib/launchpad/math";
 import type { LaunchRow, WalletTrade } from "@/lib/launchpad/queries";
@@ -233,7 +233,6 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
         ) : null}
         <ul className={styles.tokenList}>
           {me?.launches.map((l) => {
-            const q = quoteInfo(l.chain, l.quote);
             const share = feeShareBps(l.recipients, address);
             const earned = earnedRaw(l.fees_quote_collected, l.fees_quote_burned, share);
             const p = pending[key(l)];
@@ -257,11 +256,11 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
                     </div>
                   </Link>
                   <div className={styles.figure}>
-                    <div className="text-up font-bold">{l.quote_usd !== null ? fmtUsd((Number(earned) / 10 ** l.quote_decimals) * l.quote_usd) : fmtQuote(earned, q.decimals, q.symbol)}</div>
+                    <div className="text-up font-bold">{l.quote_usd !== null ? fmtUsd((Number(earned) / 10 ** l.quote_decimals) * l.quote_usd) : fmtQuote(earned, l.quote_decimals, l.quote_symbol)}</div>
                     <div className="text-[11px] text-muted">earned · {share / 100}% share</div>
                   </div>
                   <div className={styles.figure}>
-                    <div className={p && p > 0n ? "text-warm-ink font-bold" : "text-muted"}>{p === undefined ? "…" : p === null ? "—" : fmtQuote(p, q.decimals, q.symbol)}</div>
+                    <div className={p && p > 0n ? "text-warm-ink font-bold" : "text-muted"}>{p === undefined ? "…" : p === null ? "—" : fmtQuote(p, l.quote_decimals, l.quote_symbol)}</div>
                     <div className="text-[11px] text-muted">uncollected</div>
                   </div>
                   <div className={styles.rowActions}>


### PR DESCRIPTION
The candles endpoint and the Me dashboard resolved the quote with the static config lookup, which only knows ETH and USDG. For a tokenized-stock quote that answered symbol "?" and 18 decimals, so the chart's unit label read "?" and, for Coinbase B20 stocks (8 decimals), the launch reference price and candle scale were off by 1e10. The launch row already carries the registry-resolved symbol and decimals; use them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the wallet dashboard with dedicated views for launches, holdings, and trades.
  - Added refresh controls, clearer loading, empty, and error states, and wallet-connection guidance.
  - Improved transaction actions for accessibility and ease of use.
  - Loading balances now display “Reading…” for balance and USD fields.

- **Bug Fixes**
  - Wallet balance failures are clearly shown as unavailable instead of misleading values.
  - Reverted collection transactions now display an error.
  - Launch fees use the correct launch-specific quote information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->