### PR TITLE
security headers: nonce-based CSP, frame denial, HSTS

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,5 @@ denial-of-service against public RPC endpoints, and findings that require a comp
 - Every off-chain write is authorized by a wallet signature with a single-use nonce and a time window.
 - Uploaded images are re-encoded server-side; the share-card renderer never fetches user-supplied URLs.
 - Tokenized stocks are recognized only from their issuers' registries, never from on-chain names.
+- Every page ships a nonce-based Content-Security-Policy (`app/src/lib/security-headers.ts`): only scripts carrying the
+  request's nonce run, the site cannot be framed, and the browser talks only to the site itself and the wallet endpoints listed there.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,5 +31,7 @@ denial-of-service against public RPC endpoints, and findings that require a comp
 - Every off-chain write is authorized by a wallet signature with a single-use nonce and a time window.
 - Uploaded images are re-encoded server-side; the share-card renderer never fetches user-supplied URLs.
 - Tokenized stocks are recognized only from their issuers' registries, never from on-chain names.
-- Every page ships a nonce-based Content-Security-Policy (`app/src/lib/security-headers.ts`): only scripts carrying the
-  request's nonce run, the site cannot be framed, and the browser talks only to the site itself and the wallet endpoints listed there.
+- Every page ships a nonce-based Content-Security-Policy (`app/src/lib/security-headers.ts`). Scripts in the HTML run only
+  with the request's nonce; with `'strict-dynamic'`, scripts those trusted scripts load at runtime (Next.js chunks) may run
+  too, while injected markup never can. The site cannot be framed, and the browser talks only to the site itself and the
+  wallet endpoints listed there.

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { SECURITY_HEADERS } from "./src/lib/security-headers";
 
 const nextConfig: NextConfig = {
   // Fly: the Dockerfile copies .next/standalone (server.js + traced node_modules).
@@ -7,10 +8,15 @@ const nextConfig: NextConfig = {
   // .next/standalone/node_modules and scripts/migrate.mjs can import it inside
   // the image (release_command runs there, outside the Next server).
   serverExternalPackages: ["postgres"],
-  // The JSON API is the agent surface; never let a CDN cache a stale list.
   async headers() {
     return [
       {
+        // Static security headers on everything; the per-request CSP is set in src/proxy.ts.
+        source: "/(.*)",
+        headers: [...SECURITY_HEADERS],
+      },
+      {
+        // The JSON API is the agent surface; never let a CDN cache a stale list.
         source: "/api/:path*",
         headers: [{ key: "cache-control", value: "no-store" }],
       },

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { headers } from "next/headers";
 import { Inter, Space_Mono, Unbounded } from "next/font/google";
 import "./globals.css";
 import Web3Provider from "@/components/Web3Provider";
@@ -36,12 +37,14 @@ export const metadata: Metadata = {
 export const viewport: Viewport = { themeColor: "#FAFAF8", colorScheme: "light", width: "device-width", initialScale: 1, viewportFit: "cover" };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  // Minted per request in src/proxy.ts; next-themes' inline theme script must carry it to run under the CSP.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
   const usd = await ethUsd();
   const [feed, totals] = await Promise.all([getLaunchFeed(24, usd).catch(() => []), getLaunchTotals(usd)]);
   return (
     <html lang="en" className={`${inter.variable} ${spaceMono.variable} ${unbounded.variable}`} suppressHydrationWarning>
       <body id="site-top" tabIndex={-1} className="min-h-screen flex flex-col">
-        <ThemeProvider>
+        <ThemeProvider nonce={nonce}>
         <Web3Provider>
           <LiveProvider initial={{ at: 0, feed, totals, ethUsd: usd }}>
           <Suspense fallback={null}>

--- a/app/src/components/ThemeProvider.tsx
+++ b/app/src/components/ThemeProvider.tsx
@@ -39,9 +39,9 @@ function ThemeColorSync() {
  * would be the tidier model, but next-themes calls classList.remove(value) and
  * throws on an empty token.)
  */
-export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+export default function ThemeProvider({ children, nonce }: { children: React.ReactNode; nonce?: string }) {
   return (
-    <NextThemes attribute="class" defaultTheme="light" enableSystem={false} disableTransitionOnChange>
+    <NextThemes attribute="class" defaultTheme="light" enableSystem={false} disableTransitionOnChange nonce={nonce}>
       <ThemeColorSync />
       {children}
     </NextThemes>

--- a/app/src/lib/security-headers.test.ts
+++ b/app/src/lib/security-headers.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { SECURITY_HEADERS, WALLET_CONNECT_SRC, buildCsp, cspNonce, extraConnectOrigins, isOrigin } from "./security-headers.ts";
+
+const NONCE = "AAAAAAAAAAAAAAAAAAAAAA==";
+
+function directive(csp: string, name: string): string {
+  const found = csp.split("; ").find((d) => d.startsWith(`${name} `) || d === name);
+  assert.ok(found, `missing directive ${name}`);
+  return found;
+}
+
+test("cspNonce base64-encodes at least 16 random bytes", () => {
+  assert.equal(cspNonce(new Uint8Array(16)), NONCE);
+  assert.match(cspNonce(new Uint8Array(32).fill(255)), /^[A-Za-z0-9+/]+={0,2}$/);
+  assert.throws(() => cspNonce(new Uint8Array(8)), /16 random bytes/);
+});
+
+test("production policy: nonce-only scripts, no framing, same-origin by default", () => {
+  const csp = buildCsp(NONCE);
+  assert.equal(directive(csp, "default-src"), "default-src 'self'");
+  assert.equal(directive(csp, "script-src"), `script-src 'self' 'nonce-${NONCE}' 'strict-dynamic'`);
+  assert.doesNotMatch(directive(csp, "script-src"), /unsafe-inline|unsafe-eval/);
+  assert.equal(directive(csp, "frame-ancestors"), "frame-ancestors 'none'");
+  assert.equal(directive(csp, "frame-src"), "frame-src 'none'");
+  assert.equal(directive(csp, "object-src"), "object-src 'none'");
+  assert.equal(directive(csp, "base-uri"), "base-uri 'self'");
+  assert.equal(directive(csp, "form-action"), "form-action 'self'");
+  assert.equal(directive(csp, "img-src"), "img-src 'self' https: data:");
+  assert.equal(directive(csp, "upgrade-insecure-requests"), "upgrade-insecure-requests");
+  assert.doesNotMatch(csp, /ws:|localhost|127\.0\.0\.1/);
+});
+
+test("connect-src covers the site and the wallet SDK, plus vetted extra origins only", () => {
+  const csp = buildCsp(NONCE, { connectSrc: ["http://127.0.0.1:8545", "https://openlaunch.lol", "https://evil.example/path", "javascript:alert(1)", "not a url"] });
+  const connect = directive(csp, "connect-src");
+  assert.ok(connect.startsWith("connect-src 'self' "));
+  for (const origin of WALLET_CONNECT_SRC) assert.ok(connect.includes(` ${origin}`), `missing ${origin}`);
+  assert.ok(connect.includes(" http://127.0.0.1:8545"));
+  assert.ok(connect.includes(" https://openlaunch.lol"));
+  assert.doesNotMatch(connect, /evil|javascript|not a url/);
+});
+
+test("development adds eval and HMR sockets and drops the https upgrade", () => {
+  const csp = buildCsp(NONCE, { dev: true });
+  assert.ok(directive(csp, "script-src").endsWith(" 'unsafe-eval'"));
+  assert.match(directive(csp, "connect-src"), / ws: http:\/\/localhost:\* http:\/\/127\.0\.0\.1:\*$/);
+  assert.doesNotMatch(csp, /upgrade-insecure-requests/);
+});
+
+test("a malformed nonce cannot smuggle directives into the policy", () => {
+  for (const bad of ["", "short", `${NONCE}; script-src *`, "abc def ghi jkl mno", "<script>"]) {
+    assert.throws(() => buildCsp(bad), /base64/, bad);
+  }
+});
+
+test("isOrigin accepts bare web origins only", () => {
+  for (const ok of ["https://a.b", "http://localhost:3000", "wss://relay.example", "ws://127.0.0.1:8080"]) assert.equal(isOrigin(ok), true, ok);
+  for (const no of ["https://a.b/", "https://a.b/x", "https://u:p@a.b", "ftp://a.b", "data:text/html,x", "a.b", ""]) assert.equal(isOrigin(no), false, no);
+});
+
+test("extraConnectOrigins reduces env URLs to unique origins and ignores junk", () => {
+  const origins = extraConnectOrigins({
+    NEXT_PUBLIC_SITE_URL: "https://openlaunch.lol/",
+    NEXT_PUBLIC_RPC_URL_BASE: " http://127.0.0.1:8545/rpc ",
+    NEXT_PUBLIC_RPC_URL_ROBINHOOD: "http://127.0.0.1:8545",
+    DATABASE_URL: "postgres://localhost/openlaunch_dev",
+  });
+  assert.deepEqual(origins, ["https://openlaunch.lol", "http://127.0.0.1:8545"]);
+  assert.deepEqual(extraConnectOrigins({ NEXT_PUBLIC_RPC_URL_BASE: "nope" }), []);
+  assert.deepEqual(extraConnectOrigins({}), []);
+});
+
+test("static headers deny framing, sniffing, and plain-http return visits", () => {
+  const byKey = Object.fromEntries(SECURITY_HEADERS.map((h) => [h.key, h.value]));
+  assert.equal(byKey["x-frame-options"], "DENY");
+  assert.equal(byKey["x-content-type-options"], "nosniff");
+  assert.equal(byKey["referrer-policy"], "strict-origin-when-cross-origin");
+  assert.match(byKey["strict-transport-security"], /^max-age=\d{8,}; includeSubDomains$/);
+  assert.match(byKey["permissions-policy"], /camera=\(\)/);
+  // Wallet popups need window.opener; never send a COOP that severs it.
+  assert.equal(byKey["cross-origin-opener-policy"], undefined);
+});
+
+// Source contracts: the policy only protects if every hop forwards the same nonce.
+const proxy = readFileSync(new URL("../proxy.ts", import.meta.url), "utf8");
+const layout = readFileSync(new URL("../app/layout.tsx", import.meta.url), "utf8");
+const themeProvider = readFileSync(new URL("../components/ThemeProvider.tsx", import.meta.url), "utf8");
+const nextConfig = readFileSync(new URL("../../next.config.ts", import.meta.url), "utf8");
+
+test("proxy mints a random nonce and sets the policy on the request and the response", () => {
+  assert.match(proxy, /cspNonce\(crypto\.getRandomValues\(new Uint8Array\(16\)\)\)/);
+  assert.match(proxy, /headers\.set\("x-nonce", nonce\)/);
+  assert.match(proxy, /headers\.set\("content-security-policy", csp\)/);
+  assert.match(proxy, /NextResponse\.next\(\{ request: \{ headers \} \}\)/);
+  assert.match(proxy, /res\.headers\.set\("content-security-policy", csp\)/);
+  assert.match(proxy, /const DEV = process\.env\.NODE_ENV === "development"/);
+  assert.match(proxy, /dev: DEV/);
+  // Literal env reads, so the build inlines the same values browserRpc() bakes into the client.
+  for (const key of ["NEXT_PUBLIC_SITE_URL", "NEXT_PUBLIC_RPC_URL_BASE", "NEXT_PUBLIC_RPC_URL_ROBINHOOD"]) {
+    assert.match(proxy, new RegExp(`${key}: process\\.env\\.${key}`));
+  }
+  assert.doesNotMatch(proxy, /extraConnectOrigins\(process\.env\)/);
+});
+
+test("the root layout forwards the request nonce to next-themes' inline script", () => {
+  assert.match(layout, /import \{ headers \} from "next\/headers"/);
+  assert.match(layout, /\(await headers\(\)\)\.get\("x-nonce"\)/);
+  assert.match(layout, /<ThemeProvider nonce=\{nonce\}>/);
+  assert.match(themeProvider, /nonce\?: string/);
+  assert.match(themeProvider, /<NextThemes[^>]*nonce=\{nonce\}/);
+});
+
+test("next.config applies the static headers to every route", () => {
+  assert.match(nextConfig, /import \{ SECURITY_HEADERS \} from "\.\/src\/lib\/security-headers"/);
+  assert.match(nextConfig, /source: "\/\(\.\*\)",\s*headers: \[\.\.\.SECURITY_HEADERS\]/);
+});

--- a/app/src/lib/security-headers.ts
+++ b/app/src/lib/security-headers.ts
@@ -1,0 +1,99 @@
+/**
+ * Response security headers. Pure module (node --test loads it directly; no "@/" imports).
+ *
+ * The CSP is nonce-based: proxy.ts mints a nonce per request and forwards it as the
+ * `x-nonce` request header plus the policy itself, which Next.js reads to stamp its own
+ * inline scripts; layout.tsx hands the nonce to next-themes for its theme script.
+ * Everything else is same-origin. Third-party origins are listed here, once, with a reason.
+ */
+
+/**
+ * Coinbase Wallet SDK (wagmi's coinbaseWallet connector). Smart Wallet signs in a popup
+ * (window.open → keys.coinbase.com, postMessage), so no frame-src is needed. The mobile
+ * app pairs over the WalletLink relay, and some reads go through the wallet's RPC.
+ */
+export const WALLET_CONNECT_SRC = [
+  "https://keys.coinbase.com",
+  "https://rpc.wallet.coinbase.com",
+  "https://www.walletlink.org",
+  "wss://www.walletlink.org",
+] as const;
+
+const NONCE_RE = /^[A-Za-z0-9+/]{16,}={0,2}$/;
+
+/** Base64 of at least 16 random bytes. Runs in Node and the browser runtime alike. */
+export function cspNonce(bytes: Uint8Array): string {
+  if (bytes.length < 16) throw new Error("csp nonce needs at least 16 random bytes");
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+export type CspOptions = {
+  /** Development: Next's dev tooling evals source maps and talks to HMR over ws. */
+  dev?: boolean;
+  /** Extra origins the browser may call (dev RPC overrides, a non-default site URL). */
+  connectSrc?: readonly string[];
+};
+
+/** True for a bare origin such as https://host or wss://host:1234 (no path, query, or credentials). */
+export function isOrigin(value: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(value);
+  } catch {
+    return false;
+  }
+  return ["https:", "http:", "wss:", "ws:"].includes(u.protocol) && u.origin === value;
+}
+
+export function buildCsp(nonce: string, { dev = false, connectSrc = [] }: CspOptions = {}): string {
+  if (!NONCE_RE.test(nonce)) throw new Error("csp nonce must be base64");
+  const connect = new Set<string>(["'self'", ...WALLET_CONNECT_SRC, ...connectSrc.filter(isOrigin)]);
+  if (dev) for (const s of ["ws:", "http://localhost:*", "http://127.0.0.1:*"]) connect.add(s);
+  const directives = [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "frame-src 'none'",
+    "form-action 'self'",
+    // Only scripts carrying this request's nonce run; 'strict-dynamic' lets them load Next's chunks.
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${dev ? " 'unsafe-eval'" : ""}`,
+    // Server-rendered inline `style` attributes and next/font. CSSOM writes are not gated by CSP.
+    "style-src 'self' 'unsafe-inline'",
+    // Token logos are user-supplied https URLs (validated server-side); stock marks are data: SVGs.
+    "img-src 'self' https: data:",
+    "font-src 'self'",
+    `connect-src ${[...connect].join(" ")}`,
+  ];
+  if (!dev) directives.push("upgrade-insecure-requests");
+  return directives.join("; ");
+}
+
+/** Origins the browser must reach besides the page itself: the configured site URL and dev RPC overrides. */
+export function extraConnectOrigins(env: Record<string, string | undefined>): string[] {
+  const out = new Set<string>();
+  for (const key of ["NEXT_PUBLIC_SITE_URL", "NEXT_PUBLIC_RPC_URL_BASE", "NEXT_PUBLIC_RPC_URL_ROBINHOOD"]) {
+    const value = env[key]?.trim();
+    if (!value) continue;
+    try {
+      const origin = new URL(value).origin;
+      if (isOrigin(origin)) out.add(origin);
+    } catch {
+      /* not a URL; nothing to allow */
+    }
+  }
+  return [...out];
+}
+
+/** Static headers for every response (next.config.ts). The CSP is per request and lives in proxy.ts. */
+export const SECURITY_HEADERS: readonly { key: string; value: string }[] = [
+  { key: "x-content-type-options", value: "nosniff" },
+  // Belt and braces with frame-ancestors for browsers that predate CSP2.
+  { key: "x-frame-options", value: "DENY" },
+  { key: "referrer-policy", value: "strict-origin-when-cross-origin" },
+  { key: "permissions-policy", value: "camera=(), microphone=(), geolocation=(), payment=()" },
+  // Fly already forces https; this stops the first plain-http hop on return visits.
+  { key: "strict-transport-security", value: "max-age=63072000; includeSubDomains" },
+];

--- a/app/src/lib/security-headers.ts
+++ b/app/src/lib/security-headers.ts
@@ -47,6 +47,11 @@ export function isOrigin(value: string): boolean {
   return ["https:", "http:", "wss:", "ws:"].includes(u.protocol) && u.origin === value;
 }
 
+/**
+ * The Content-Security-Policy for one request. Scripts in the HTML run only with this nonce;
+ * 'strict-dynamic' extends that trust to scripts they load at runtime (Next.js chunks) but not to
+ * injected markup. Everything else is same-origin apart from the listed wallet and image sources.
+ */
 export function buildCsp(nonce: string, { dev = false, connectSrc = [] }: CspOptions = {}): string {
   if (!NONCE_RE.test(nonce)) throw new Error("csp nonce must be base64");
   const connect = new Set<string>(["'self'", ...WALLET_CONNECT_SRC, ...connectSrc.filter(isOrigin)]);
@@ -58,7 +63,7 @@ export function buildCsp(nonce: string, { dev = false, connectSrc = [] }: CspOpt
     "frame-ancestors 'none'",
     "frame-src 'none'",
     "form-action 'self'",
-    // Only scripts carrying this request's nonce run; 'strict-dynamic' lets them load Next's chunks.
+    // Nonce for scripts in the HTML; 'strict-dynamic' trusts what those scripts load (Next's chunks).
     `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${dev ? " 'unsafe-eval'" : ""}`,
     // Server-rendered inline `style` attributes and next/font. CSSOM writes are not gated by CSP.
     "style-src 'self' 'unsafe-inline'",

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -1,9 +1,22 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { BRAND_DOMAIN, LEGACY_DOMAIN } from "@/lib/brand";
+import { buildCsp, cspNonce, extraConnectOrigins } from "@/lib/security-headers";
+
+const DEV = process.env.NODE_ENV === "development";
+// Literal accesses so Next inlines the same build-time values the client bundle uses (see browserRpc).
+const CONNECT_SRC = extraConnectOrigins({
+  NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+  NEXT_PUBLIC_RPC_URL_BASE: process.env.NEXT_PUBLIC_RPC_URL_BASE,
+  NEXT_PUBLIC_RPC_URL_ROBINHOOD: process.env.NEXT_PUBLIC_RPC_URL_ROBINHOOD,
+});
 
 /**
  * basebid.lol → openlaunch.lol. Permanent redirect for pages; /api stays served
  * on both hosts because early launches carry basebid.lol metadata URIs on-chain.
+ *
+ * Every other response carries a nonce-based Content-Security-Policy. Next.js reads
+ * the nonce from the CSP *request* header to stamp its inline scripts, layout.tsx
+ * reads `x-nonce` for next-themes, and the response repeats the same policy.
  */
 export function proxy(req: NextRequest) {
   const host = req.headers.get("host")?.toLowerCase() ?? "";
@@ -14,7 +27,14 @@ export function proxy(req: NextRequest) {
     url.protocol = "https:";
     return NextResponse.redirect(url, 308);
   }
-  return NextResponse.next();
+  const nonce = cspNonce(crypto.getRandomValues(new Uint8Array(16)));
+  const csp = buildCsp(nonce, { dev: DEV, connectSrc: CONNECT_SRC });
+  const headers = new Headers(req.headers);
+  headers.set("x-nonce", nonce);
+  headers.set("content-security-policy", csp);
+  const res = NextResponse.next({ request: { headers } });
+  res.headers.set("content-security-policy", csp);
+  return res;
 }
 
 export const config = { matcher: ["/((?!_next/|favicon|icon|apple-icon|opengraph-image).*)"] };


### PR DESCRIPTION
Every page now carries a per-request Content-Security-Policy. The proxy mints a nonce, Next.js stamps it on its inline scripts, and the root layout forwards it to next-themes. Scripts run only with the nonce plus strict-dynamic; framing is denied; connect-src covers the site and the Coinbase Wallet SDK endpoints; images allow https because token logos are user-supplied URLs validated server-side.

Static headers (nosniff, X-Frame-Options, Referrer-Policy, Permissions-Policy, HSTS) apply to every route from next.config.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added nonce-based Content Security Policy protection across all routes.
  - Restricted browser connections to the site and approved wallet endpoints.
  - Added framing protection and secure response headers.
  - Enabled nonce propagation for theme-related scripts and styles.
  - Improved support for trusted descendant scripts under `strict-dynamic`.

- **Documentation**
  - Updated security documentation to clarify nonce and script-execution behavior.

- **Tests**
  - Added comprehensive coverage for security headers, CSP behavior, nonce handling, and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->