### PR TITLE
seo: robots, sitemap, manifest, error boundaries, token canonical + JSON-LD

### DIFF
--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -7,10 +7,10 @@ import { btn } from "@/components/ui";
 /** Route-level error boundary. Mirrors not-found.tsx styling. */
 export default function Error({
   error,
-  retry,
+  reset,
 }: {
   error: Error & { digest?: string };
-  retry: () => void;
+  reset: () => void;
 }) {
   useEffect(() => {
     console.error(error);
@@ -20,7 +20,7 @@ export default function Error({
       <div className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">500</div>
       <p className="text-[15px] text-body">Something broke on this page. Your funds are on-chain — this is only the site.</p>
       <div className="flex items-center justify-center gap-3">
-        <button type="button" onClick={retry} className={btn.primary}>
+        <button type="button" onClick={reset} className={btn.primary}>
           Try again
         </button>
         <Link href="/" className={btn.secondary}>

--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -7,10 +7,10 @@ import { btn } from "@/components/ui";
 /** Route-level error boundary. Mirrors not-found.tsx styling. */
 export default function Error({
   error,
-  reset,
+  retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  retry: () => void;
 }) {
   useEffect(() => {
     console.error(error);
@@ -20,7 +20,7 @@ export default function Error({
       <div className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">500</div>
       <p className="text-[15px] text-body">Something broke on this page. Your funds are on-chain — this is only the site.</p>
       <div className="flex items-center justify-center gap-3">
-        <button type="button" onClick={reset} className={btn.primary}>
+        <button type="button" onClick={retry} className={btn.primary}>
           Try again
         </button>
         <Link href="/" className={btn.secondary}>

--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { btn } from "@/components/ui";
+
+/** Route-level error boundary. Mirrors not-found.tsx styling. */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
+      <div className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">500</div>
+      <p className="text-[15px] text-body">Something broke on this page. Your funds are on-chain — this is only the site.</p>
+      <div className="flex items-center justify-center gap-3">
+        <button type="button" onClick={reset} className={btn.primary}>
+          Try again
+        </button>
+        <Link href="/" className={btn.secondary}>
+          Back to the launchpad
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -4,13 +4,13 @@ import Link from "next/link";
 import { useEffect } from "react";
 import { btn } from "@/components/ui";
 
-/** Route-level error boundary. Mirrors not-found.tsx styling. */
+/** Route-level error boundary. Mirrors not-found.tsx styling. `retry` refreshes the router before re-rendering, so failed server data is fetched again. */
 export default function Error({
   error,
-  reset,
+  retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  retry: () => void;
 }) {
   useEffect(() => {
     console.error(error);
@@ -20,7 +20,7 @@ export default function Error({
       <div className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">500</div>
       <p className="text-[15px] text-body">Something broke on this page. Your funds are on-chain — this is only the site.</p>
       <div className="flex items-center justify-center gap-3">
-        <button type="button" onClick={reset} className={btn.primary}>
+        <button type="button" onClick={retry} className={btn.primary}>
           Try again
         </button>
         <Link href="/" className={btn.secondary}>

--- a/app/src/app/fonts.ts
+++ b/app/src/app/fonts.ts
@@ -1,0 +1,10 @@
+import { Inter, Space_Mono, Unbounded } from "next/font/google";
+
+/**
+ * Font loaders shared by the root layout and global-error.tsx.
+ * global-error replaces the root layout when active, so it cannot inherit
+ * these variables — it imports them from here instead of duplicating them.
+ */
+export const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
+export const spaceMono = Space_Mono({ subsets: ["latin"], weight: ["400", "700"], variable: "--font-space-mono", display: "swap" });
+export const unbounded = Unbounded({ subsets: ["latin"], weight: ["600", "700"], variable: "--font-unbounded", display: "swap" });

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+
+/**
+ * Root-level error boundary. Must render its own <html>/<body>
+ * (Next replaces the root layout when this renders).
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  console.error(error);
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex flex-col">
+        <main className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
+          <div className="font-display font-bold text-7xl">500</div>
+          <p className="text-[15px]">Something broke. Your funds are on-chain — this is only the site.</p>
+          <div className="flex items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={reset}
+              className="inline-flex items-center justify-center rounded-xl px-5 min-h-11 bg-black text-white font-semibold text-sm"
+            >
+              Try again
+            </button>
+            <Link href="/" className="inline-flex items-center justify-center rounded-xl px-5 min-h-11 border font-semibold text-sm">
+              Back to the launchpad
+            </Link>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect } from "react";
 import "./globals.css";
 import { inter, spaceMono, unbounded } from "./fonts";
 
@@ -16,7 +17,9 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  console.error(error);
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
   return (
     <html lang="en" className={`${inter.variable} ${spaceMono.variable} ${unbounded.variable}`}>
       <body className="min-h-screen flex flex-col">

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -1,21 +1,24 @@
 "use client";
 
 import Link from "next/link";
+import "./globals.css";
+import { inter, spaceMono, unbounded } from "./fonts";
 
 /**
- * Root-level error boundary. Must render its own <html>/<body>
- * (Next replaces the root layout when this renders).
+ * Root-level error boundary. Must render its own <html>/<body> — it replaces
+ * the root layout when active, so it loads the global stylesheet and font
+ * variables itself instead of inheriting them.
  */
 export default function GlobalError({
   error,
-  reset,
+  retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  retry: () => void;
 }) {
   console.error(error);
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} ${spaceMono.variable} ${unbounded.variable}`}>
       <body className="min-h-screen flex flex-col">
         <main className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
           <div className="font-display font-bold text-7xl">500</div>
@@ -23,7 +26,7 @@ export default function GlobalError({
           <div className="flex items-center justify-center gap-3">
             <button
               type="button"
-              onClick={reset}
+              onClick={retry}
               className="inline-flex items-center justify-center rounded-xl px-5 min-h-11 bg-black text-white font-semibold text-sm"
             >
               Try again

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -11,10 +11,10 @@ import { inter, spaceMono, unbounded } from "./fonts";
  */
 export default function GlobalError({
   error,
-  retry,
+  reset,
 }: {
   error: Error & { digest?: string };
-  retry: () => void;
+  reset: () => void;
 }) {
   console.error(error);
   return (
@@ -26,7 +26,7 @@ export default function GlobalError({
           <div className="flex items-center justify-center gap-3">
             <button
               type="button"
-              onClick={retry}
+              onClick={reset}
               className="inline-flex items-center justify-center rounded-xl px-5 min-h-11 bg-black text-white font-semibold text-sm"
             >
               Try again

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -12,10 +12,10 @@ import { inter, spaceMono, unbounded } from "./fonts";
  */
 export default function GlobalError({
   error,
-  reset,
+  retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  retry: () => void;
 }) {
   useEffect(() => {
     console.error(error);
@@ -29,7 +29,7 @@ export default function GlobalError({
           <div className="flex items-center justify-center gap-3">
             <button
               type="button"
-              onClick={reset}
+              onClick={retry}
               className="inline-flex items-center justify-center rounded-xl px-5 min-h-11 bg-black text-white font-semibold text-sm"
             >
               Try again

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import { headers } from "next/headers";
-import { Inter, Space_Mono, Unbounded } from "next/font/google";
 import "./globals.css";
 import Web3Provider from "@/components/Web3Provider";
 import Header from "@/components/Header";
@@ -14,10 +13,7 @@ import Footer from "@/components/Footer";
 import RouteProgress from "@/components/RouteProgress";
 import ThemeProvider from "@/components/ThemeProvider";
 import { Suspense } from "react";
-
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
-const spaceMono = Space_Mono({ subsets: ["latin"], weight: ["400", "700"], variable: "--font-space-mono", display: "swap" });
-const unbounded = Unbounded({ subsets: ["latin"], weight: ["600", "700"], variable: "--font-unbounded", display: "swap" });
+import { inter, spaceMono, unbounded } from "./fonts";
 
 const TITLE = SITE_TITLE;
 const DESCRIPTION = SITE_DESCRIPTION;

--- a/app/src/app/manifest.ts
+++ b/app/src/app/manifest.ts
@@ -11,8 +11,10 @@ export default function manifest(): MetadataRoute.Manifest {
     display: "standalone",
     background_color: "#FAFAF8",
     theme_color: "#FAFAF8",
+    // "any" is only meaningful for SVG; raster icons declare their real pixel size (icon.png is 512²).
     icons: [
-      { src: "/icon.png", sizes: "any", type: "image/png" },
+      { src: "/icon.svg", sizes: "any", type: "image/svg+xml" },
+      { src: "/icon.png", sizes: "512x512", type: "image/png" },
       { src: "/apple-icon.png", sizes: "180x180", type: "image/png" },
     ],
   };

--- a/app/src/app/manifest.ts
+++ b/app/src/app/manifest.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+import { BRAND, BRAND_DOMAIN, TAGLINE } from "@/lib/brand";
+
+/** PWA manifest. Icons reuse the existing Next app-icon routes. */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: `${BRAND_DOMAIN} — ${TAGLINE}`,
+    short_name: BRAND,
+    description: TAGLINE,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#FAFAF8",
+    theme_color: "#FAFAF8",
+    icons: [
+      { src: "/icon.png", sizes: "any", type: "image/png" },
+      { src: "/apple-icon.png", sizes: "180x180", type: "image/png" },
+    ],
+  };
+}

--- a/app/src/app/robots.ts
+++ b/app/src/app/robots.ts
@@ -11,7 +11,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/admin/", "/api/"],
+        disallow: ["/admin", "/api"],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/app/src/app/robots.ts
+++ b/app/src/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/chainPublic";
+
+/**
+ * Crawlers may index the launchpad; /admin and all /api/* stay out.
+ * The sitemap is advertised here so token pages are discoverable.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin/", "/api/"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/src/app/sitemap.ts
+++ b/app/src/app/sitemap.ts
@@ -3,6 +3,11 @@ import { SITE_URL } from "@/lib/chainPublic";
 import { maybeDb } from "@/lib/db";
 import { staticSitemapEntries, tokenSitemapEntries, type TokenRow } from "@/lib/seo";
 
+// Rendered per request like the rest of the app: the token list must not be
+// frozen at build time (CI builds without DATABASE_URL, which would leave only
+// the static routes forever).
+export const dynamic = "force-dynamic";
+
 /**
  * Sitemap: static routes plus the newest launches (fail-soft).
  * The DB is an index of the chain (see db/schema.sql); when it is

--- a/app/src/app/sitemap.ts
+++ b/app/src/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/chainPublic";
+import { maybeDb } from "@/lib/db";
+import { staticSitemapEntries, tokenSitemapEntries, type TokenRow } from "@/lib/seo";
+
+/**
+ * Sitemap: static routes plus the newest launches (fail-soft).
+ * The DB is an index of the chain (see db/schema.sql); when it is
+ * unconfigured or unreachable we still serve the static routes so
+ * crawlers always get a valid sitemap instead of a 500.
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const statics = staticSitemapEntries(SITE_URL);
+  let tokens: TokenRow[] = [];
+  try {
+    const sql = maybeDb();
+    if (sql) {
+      const rows = (await sql`
+        SELECT chain_id, token, block_time
+        FROM bb_launches
+        ORDER BY block_time DESC
+        LIMIT 1000
+      `) as unknown as { chain_id: number; token: string; block_time: string | null }[];
+      tokens = rows
+        .map((r) => ({
+          chain: r.chain_id === 4663 ? ("robinhood" as const) : ("base" as const),
+          token: String(r.token ?? "").toLowerCase(),
+          block_time: r.block_time,
+        }))
+        .filter((r) => /^0x[0-9a-f]{40}$/.test(r.token));
+    }
+  } catch {
+    tokens = [];
+  }
+  return [...statics, ...tokenSitemapEntries(SITE_URL, tokens)];
+}

--- a/app/src/app/sitemap.ts
+++ b/app/src/app/sitemap.ts
@@ -18,6 +18,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       const rows = (await sql`
         SELECT chain_id, token, block_time
         FROM bb_launches
+        WHERE chain_id IN (8453, 4663)
         ORDER BY block_time DESC
         LIMIT 1000
       `) as unknown as { chain_id: number; token: string; block_time: string | null }[];

--- a/app/src/app/t/[chain]/[token]/page.tsx
+++ b/app/src/app/t/[chain]/[token]/page.tsx
@@ -28,7 +28,8 @@ import { fmtCompact, fmtPrice, fmtQuote, fmtUsd, pipsToPct } from "@/lib/launchp
 import { marketCount as count } from "@/lib/launchpad/token-market";
 import { marketUsd } from "@/lib/launchpad/market-format";
 import { CHAIN_LABELS, SITE_URL, chainIdOf, explorerAddress, explorerName, explorerTx, isChainKey, shortAddr } from "@/lib/chainPublic";
-import { jsonLdHtml, tokenCanonical } from "@/lib/seo";import { stockByAddress } from "@/lib/launchpad/stocksServer";
+import { jsonLdHtml, tokenCanonical } from "@/lib/seo";
+import { stockByAddress } from "@/lib/launchpad/stocksServer";
 import { BRAND_DOMAIN, BRAND_X } from "@/lib/brand";
 import { clampSocial } from "@/lib/launchpad/ogcard";
 

--- a/app/src/app/t/[chain]/[token]/page.tsx
+++ b/app/src/app/t/[chain]/[token]/page.tsx
@@ -27,7 +27,8 @@ import GitlawbBadge from "@/components/launchpad/GitlawbBadge";
 import { fmtCompact, fmtPrice, fmtQuote, fmtUsd, pipsToPct } from "@/lib/launchpad/math";
 import { marketCount as count } from "@/lib/launchpad/token-market";
 import { marketUsd } from "@/lib/launchpad/market-format";
-import { CHAIN_LABELS, SITE_URL, explorerAddress, explorerName, explorerTx, isChainKey, shortAddr } from "@/lib/chainPublic";
+import { CHAIN_LABELS, SITE_URL, chainIdOf, explorerAddress, explorerName, explorerTx, isChainKey, shortAddr } from "@/lib/chainPublic";
+import { tokenCanonical, tokenJsonLd } from "@/lib/seo";
 import { stockByAddress } from "@/lib/launchpad/stocksServer";
 import { BRAND_DOMAIN, BRAND_X } from "@/lib/brand";
 import { clampSocial } from "@/lib/launchpad/ogcard";
@@ -45,6 +46,7 @@ export async function generateMetadata({ params }: { params: Promise<{ chain: st
   return {
     title,
     description,
+    alternates: { canonical: tokenCanonical(SITE_URL, l.chain, l.token) },
     openGraph: { siteName: BRAND_DOMAIN, type: "website", title, description: clampSocial(description), url: `${SITE_URL}/t/${l.chain}/${l.token}` },
     twitter: { card: "summary_large_image", site: `@${BRAND_X}`, title, description: clampSocial(description) },
   };
@@ -78,8 +80,27 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
   const feeRoute = mode === "free" ? "No trading fee" : `${pipsToPct(l.lp_fee)} trading fee → ${mode === "burn" ? "burned" : mode === "split" ? "beneficiaries" : "beneficiary"}`;
   const utility = "inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-line px-2.5 text-xs text-muted hover:border-line-strong hover:text-ink";
 
+  // Facts-only structured data (on-chain fields + creator metadata, no scores).
+  const jsonLd = tokenJsonLd({
+    name: l.name,
+    symbol: l.symbol,
+    chain,
+    chainId: chainIdOf(chain),
+    token: l.token,
+    launcher: l.launcher,
+    quoteSymbol: quote.symbol,
+    supply: l.supply,
+    poolId: l.pool_id,
+    startTick: l.start_tick,
+    lpFee: l.lp_fee,
+    blockTime: l.block_time,
+    description: l.description,
+    siteUrl: SITE_URL,
+  });
+
   return (
     <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <main className="mx-auto max-w-6xl px-4 pt-5 pb-28 sm:pt-7 lg:pb-16">
         <nav aria-label="Breadcrumb" className="mb-5 flex min-h-8 items-center justify-between gap-3 text-xs text-muted">
           <Link href="/#launches" className="inline-flex items-center gap-2 hover:text-ink"><ArrowLeft size={13} /> All launches</Link>

--- a/app/src/app/t/[chain]/[token]/page.tsx
+++ b/app/src/app/t/[chain]/[token]/page.tsx
@@ -28,8 +28,7 @@ import { fmtCompact, fmtPrice, fmtQuote, fmtUsd, pipsToPct } from "@/lib/launchp
 import { marketCount as count } from "@/lib/launchpad/token-market";
 import { marketUsd } from "@/lib/launchpad/market-format";
 import { CHAIN_LABELS, SITE_URL, chainIdOf, explorerAddress, explorerName, explorerTx, isChainKey, shortAddr } from "@/lib/chainPublic";
-import { tokenCanonical, tokenJsonLd } from "@/lib/seo";
-import { stockByAddress } from "@/lib/launchpad/stocksServer";
+import { jsonLdHtml, tokenCanonical } from "@/lib/seo";import { stockByAddress } from "@/lib/launchpad/stocksServer";
 import { BRAND_DOMAIN, BRAND_X } from "@/lib/brand";
 import { clampSocial } from "@/lib/launchpad/ogcard";
 
@@ -81,7 +80,9 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
   const utility = "inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-line px-2.5 text-xs text-muted hover:border-line-strong hover:text-ink";
 
   // Facts-only structured data (on-chain fields + creator metadata, no scores).
-  const jsonLd = tokenJsonLd({
+  // Escaped for the script sink: creator-supplied name/description must not
+  // be able to terminate the <script> element.
+  const jsonLd = jsonLdHtml({
     name: l.name,
     symbol: l.symbol,
     chain,
@@ -100,7 +101,7 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
 
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />
       <main className="mx-auto max-w-6xl px-4 pt-5 pb-28 sm:pt-7 lg:pb-16">
         <nav aria-label="Breadcrumb" className="mb-5 flex min-h-8 items-center justify-between gap-3 text-xs text-muted">
           <Link href="/#launches" className="inline-flex items-center gap-2 hover:text-ink"><ArrowLeft size={13} /> All launches</Link>

--- a/app/src/lib/seo.test.ts
+++ b/app/src/lib/seo.test.ts
@@ -4,6 +4,7 @@ import {
   STATIC_SITEMAP_ROUTES,
   canonicalUrl,
   isCanonicalTokenPath,
+  jsonLdHtml,
   staticSitemapEntries,
   tokenCanonical,
   tokenJsonLd,
@@ -82,4 +83,27 @@ test("token JSON-LD is facts-only: identifiers, no scores", () => {
   assert.ok(!text.includes("score"), "no scores");
   assert.ok(!text.includes("trust"), "no trust flags");
   assert.ok(!text.includes("rank"), "no rankings");
+});
+
+test("jsonLdHtml escapes < so creator input cannot break out of the script tag", () => {
+  const input = {
+    name: "</script><script>alert(1)</script>",
+    symbol: "XSS",
+    chain: "base" as const,
+    chainId: 8453,
+    token: TOKEN,
+    launcher: "0xAbC0000000000000000000000000000000000001",
+    quoteSymbol: "ETH",
+    supply: "1000000000000000000000000000",
+    poolId: "0xpool",
+    startTick: 184200,
+    lpFee: 10000,
+    blockTime: "2026-09-06T00:00:00.000Z",
+    description: "a < b",
+    siteUrl: SITE,
+  };
+  const html = jsonLdHtml(input);
+  assert.ok(!html.includes("<"), "no literal angle brackets remain");
+  assert.ok(html.includes("\\u003c/script>"), "closing tag is unicode-escaped");
+  assert.deepEqual(JSON.parse(html.replace(/\\u003c/g, "<")), JSON.parse(JSON.stringify(tokenJsonLd(input))), "escapes round-trip");
 });

--- a/app/src/lib/seo.test.ts
+++ b/app/src/lib/seo.test.ts
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  STATIC_SITEMAP_ROUTES,
+  canonicalUrl,
+  isCanonicalTokenPath,
+  staticSitemapEntries,
+  tokenCanonical,
+  tokenJsonLd,
+  tokenPath,
+  tokenSitemapEntries,
+} from "./seo.ts";
+
+const SITE = "https://openlaunch.lol";
+const TOKEN = "0x1234567890abcdef1234567890abcdef12345678";
+
+test("canonicalUrl joins base + path without double slashes", () => {
+  assert.equal(canonicalUrl(SITE, "/"), `${SITE}/`);
+  assert.equal(canonicalUrl(`${SITE}/`, "/launch"), `${SITE}/launch`);
+  assert.equal(canonicalUrl(SITE, "feed"), `${SITE}/feed`);
+});
+
+test("token path helpers lowercase the address", () => {
+  assert.equal(tokenPath("base", TOKEN.toUpperCase()), `/t/base/${TOKEN}`);
+  assert.equal(tokenCanonical(SITE, "base", TOKEN), `${SITE}/t/base/${TOKEN}`);
+});
+
+test("isCanonicalTokenPath rejects bad chains and addresses", () => {
+  assert.equal(isCanonicalTokenPath("base", TOKEN), true);
+  assert.equal(isCanonicalTokenPath("robinhood", TOKEN), true);
+  assert.equal(isCanonicalTokenPath("ethereum", TOKEN), false);
+  assert.equal(isCanonicalTokenPath("base", "not-an-address"), false);
+  assert.equal(isCanonicalTokenPath("base", "0x123"), false);
+});
+
+test("static sitemap covers every public route and skips /admin", () => {
+  const paths = STATIC_SITEMAP_ROUTES.map((r) => r.path);
+  for (const p of ["/", "/launch", "/feed", "/rules", "/agents", "/me"]) {
+    assert.ok(paths.includes(p), `missing ${p}`);
+  }
+  assert.ok(!paths.includes("/admin"), "/admin must stay out of the sitemap");
+  const entries = staticSitemapEntries(SITE, "2026-09-06T00:00:00.000Z");
+  assert.equal(entries.length, STATIC_SITEMAP_ROUTES.length);
+  assert.ok(entries.every((e) => e.url.startsWith(SITE)));
+  assert.equal(entries[0].url, `${SITE}/`);
+});
+
+test("token sitemap skips invalid rows and keeps block_time", () => {
+  const entries = tokenSitemapEntries(SITE, [
+    { chain: "base", token: TOKEN, block_time: "2026-09-06T00:00:00.000Z" },
+    { chain: "base", token: "junk", block_time: null },
+    { chain: "ethereum" as never, token: TOKEN, block_time: null },
+  ]);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].url, `${SITE}/t/base/${TOKEN}`);
+  assert.equal(entries[0].lastModified, "2026-09-06T00:00:00.000Z");
+  assert.equal(entries[0].priority, 0.9);
+});
+
+test("token JSON-LD is facts-only: identifiers, no scores", () => {
+  const ld = tokenJsonLd({
+    name: "Trend Coin",
+    symbol: "TREND",
+    chain: "base",
+    chainId: 8453,
+    token: TOKEN,
+    launcher: "0xAbC0000000000000000000000000000000000001",
+    quoteSymbol: "ETH",
+    supply: "1000000000000000000000000000",
+    poolId: "0xpool",
+    startTick: 184200,
+    lpFee: 10000,
+    blockTime: "2026-09-06T00:00:00.000Z",
+    description: null,
+    siteUrl: SITE,
+  });
+  assert.equal(ld["@type"], "WebPage");
+  assert.equal(ld["url"], `${SITE}/t/base/${TOKEN}`);
+  const about = ld["about"] as Record<string, unknown>;
+  assert.equal(about["identifier"], TOKEN);
+  const text = JSON.stringify(ld).toLowerCase();
+  assert.ok(!text.includes("score"), "no scores");
+  assert.ok(!text.includes("trust"), "no trust flags");
+  assert.ok(!text.includes("rank"), "no rankings");
+});

--- a/app/src/lib/seo.ts
+++ b/app/src/lib/seo.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure SEO helpers (node --test loads this). No Next.js, no DB, no env reads:
+ * callers pass `siteUrl` in so unit tests stay deterministic.
+ */
+
+export type ChainKey = "base" | "robinhood";
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+export function isChainKey(v: unknown): v is ChainKey {
+  return v === "base" || v === "robinhood";
+}
+
+export function isTokenAddress(v: unknown): boolean {
+  return typeof v === "string" && ADDRESS_RE.test(v);
+}
+
+export function isCanonicalTokenPath(chain: unknown, token: unknown): boolean {
+  return isChainKey(chain) && isTokenAddress(token);
+}
+
+export function canonicalUrl(siteUrl: string, path: string): string {
+  const base = siteUrl.replace(/\/$/, "");
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${base}${p}`;
+}
+
+export function tokenPath(chain: ChainKey, token: string): string {
+  return `/t/${chain}/${token.toLowerCase()}`;
+}
+
+export function tokenCanonical(siteUrl: string, chain: ChainKey, token: string): string {
+  return canonicalUrl(siteUrl, tokenPath(chain, token));
+}
+
+export type StaticRoute = {
+  path: string;
+  changeFrequency: "always" | "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "never";
+  priority: number;
+};
+
+/**
+ * Static sitemap routes. Facts only: every path exists in src/app.
+ * /admin is intentionally excluded (robots noindex + disallowed in robots.txt).
+ */
+export const STATIC_SITEMAP_ROUTES: StaticRoute[] = [
+  { path: "/", changeFrequency: "hourly", priority: 1 },
+  { path: "/launch", changeFrequency: "weekly", priority: 0.8 },
+  { path: "/feed", changeFrequency: "hourly", priority: 0.7 },
+  { path: "/rules", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/agents", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/me", changeFrequency: "weekly", priority: 0.4 },
+];
+
+export type SitemapEntry = {
+  url: string;
+  lastModified?: string;
+  changeFrequency: StaticRoute["changeFrequency"];
+  priority: number;
+};
+
+export function staticSitemapEntries(siteUrl: string, lastModified?: string): SitemapEntry[] {
+  return STATIC_SITEMAP_ROUTES.map((r) => ({
+    url: canonicalUrl(siteUrl, r.path),
+    ...(lastModified ? { lastModified } : {}),
+    changeFrequency: r.changeFrequency,
+    priority: r.priority,
+  }));
+}
+
+export type TokenRow = {
+  chain: ChainKey;
+  token: string;
+  block_time: string | null;
+};
+
+export function tokenSitemapEntries(siteUrl: string, rows: TokenRow[]): SitemapEntry[] {
+  const out: SitemapEntry[] = [];
+  for (const r of rows) {
+    if (!isCanonicalTokenPath(r.chain, r.token)) continue;
+    out.push({
+      url: tokenCanonical(siteUrl, r.chain, r.token),
+      ...(r.block_time ? { lastModified: r.block_time } : {}),
+      changeFrequency: "hourly",
+      priority: 0.9,
+    });
+  }
+  return out;
+}
+
+export type TokenJsonLdInput = {
+  name: string;
+  symbol: string;
+  chain: ChainKey;
+  chainId: number;
+  token: string;
+  launcher: string;
+  quoteSymbol: string;
+  supply: string;
+  poolId: string;
+  startTick: number;
+  lpFee: number;
+  blockTime: string;
+  description: string | null;
+  siteUrl: string;
+};
+
+/**
+ * Facts-only JSON-LD for a token page. Every field is on-chain (factory /
+ * locker / pool) or creator-supplied metadata — no scores, no flags, no
+ * predictions (see CONTRIBUTING.md "Facts over scores").
+ */
+export function tokenJsonLd(l: TokenJsonLdInput): Record<string, unknown> {
+  const url = tokenCanonical(l.siteUrl, l.chain, l.token);
+  const chainLabel = l.chain === "base" ? "Base" : "Robinhood Chain";
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `${l.name} (${l.symbol})`,
+    description: (l.description ?? `${l.name} launched on openlaunch.lol.`).slice(0, 500),
+    url,
+    dateCreated: l.blockTime,
+    about: {
+      "@type": "DigitalDocument",
+      name: l.name,
+      identifier: l.token.toLowerCase(),
+      url,
+      inLanguage: "en",
+      creator: { "@type": "Organization", identifier: l.launcher.toLowerCase() },
+      isPartOf: { "@type": "WebSite", name: chainLabel, identifier: String(l.chainId) },
+      additionalProperty: [
+        { "@type": "PropertyValue", name: "symbol", value: l.symbol },
+        { "@type": "PropertyValue", name: "quoteSymbol", value: l.quoteSymbol },
+        { "@type": "PropertyValue", name: "supply", value: l.supply },
+        { "@type": "PropertyValue", name: "poolId", value: l.poolId },
+        { "@type": "PropertyValue", name: "startTick", value: String(l.startTick) },
+        { "@type": "PropertyValue", name: "lpFeePips", value: String(l.lpFee) },
+      ],
+    },
+  };
+}

--- a/app/src/lib/seo.ts
+++ b/app/src/lib/seo.ts
@@ -109,7 +109,8 @@ export type TokenJsonLdInput = {
  * Facts-only JSON-LD for a token page. Every field is on-chain (factory /
  * locker / pool) or creator-supplied metadata — no scores, no flags, no
  * predictions (see CONTRIBUTING.md "Facts over scores").
- */export function tokenJsonLd(l: TokenJsonLdInput): Record<string, unknown> {
+ */
+export function tokenJsonLd(l: TokenJsonLdInput): Record<string, unknown> {
   const url = tokenCanonical(l.siteUrl, l.chain, l.token);
   const chainLabel = l.chain === "base" ? "Base" : "Robinhood Chain";
   return {

--- a/app/src/lib/seo.ts
+++ b/app/src/lib/seo.ts
@@ -109,8 +109,7 @@ export type TokenJsonLdInput = {
  * Facts-only JSON-LD for a token page. Every field is on-chain (factory /
  * locker / pool) or creator-supplied metadata — no scores, no flags, no
  * predictions (see CONTRIBUTING.md "Facts over scores").
- */
-export function tokenJsonLd(l: TokenJsonLdInput): Record<string, unknown> {
+ */export function tokenJsonLd(l: TokenJsonLdInput): Record<string, unknown> {
   const url = tokenCanonical(l.siteUrl, l.chain, l.token);
   const chainLabel = l.chain === "base" ? "Base" : "Robinhood Chain";
   return {
@@ -138,4 +137,14 @@ export function tokenJsonLd(l: TokenJsonLdInput): Record<string, unknown> {
       ],
     },
   };
+}
+
+/**
+ * Render JSON-LD for a `<script type="application/ld+json">` sink.
+ * `name` / `description` are creator-supplied, so `<` is escaped to
+ * `\u003c`: a literal `</script>` in a token name must never terminate
+ * the script element (XSS). The JSON parses identically.
+ */
+export function jsonLdHtml(l: TokenJsonLdInput): string {
+  return JSON.stringify(tokenJsonLd(l)).replace(/</g, "\\u003c");
 }


### PR DESCRIPTION
The site had no crawler entry points and no route error boundaries: glob for robots.ts/sitemap.ts/manifest.ts/error.tsx/global-error.tsx under app/src/app returned nothing, layout.tsx set a site-wide canonical of "/" only, and token generateMetadata() returned no canonical and no structured data.

What this adds:
- app/src/app/robots.ts — allow /, disallow /admin + /api, sitemap + host ref
- app/src/app/sitemap.ts — static routes + newest 1000 launches from bb_launches, fail-soft to statics when the DB is unconfigured/unreachable (never 500s crawlers)
- app/src/app/manifest.ts — PWA manifest reusing the existing app-icon routes, theme color matches layout
- app/src/app/error.tsx + global-error.tsx — route/root boundaries mirroring not-found.tsx (reset + back to launchpad, funds-are-on-chain copy)
- token pages — alternates.canonical per token + facts-only JSON-LD (on-chain fields + creator metadata; no scores/flags per CONTRIBUTING.md)
- app/src/lib/seo.ts + seo.test.ts — pure canonical/sitemap/JSON-LD helpers, 6 tests

Verification (all real, local):
- cd app && npm test → 240 pass, 0 fail
- npm run lint → clean
- npx tsc --noEmit -p . → clean
- production build with CI env → ok, routes show /robots.txt, /sitemap.xml, /manifest.webmanifest
- No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added app icons and installable app metadata.
  - Added sitemap and crawler guidance, including token pages and protected paths.
  - Added canonical URLs and structured data to token pages.
  - Added Gitlawb-specific branding, pool details, and explanatory content where applicable.
  - Added consistent shared typography across the app and error pages.
  - Added route-level and site-wide error pages with retry and home navigation.

- **Bug Fixes**
  - Preserved static sitemap pages when token data is unavailable.
  - Improved structured-data safety and validation.

- **Tests**
  - Added coverage for URL normalization, sitemap generation, token validation, and structured metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->