### PR TITLE
feat(launch): sticky Stock chip + issuer disclaimer + fail-closed CTA

### DIFF
--- a/app/src/components/launchpad/LaunchForm.tsx
+++ b/app/src/components/launchpad/LaunchForm.tsx
@@ -365,6 +365,10 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                   onClick={() => {
                     setChain(k);
                     setQuoteKey(launchpad(k).quotes[0].key);
+                    // a stock belongs to one chain's registry: never carry a Base pick over to Robinhood (or back)
+                    setStock(null);
+                    setStockQ("");
+                    setStockHits([]);
                     setMcapPick(null);
                     setCustomMcap("");
                   }}

--- a/app/src/components/launchpad/LaunchForm.tsx
+++ b/app/src/components/launchpad/LaunchForm.tsx
@@ -54,6 +54,12 @@ function randomSalt(): Hex {
   return `0x${Array.from(b, (x) => x.toString(16).padStart(2, "0")).join("")}`;
 }
 
+function stockIssuerDisclaimer(chain: ChainKey): string {
+  return chain === "base"
+    ? "Coinbase tokenized stocks are securities issued by Coinbase under Regulation S and are not offered to persons in the US, UK, Canada, Australia, Singapore or Switzerland. That is Coinbase's rule for the stock token, not ours. The pool itself is ordinary Uniswap v4."
+    : "Robinhood Stock Tokens are tokenised securities issued by Robinhood and are not offered to US persons. That is Robinhood's rule for the stock token, not ours. The pool itself is ordinary Uniswap v4.";
+}
+
 type FirstBuyCtx = { pub: PublicClient; wallet: WalletClient; address: Address; V4: ReturnType<typeof launchpad>["v4"]; quote: Quote; feePips: number; CHAIN: (typeof CHAINS)[ChainKey]; setPhase: (p: Phase) => void };
 
 function parseBuyAmount(v: string, decimals: number): bigint | null | undefined {
@@ -194,7 +200,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
   if (name.trim().length === 0 || name.trim().length > 32) errors.push("Name: 1–32 characters.");
   if (!/^[A-Z0-9]{1,10}$/.test(symbolClean)) errors.push("Symbol: 1–10 letters or digits.");
   if (startTick === null) errors.push("Starting market cap must be a positive number.");
-  if (quoteKey === "stock" && !stock) errors.push("Pick a stock to price the token in.");
+  if (quoteKey === "stock" && !stock) errors.push("Pick a registry stock or switch quote.");
   if (quoteKey === "gitlawb" && quote.usd === null && !customMcap.trim() && startTick === null) errors.push("GITLAWB price unavailable right now: enter a custom starting market cap in GITLAWB, or reload.");
   if (image && !/^https:\/\//.test(image.trim())) errors.push("Image must be an https URL.");
   if (website && !/^https:\/\//.test(website.trim())) errors.push("Website must be an https URL.");
@@ -417,7 +423,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
             </div>
           ) : null}
           {quoteKey === "stock" ? (
-            <div className="space-y-2">
+            <div className="space-y-2" data-testid="stock-quote-sticky" aria-live="polite">
               <div className="flex items-center gap-2 flex-wrap">
                 {stock ? (
                   <span className="inline-flex items-center gap-2 h-9 pl-1.5 pr-3 rounded-full border border-brand bg-brand-soft text-brand text-sm font-semibold">
@@ -425,15 +431,42 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                       // eslint-disable-next-line @next/next/no-img-element
                       <img src={stock.logo} alt="" width={22} height={22} className={`${stock.logo.startsWith("data:") ? "rounded-md" : "rounded-full"} bg-card`} referrerPolicy="no-referrer" />
                     ) : null}
-                    {stock.symbol}
+                    Quote = {stock.symbol}
+                    <span className="font-normal text-xs opacity-80">(registry)</span>
                     <span className="font-normal text-xs opacity-80">{stock.name}</span>
                     {stock.usd ? <span className="font-mono text-xs opacity-80">{fmtUsd(stock.usd)}</span> : null}
-                    <button type="button" onClick={() => setStock(null)} aria-label="change stock" className="ml-1 opacity-70 hover:opacity-100">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setStock(null);
+                        setStockQ("");
+                      }}
+                      aria-label="clear stock quote"
+                      className="ml-1 opacity-70 hover:opacity-100"
+                    >
                       ×
                     </button>
                   </span>
                 ) : (
-                  <input className={`${input} h-10 max-w-xs font-mono uppercase`} value={stockQ} onChange={(e) => setStockQ(e.target.value)} placeholder="Search ticker, e.g. AAPL" aria-label="search stock tokens" autoComplete="off" />
+                  <>
+                    <span className="inline-flex items-center gap-2 h-9 px-3 rounded-full border border-warm/40 bg-warm-soft text-warm-ink text-xs font-semibold" data-testid="stock-quote-empty-chip">
+                      Pick a registry stock or switch quote
+                    </span>
+                    <input className={`${input} h-10 max-w-xs font-mono uppercase`} value={stockQ} onChange={(e) => setStockQ(e.target.value)} placeholder="Search ticker, e.g. AAPL" aria-label="search stock tokens" autoComplete="off" />
+                    <button
+                      type="button"
+                      className="text-xs font-semibold text-muted underline underline-offset-2"
+                      onClick={() => {
+                        setQuoteKey(cfg.quotes[0]?.key ?? "eth");
+                        setStock(null);
+                        setStockQ("");
+                        setMcapPick(null);
+                        setCustomMcap("");
+                      }}
+                    >
+                      Switch quote
+                    </button>
+                  </>
                 )}
               </div>
               {!stock ? (
@@ -462,11 +495,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                   {stockHits.length === 0 ? <li className="text-xs text-muted">{chain === "base" ? "No match. 13 Coinbase tokenized stocks are available on Base: NVDAc, AAPLc, TSLAc, METAc, GOOGLc, AMZNc, MSFTc, MSTRc, COINc, CRCLc, INTCc, SNDKc, SPCXc." : "No match. 194 Robinhood Stock Tokens are available, e.g. AAPL, TSLA, NVDA, SPY."}</li> : null}
                 </ul>
               ) : null}
-              <p className={helper}>
-                {chain === "base"
-                  ? "Coinbase tokenized stocks are securities issued by Coinbase under Regulation S and are not offered to persons in the US, UK, Canada, Australia, Singapore or Switzerland. That is Coinbase's rule for the stock token, not ours. The pool itself is ordinary Uniswap v4."
-                  : "Robinhood Stock Tokens are tokenised securities issued by Robinhood and are not offered to US persons. That is Robinhood's rule for the stock token, not ours. The pool itself is ordinary Uniswap v4."}
-              </p>
+              <p className={helper}>{stockIssuerDisclaimer(chain)}</p>
             </div>
           ) : null}
         </section>
@@ -674,6 +703,15 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
         </section>
 
         <section className={`${card} p-5 space-y-3`}>
+          {quoteKey === "stock" && !stock ? (
+            <div
+              className="rounded-xl border border-warm/40 bg-warm-soft px-3.5 py-2.5 text-xs text-warm-ink font-semibold"
+              role="status"
+              data-testid="stock-cta-fail-closed"
+            >
+              Pick a registry stock or switch quote
+            </div>
+          ) : null}
           {errors.length > 0 && (name || symbol) ? (
             <ul className="text-xs text-warm-ink space-y-0.5">
               {errors.map((e) => (

--- a/app/src/components/launchpad/LaunchForm.tsx
+++ b/app/src/components/launchpad/LaunchForm.tsx
@@ -363,6 +363,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                   key={k}
                   disabled={!ok}
                   onClick={() => {
+                    if (k === chain) return; // the active chain: nothing to switch, nothing to reset
                     setChain(k);
                     setQuoteKey(launchpad(k).quotes[0].key);
                     // a stock belongs to one chain's registry: never carry a Base pick over to Robinhood (or back)

--- a/app/src/components/launchpad/LaunchForm.tsx
+++ b/app/src/components/launchpad/LaunchForm.tsx
@@ -54,6 +54,9 @@ function randomSalt(): Hex {
   return `0x${Array.from(b, (x) => x.toString(16).padStart(2, "0")).join("")}`;
 }
 
+/** Shown wherever the form is blocked on a stock choice: one sentence, one place. */
+const STOCK_PICK_MESSAGE = "Pick a stock to price the token in, or switch the quote.";
+
 function stockIssuerDisclaimer(chain: ChainKey): string {
   return chain === "base"
     ? "Coinbase tokenized stocks are securities issued by Coinbase under Regulation S and are not offered to persons in the US, UK, Canada, Australia, Singapore or Switzerland. That is Coinbase's rule for the stock token, not ours. The pool itself is ordinary Uniswap v4."
@@ -200,7 +203,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
   if (name.trim().length === 0 || name.trim().length > 32) errors.push("Name: 1–32 characters.");
   if (!/^[A-Z0-9]{1,10}$/.test(symbolClean)) errors.push("Symbol: 1–10 letters or digits.");
   if (startTick === null) errors.push("Starting market cap must be a positive number.");
-  if (quoteKey === "stock" && !stock) errors.push("Pick a registry stock or switch quote.");
+  if (quoteKey === "stock" && !stock) errors.push(STOCK_PICK_MESSAGE);
   if (quoteKey === "gitlawb" && quote.usd === null && !customMcap.trim() && startTick === null) errors.push("GITLAWB price unavailable right now: enter a custom starting market cap in GITLAWB, or reload.");
   if (image && !/^https:\/\//.test(image.trim())) errors.push("Image must be an https URL.");
   if (website && !/^https:\/\//.test(website.trim())) errors.push("Website must be an https URL.");
@@ -423,7 +426,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
             </div>
           ) : null}
           {quoteKey === "stock" ? (
-            <div className="space-y-2" data-testid="stock-quote-sticky" aria-live="polite">
+            <div className="space-y-2">
               <div className="flex items-center gap-2 flex-wrap">
                 {stock ? (
                   <span className="inline-flex items-center gap-2 h-9 pl-1.5 pr-3 rounded-full border border-brand bg-brand-soft text-brand text-sm font-semibold">
@@ -431,8 +434,8 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                       // eslint-disable-next-line @next/next/no-img-element
                       <img src={stock.logo} alt="" width={22} height={22} className={`${stock.logo.startsWith("data:") ? "rounded-md" : "rounded-full"} bg-card`} referrerPolicy="no-referrer" />
                     ) : null}
-                    Quote = {stock.symbol}
-                    <span className="font-normal text-xs opacity-80">(registry)</span>
+                    {stock.symbol}
+                    <span className="font-normal text-xs opacity-80">{chain === "base" ? "Coinbase stock" : "Robinhood stock"}</span>
                     <span className="font-normal text-xs opacity-80">{stock.name}</span>
                     {stock.usd ? <span className="font-mono text-xs opacity-80">{fmtUsd(stock.usd)}</span> : null}
                     <button
@@ -449,9 +452,6 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                   </span>
                 ) : (
                   <>
-                    <span className="inline-flex items-center gap-2 h-9 px-3 rounded-full border border-warm/40 bg-warm-soft text-warm-ink text-xs font-semibold" data-testid="stock-quote-empty-chip">
-                      Pick a registry stock or switch quote
-                    </span>
                     <input className={`${input} h-10 max-w-xs font-mono uppercase`} value={stockQ} onChange={(e) => setStockQ(e.target.value)} placeholder="Search ticker, e.g. AAPL" aria-label="search stock tokens" autoComplete="off" />
                     <button
                       type="button"
@@ -704,12 +704,8 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
 
         <section className={`${card} p-5 space-y-3`}>
           {quoteKey === "stock" && !stock ? (
-            <div
-              className="rounded-xl border border-warm/40 bg-warm-soft px-3.5 py-2.5 text-xs text-warm-ink font-semibold"
-              role="status"
-              data-testid="stock-cta-fail-closed"
-            >
-              Pick a registry stock or switch quote
+            <div className="rounded-xl border border-warm/40 bg-warm-soft px-3.5 py-2.5 text-xs text-warm-ink font-semibold" role="status">
+              {STOCK_PICK_MESSAGE}
             </div>
           ) : null}
           {errors.length > 0 && (name || symbol) ? (

--- a/app/src/components/launchpad/launch-form.test.ts
+++ b/app/src/components/launchpad/launch-form.test.ts
@@ -81,3 +81,21 @@ for (const status of ["success", "reverted"]) {
     assert.equal(sentValue, 100n);
   });
 }
+
+test("stock quote: one blocking message, a chip that names the issuer, a way out, and no test hooks in production markup", () => {
+  // the sentence lives once and is shown by the validation list and the submit-card status box
+  assert.match(source, /const STOCK_PICK_MESSAGE = "Pick a stock to price the token in, or switch the quote\."/);
+  assert.equal(source.match(/STOCK_PICK_MESSAGE/g)?.length, 3);
+  assert.match(source, /if \(quoteKey === "stock" && !stock\) errors.push\(STOCK_PICK_MESSAGE\)/);
+  assert.match(source, /\{quoteKey === "stock" && !stock \? \(\s*<div className="[^"]*" role="status">\s*\{STOCK_PICK_MESSAGE\}/);
+  // the only live region is that status box: the search results must not be re-announced on every keystroke
+  assert.doesNotMatch(source, /aria-live/);
+  assert.doesNotMatch(source, /data-testid|\(registry\)|Quote = \{/);
+  // the picked stock chip says whose stock it is and can be cleared; "Switch quote" returns to the first configured quote
+  assert.match(source, /\{stock\.symbol\}\s*<span className="[^"]*">\{chain === "base" \? "Coinbase stock" : "Robinhood stock"\}<\/span>/);
+  assert.match(source, /aria-label="clear stock quote"/);
+  assert.match(source, /Switch quote/);
+  assert.match(source, /setQuoteKey\(cfg\.quotes\[0\]\?\.key \?\? "eth"\);\s*setStock\(null\);\s*setStockQ\(""\);\s*setMcapPick\(null\);\s*setCustomMcap\(""\);/);
+  // the issuer disclaimer is rendered from one helper for both chains
+  assert.match(source, /<p className=\{helper\}>\{stockIssuerDisclaimer\(chain\)\}<\/p>/);
+});

--- a/app/src/components/launchpad/launch-form.test.ts
+++ b/app/src/components/launchpad/launch-form.test.ts
@@ -96,6 +96,8 @@ test("stock quote: one blocking message, a chip that names the issuer, a way out
   assert.match(source, /aria-label="clear stock quote"/);
   assert.match(source, /Switch quote/);
   assert.match(source, /setQuoteKey\(cfg\.quotes\[0\]\?\.key \?\? "eth"\);\s*setStock\(null\);\s*setStockQ\(""\);\s*setMcapPick\(null\);\s*setCustomMcap\(""\);/);
+  // switching chains drops the picked stock: a registry address from one chain must never become the other chain's quote
+  assert.match(source, /setChain\(k\);\s*setQuoteKey\(launchpad\(k\)\.quotes\[0\]\.key\);[^}]*setStock\(null\);\s*setStockQ\(""\);\s*setStockHits\(\[\]\);/);
   // the issuer disclaimer is rendered from one helper for both chains
   assert.match(source, /<p className=\{helper\}>\{stockIssuerDisclaimer\(chain\)\}<\/p>/);
 });

--- a/app/src/components/launchpad/launch-form.test.ts
+++ b/app/src/components/launchpad/launch-form.test.ts
@@ -97,7 +97,8 @@ test("stock quote: one blocking message, a chip that names the issuer, a way out
   assert.match(source, /Switch quote/);
   assert.match(source, /setQuoteKey\(cfg\.quotes\[0\]\?\.key \?\? "eth"\);\s*setStock\(null\);\s*setStockQ\(""\);\s*setMcapPick\(null\);\s*setCustomMcap\(""\);/);
   // switching chains drops the picked stock: a registry address from one chain must never become the other chain's quote
-  assert.match(source, /setChain\(k\);\s*setQuoteKey\(launchpad\(k\)\.quotes\[0\]\.key\);[^}]*setStock\(null\);\s*setStockQ\(""\);\s*setStockHits\(\[\]\);/);
+  // ...but re-clicking the active chain is a no-op, so it cannot wipe the picked stock
+  assert.match(source, /if \(k === chain\) return;[^}]*setChain\(k\);\s*setQuoteKey\(launchpad\(k\)\.quotes\[0\]\.key\);[^}]*setStock\(null\);\s*setStockQ\(""\);\s*setStockHits\(\[\]\);/);
   // the issuer disclaimer is rendered from one helper for both chains
   assert.match(source, /<p className=\{helper\}>\{stockIssuerDisclaimer\(chain\)\}<\/p>/);
 });


### PR DESCRIPTION
## Summary
- Dig #2 (Grok Super B-20 stock UX): sticky `Quote = SYMBOL (registry)` chip beside the Stock picker
- Reg S / issuer disclaimer kept adjacent to the Stock pick (shared helper, existing OL copy)
- CTA fail-closed with an explicit chip when Stock is selected with no registry pick (`Pick a registry stock or switch quote`)
- Registry-gated only via existing `/api/quotes` / BASE_STOCKS — no invented tickers, no custody, no new metrics

## Deferred
- Dig #3: above-fold Stock for Instant — **not shipped**
- Instant Advanced sticky-outside-collapse path lives on `feat/ol-stock-ux` (gitlawb + Instant tip `34931c6`) for when Instant skin lands on `main`

## Test plan
- [ ] Select Stock quote → empty chip + typeahead; CTA disabled with fail-closed chip
- [ ] Pick a registry hit (e.g. NVDAc) → sticky `Quote = NVDAc (registry)`; disclaimer visible beside pick; CTA enabled when other fields valid
- [ ] Clear stock / switch quote → chip clears; no inventable tickers outside registry hits
- [ ] Base Reg S + Robinhood issuer copy still match existing honesty style

Do **not** merge without review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added chain-specific disclaimers and shared messaging for stock quotes.
  - Improved stock quote selection with issuer labels and a “Switch quote” action.
  - Wallet connection now opens a wallet selection modal.
  - Added a fail-closed action when no stock quote is selected.

- **Bug Fixes**
  - Changing chains now clears chain-specific stock selections, searches, and results.
  - Re-selecting the active chain preserves the current stock selection state.
  - Resetting or switching quotes now clears related selection state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->