### PR TITLE
feed: rebuild the /feed loading skeleton to match the real page

### DIFF
--- a/app/src/app/(home)/loading.tsx
+++ b/app/src/app/(home)/loading.tsx
@@ -49,23 +49,24 @@ export default function Loading() {
         </section>
         <aside className="space-y-4">
           <div className="rounded-2xl bg-card border border-line shadow-card overflow-hidden">
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="flex min-h-14 items-center justify-between border-b border-line px-4">
               <Sk className="h-4 w-14" />
               <Sk className="h-3 w-16" />
             </div>
             <ul>
               {Array.from({ length: 4 }, (_, i) => (
-                <SkPost key={i} />
+                <SkPost key={i} i={i} avatar="tile" />
               ))}
             </ul>
           </div>
           <div className="rounded-2xl bg-card border border-line shadow-card overflow-hidden">
-            <div className="px-4 py-3">
+            <div className="flex min-h-14 items-center justify-between gap-2 border-b border-line px-4">
               <Sk className="h-4 w-20" />
+              <div className="flex items-center gap-2"><Sk className="h-3 w-14" /><Sk className="h-10 w-10 rounded-lg" /></div>
             </div>
             <ul>
-              {Array.from({ length: 6 }, (_, i) => (
-                <SkPost key={i} />
+              {Array.from({ length: 5 }, (_, i) => (
+                <SkPost key={i} i={i} />
               ))}
             </ul>
           </div>

--- a/app/src/app/feed/loading.tsx
+++ b/app/src/app/feed/loading.tsx
@@ -1,17 +1,66 @@
-import { Sk, SkPost } from "@/components/Skeleton";
+import { Sk, SkFeedPost } from "@/components/Skeleton";
+import shell from "@/components/sections/SectionShell.module.css";
+import styles from "@/components/sections/CommunityFeed.module.css";
 
+/**
+ * /feed skeleton. Same shell, intro, two-column grid and post rhythm as FeedPage + CommunityFeed
+ * (it borrows their CSS modules, so breakpoints stay in sync) so nothing shifts when the posts arrive.
+ */
 export default function Loading() {
   return (
-    <main className="mx-auto max-w-3xl px-4 pt-8 sm:pt-10 pb-16 space-y-6" aria-busy="true" aria-label="loading posts">
-      <header className="space-y-3">
-        <Sk className="h-9 w-24" />
-        <Sk className="h-5 w-3/4 max-w-xl" />
+    <main className={shell.page} aria-busy="true" aria-label="Loading posts">
+      <header className={shell.intro}>
+        <div className="flex h-4 items-center"><Sk className="h-3 w-36" /></div>
+        <div className={shell.introRow}>
+          <div className={`${shell.introCopy} w-full`}>
+            <Sk className="h-9 w-72 max-w-full sm:h-[50px]" />
+            <div className="mt-4">
+              <div className="flex h-[26px] items-center sm:h-[27px]"><Sk className="h-4 w-full max-w-[620px]" /></div>
+              <div className="flex h-[26px] items-center sm:h-[27px]"><Sk className="h-4 w-3/4 max-w-[460px]" /></div>
+            </div>
+          </div>
+          <Sk className="h-11 w-40 rounded-full" />
+        </div>
       </header>
-      <ul className="rounded-2xl bg-card border border-line shadow-card overflow-hidden">
-        {Array.from({ length: 10 }, (_, i) => (
-          <SkPost key={i} />
-        ))}
-      </ul>
+      <div className={styles.layout}>
+        <section className={shell.panel} aria-label="Loading recent community posts">
+          <div className={styles.toolbar}><Sk className="h-4 w-44 max-w-full" /><Sk className="h-11 w-11 rounded-full" /></div>
+          <div className={styles.filters}><Sk className="h-[54px] w-60 max-w-full rounded-xl" /><Sk className="h-11 min-w-[180px] flex-1" /></div>
+          <div className={styles.resultLine}><p className="flex h-4 items-center"><Sk className="h-3 w-24" /></p><span className="flex h-4 items-center"><Sk className="h-3 w-36" /></span></div>
+          <ul>
+            {Array.from({ length: 6 }, (_, i) => (
+              <SkFeedPost key={i} i={i} />
+            ))}
+          </ul>
+          <div className={styles.feedFoot}><Sk className="h-3 w-80 max-w-full" /></div>
+        </section>
+        <aside className={styles.aside} aria-hidden="true">
+          <section className={styles.guide}>
+            <Sk className="h-3 w-44" />
+            <div className="mt-3.5 flex h-[30px] items-center"><Sk className="h-6 w-48 max-w-full" /></div>
+            <div className="mt-3">
+              <div className="flex h-[23px] items-center"><Sk className="h-3.5 w-full" /></div>
+              <div className="flex h-[23px] items-center"><Sk className="h-3.5 w-5/6" /></div>
+            </div>
+            <ul className={styles.steps}>
+              {[0, 1, 2].map((i) => (
+                <li key={i}><span className="flex h-5 shrink-0 items-center"><Sk className="h-3 w-5" /></span><div className="min-w-0 flex-1"><div className="flex h-5 items-center"><Sk className="h-3.5 w-32 max-w-full" /></div><div className="mt-1 flex h-5 items-center"><Sk className="h-3 w-44 max-w-full" /></div></div></li>
+              ))}
+            </ul>
+            <div className="flex h-11 items-center"><Sk className="h-3.5 w-32" /></div>
+          </section>
+          <section className={styles.note}>
+            <Sk className="h-5 w-5" />
+            <div className="mt-4 flex h-[21px] items-center"><Sk className="h-4 w-44 max-w-full" /></div>
+            <div className="mt-2.5">
+              {["w-full", "w-full", "w-full", "w-2/3"].map((w, i) => <div key={i} className="flex h-[21px] items-center"><Sk className={`h-3 ${w}`} /></div>)}
+            </div>
+            <div className={styles.caution}>
+              {["w-full", "w-full", "w-1/2"].map((w, i) => <div key={i} className="flex h-[21px] items-center"><Sk className={`h-3 ${w}`} /></div>)}
+            </div>
+          </section>
+        </aside>
+      </div>
     </main>
   );
 }

--- a/app/src/components/Skeleton.tsx
+++ b/app/src/components/Skeleton.tsx
@@ -48,14 +48,45 @@ export function SkStat() {
   );
 }
 
-export function SkPost() {
+/**
+ * One compact sidebar row. `round` (default) is a post: 28px wallet avatar, author line, token line and a
+ * clamped body (PostsFeed compact). `tile` is a launch-tape row: 28px square token tile and two lines.
+ */
+export function SkPost({ i = 0, avatar = "round" }: { i?: number; avatar?: "round" | "tile" }) {
   return (
-    <li className="px-4 py-3 border-t border-line first:border-t-0 flex gap-3">
-      <Sk className="h-8 w-8 rounded-full shrink-0" />
-      <div className="flex-1 space-y-2">
-        <Sk className="h-3 w-32" />
-        <Sk className="h-3.5 w-3/4" />
+    <li className="px-4 py-3 border-t border-line first:border-t-0 flex gap-2.5">
+      <Sk className={`h-7 w-7 shrink-0 ${avatar === "tile" ? "rounded-lg" : "rounded-full"}`} />
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <div className="flex items-center justify-between gap-2"><Sk className="h-3 w-24" /><Sk className="h-2.5 w-8" /></div>
+        <Sk className="h-2.5 w-28" />
+        {avatar === "round" ? <><Sk className="mt-2 h-3.5 w-full" /><Sk className="h-3.5" style={{ width: `${40 + ((i * 29) % 45)}%` }} /></> : null}
       </div>
+    </li>
+  );
+}
+
+/**
+ * One community-feed post (CommunityFeed.tsx `.post`): 40px wallet avatar + author heading, a 15px body
+ * (26px line pitch), the 20px token tile line and the "Open conversation" line. Same 24px padding
+ * (20px 16px on phones) so the real post lands exactly where its placeholder was.
+ */
+export function SkFeedPost({ i }: { i: number }) {
+  const lines = 1 + (i % 2);
+  return (
+    <li className="border-t border-line first:border-t-0 px-4 py-5 sm:p-6">
+      <div className="flex items-center gap-3">
+        <Sk className="h-10 w-10 shrink-0 rounded-full" />
+        <div className="min-w-0 flex-1">
+          <div className="flex h-5 items-center"><Sk className="h-3.5 w-28" /></div>
+          <div className="mt-1 flex h-5 items-center gap-2"><Sk className="h-5 w-14 rounded" /><Sk className="h-2.5 w-16" /></div>
+        </div>
+        <Sk className="h-4 w-4 shrink-0" />
+      </div>
+      <div className="mt-[18px]">
+        {Array.from({ length: lines }, (_, n) => <div key={n} className="flex h-[26px] items-center"><Sk className="h-3.5" style={{ width: n === lines - 1 ? `${30 + ((i * 23) % 45)}%` : "100%" }} /></div>)}
+      </div>
+      <div className="mt-[18px] flex items-center gap-2"><Sk className="h-5 w-5 shrink-0 rounded-md" /><Sk className="h-3 w-44 max-w-full" /></div>
+      <div className="mt-2 flex h-8 items-center"><Sk className="h-3 w-28" /></div>
     </li>
   );
 }

--- a/app/src/components/feed-loading.test.ts
+++ b/app/src/components/feed-loading.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+/**
+ * Source contracts for the /feed route skeleton. The loader must keep the same shell, intro, two-column
+ * layout and post anatomy as the real page, otherwise the page jumps when posts stream in.
+ */
+const loading = readFileSync(new URL("../app/feed/loading.tsx", import.meta.url), "utf8");
+const page = readFileSync(new URL("../app/feed/page.tsx", import.meta.url), "utf8");
+const feed = readFileSync(new URL("./sections/CommunityFeed.tsx", import.meta.url), "utf8");
+const skeleton = readFileSync(new URL("./Skeleton.tsx", import.meta.url), "utf8");
+const homeLoading = readFileSync(new URL("../app/(home)/loading.tsx", import.meta.url), "utf8");
+
+test("the /feed skeleton borrows the real page's CSS modules instead of hand-rolled widths", () => {
+  assert.match(loading, /from "@\/components\/sections\/SectionShell\.module\.css"/);
+  assert.match(loading, /from "@\/components\/sections\/CommunityFeed\.module\.css"/);
+  assert.match(page, /styles\.page\b/, "the real page uses the section shell");
+  assert.doesNotMatch(loading, /max-w-3xl/, "the old single-column loader width is gone");
+  assert.match(loading, /aria-busy="true"/);
+});
+
+test("the /feed skeleton mirrors every layout region of FeedPage + CommunityFeed", () => {
+  for (const cls of ["shell.page", "shell.intro", "shell.introRow", "shell.introCopy", "shell.panel"]) {
+    assert.match(loading, new RegExp(`className=\\{[^}]*\\b${cls.replace(".", "\\.")}\\b`), `loader uses ${cls}`);
+  }
+  for (const cls of ["layout", "toolbar", "filters", "resultLine", "feedFoot", "aside", "guide", "steps", "note", "caution"]) {
+    assert.match(loading, new RegExp(`\\bstyles\\.${cls}\\b`), `loader uses styles.${cls}`);
+    assert.match(feed, new RegExp(`\\bstyles\\.${cls}\\b`), `CommunityFeed still defines the region styles.${cls}`);
+  }
+  // Regions appear in the same order as the real markup.
+  const order = ["shell.intro", "styles.layout", "shell.panel", "styles.toolbar", "styles.filters", "styles.resultLine", "<SkFeedPost", "styles.feedFoot", "styles.aside", "styles.guide", "styles.note"];
+  const positions = order.map((token) => loading.indexOf(token));
+  assert.ok(positions.every((p) => p >= 0));
+  assert.deepEqual(positions, [...positions].sort((a, b) => a - b), "loader regions are in page order");
+});
+
+test("the /feed skeleton renders full feed posts, not the compact sidebar rows", () => {
+  assert.match(loading, /<SkFeedPost key=\{i\} i=\{i\} \/>/);
+  assert.doesNotMatch(loading, /<SkPost\b/);
+  const count = Number(loading.match(/Array\.from\(\{ length: (\d+) \}, \(_, i\) => \(\s*<SkFeedPost/)?.[1]);
+  assert.ok(count >= 4 && count <= 8, `a viewport's worth of posts, got ${count}`);
+});
+
+test("SkFeedPost matches the real post anatomy: 40px round avatar, body, 20px token tile, conversation line", () => {
+  const block = skeleton.slice(skeleton.indexOf("export function SkFeedPost"), skeleton.indexOf("export function Spinner"));
+  assert.ok(block.length > 0);
+  assert.match(block, /h-10 w-10 shrink-0 rounded-full/, "40px wallet avatar");
+  assert.match(block, /h-5 w-5 shrink-0 rounded-md/, "20px token tile");
+  assert.match(block, /px-4 py-5 sm:p-6/, "24px padding, 20px 16px on phones, like .postLink");
+  assert.match(feed, /<WalletAvatar address=\{post\.wallet\} size=\{40\}/);
+  assert.match(feed, /<TokenAvatar[^>]*size=\{20\}/);
+  assert.match(block, /mt-\[18px\]/, "body and meta keep the 18px rhythm of .postBody / .postMeta");
+});
+
+test("home sidebar skeletons match the compact posts widget and the launch tape", () => {
+  assert.match(homeLoading, /<SkPost key=\{i\} i=\{i\} avatar="tile" \/>/, "launch tape rows use the square token tile");
+  assert.match(homeLoading, /Array\.from\(\{ length: 5 \}, \(_, i\) => \(\s*<SkPost key=\{i\} i=\{i\} \/>/, "posts widget shows COMPACT_LIMIT rows");
+  assert.match(homeLoading, /min-h-14 items-center justify-between/, "56px widget headers");
+  const compact = skeleton.slice(skeleton.indexOf("export function SkPost"), skeleton.indexOf("export function SkFeedPost"));
+  assert.match(compact, /h-7 w-7 shrink-0/, "28px avatar like PostsFeed compact / LaunchTape");
+});


### PR DESCRIPTION
The /feed loader still mirrored the old single-column feed (48rem wide, ten 32px rows), so navigating to Posts showed a narrow, short placeholder that jumped into the wide two-column layout when posts streamed in.

- feed/loading.tsx now borrows the SectionShell and CommunityFeed CSS modules: intro (eyebrow, title, description, pill action), then the panel (toolbar, filters, result line, posts, foot) beside the guide and note aside, so breakpoints stay in sync with the real markup
- new SkFeedPost primitive matches one community post: 40px wallet avatar + author heading, 26px-pitch body lines, 20px token tile line, "Open conversation" line, 24px padding (20/16 on phones)
- SkPost gains `i` and `avatar` ("round" post / "tile" launch-tape row), a 28px avatar and a clamped-body shape; the home sidebar skeleton uses 56px widget headers and COMPACT_LIMIT rows
- feed-loading.test.ts pins the shell/region usage, region order, post anatomy and the home sidebar shapes so the loader cannot drift again

Measured against the live page in headless Chrome at 1440px and 500px: every region lands within 1-2px of the real one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated home-page loading placeholders with more accurate card headers, avatars, controls, and post counts.
  - Redesigned the feed loading state to mirror the feed page, including filters, metadata, posts, footer, and sidebar panels.
  - Added richer loading placeholders with varied avatar styles, post content, author details, token information, and conversation controls.

- **Tests**
  - Added coverage to verify the feed loading layout, structure, styling, and sidebar variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->