### PR TITLE
fix(app): error boundaries use Next.js reset, safe digest, alert semantics

### DIFF
--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -3,24 +3,29 @@
 import Link from "next/link";
 import { useEffect } from "react";
 import { btn } from "@/components/ui";
+import { errorBody, errorRegionLabel, sanitizeDigest } from "@/lib/error-copy";
 
-/** Route-level error boundary. Mirrors not-found.tsx styling. `retry` refreshes the router before re-rendering, so failed server data is fetched again. */
+/** Route-level error boundary. Next.js injects `{ error, reset }`: `reset` re-renders the route segment so failed server data is fetched again. */
 export default function Error({
   error,
-  retry,
+  reset,
 }: {
   error: Error & { digest?: string };
-  retry: () => void;
+  reset: () => void;
 }) {
   useEffect(() => {
     console.error(error);
   }, [error]);
+  const digest = sanitizeDigest(error.digest);
   return (
-    <main className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
-      <div className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">500</div>
-      <p className="text-[15px] text-body">Something broke on this page. Your funds are on-chain — this is only the site.</p>
+    <main aria-label={errorRegionLabel("route")} className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
+      <h1 className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">500</h1>
+      <p role="alert" className="text-[15px] text-body">{errorBody("route")}</p>
+      {digest ? (
+        <p className="text-xs text-muted">Error ID: {digest}</p>
+      ) : null}
       <div className="flex items-center justify-center gap-3">
-        <button type="button" onClick={retry} className={btn.primary}>
+        <button type="button" onClick={reset} className={btn.primary}>
           Try again
         </button>
         <Link href="/" className={btn.secondary}>

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -4,32 +4,38 @@ import Link from "next/link";
 import { useEffect } from "react";
 import "./globals.css";
 import { inter, spaceMono, unbounded } from "./fonts";
+import { errorBody, errorRegionLabel, sanitizeDigest } from "@/lib/error-copy";
 
 /**
  * Root-level error boundary. Must render its own <html>/<body> — it replaces
  * the root layout when active, so it loads the global stylesheet and font
- * variables itself instead of inheriting them.
+ * variables itself instead of inheriting them. Next.js injects
+ * `{ error, reset }`: `reset` re-renders from the root.
  */
 export default function GlobalError({
   error,
-  retry,
+  reset,
 }: {
   error: Error & { digest?: string };
-  retry: () => void;
+  reset: () => void;
 }) {
   useEffect(() => {
     console.error(error);
   }, [error]);
+  const digest = sanitizeDigest(error.digest);
   return (
     <html lang="en" className={`${inter.variable} ${spaceMono.variable} ${unbounded.variable}`}>
       <body className="min-h-screen flex flex-col">
-        <main className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
-          <div className="font-display font-bold text-7xl">500</div>
-          <p className="text-[15px]">Something broke. Your funds are on-chain — this is only the site.</p>
+        <main aria-label={errorRegionLabel("global")} className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
+          <h1 className="font-display font-bold text-7xl">500</h1>
+          <p role="alert" className="text-[15px]">{errorBody("global")}</p>
+          {digest ? (
+            <p className="text-xs opacity-70">Error ID: {digest}</p>
+          ) : null}
           <div className="flex items-center justify-center gap-3">
             <button
               type="button"
-              onClick={retry}
+              onClick={reset}
               className="inline-flex items-center justify-center rounded-xl px-5 min-h-11 bg-black text-white font-semibold text-sm"
             >
               Try again

--- a/app/src/app/not-found.tsx
+++ b/app/src/app/not-found.tsx
@@ -1,14 +1,20 @@
 import Link from "next/link";
 import { btn } from "@/components/ui";
+import { errorBody, errorRegionLabel } from "@/lib/error-copy";
 
 export default function NotFound() {
   return (
-    <main className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
-      <div className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">404</div>
-      <p className="text-[15px] text-body">Nothing here. That token has not been launched here.</p>
-      <Link href="/" className={btn.primary}>
-        Back to the launchpad
-      </Link>
+    <main aria-label={errorRegionLabel("not-found")} className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
+      <h1 className="font-display font-bold text-7xl text-brand-soft [text-shadow:0_1px_0_#d6d3d1]">404</h1>
+      <p className="text-[15px] text-body">{errorBody("not-found")}</p>
+      <div className="flex items-center justify-center gap-3">
+        <Link href="/" className={btn.primary}>
+          Back to the launchpad
+        </Link>
+        <Link href="/launch" className={btn.secondary}>
+          Launch a token
+        </Link>
+      </div>
     </main>
   );
 }

--- a/app/src/lib/error-copy.test.ts
+++ b/app/src/lib/error-copy.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { errorBody, errorHeading, errorRegionLabel, sanitizeDigest } from "./error-copy.ts";
+
+test("sanitizeDigest keeps short opaque ids and drops markup", () => {
+  assert.equal(sanitizeDigest("abc123"), "abc123");
+  assert.equal(sanitizeDigest("  aBc-12_34  "), "aBc-12_34");
+  assert.equal(sanitizeDigest(undefined), null);
+  assert.equal(sanitizeDigest(null), null);
+  assert.equal(sanitizeDigest(""), null);
+  assert.equal(sanitizeDigest("   "), null);
+  assert.equal(sanitizeDigest(123), null);
+  assert.equal(sanitizeDigest("</script>"), null);
+  assert.equal(sanitizeDigest("<img src=x onerror=alert(1)>"), null);
+  assert.equal(sanitizeDigest("digest with spaces"), null);
+  assert.equal(sanitizeDigest("a".repeat(64)), "a".repeat(64));
+  assert.equal(sanitizeDigest("a".repeat(65)), null);
+});
+
+test("headings and copy stay factual per page kind", () => {
+  assert.equal(errorHeading("route"), "500");
+  assert.equal(errorHeading("global"), "500");
+  assert.equal(errorHeading("not-found"), "404");
+  assert.match(errorBody("route"), /funds are on-chain/);
+  assert.match(errorBody("global"), /funds are on-chain/);
+  assert.equal(errorBody("not-found"), "Nothing here. The page you asked for does not exist.");
+  assert.doesNotMatch(errorBody("not-found"), /token/i);
+  assert.equal(errorRegionLabel("route"), "Page error");
+  assert.equal(errorRegionLabel("global"), "Page error");
+  assert.equal(errorRegionLabel("not-found"), "Page not found");
+});
+
+const routeError = readFileSync(new URL("../app/error.tsx", import.meta.url), "utf8");
+const globalError = readFileSync(new URL("../app/global-error.tsx", import.meta.url), "utf8");
+const notFound = readFileSync(new URL("../app/not-found.tsx", import.meta.url), "utf8");
+
+// Source contracts: Next.js injects `{ error, reset }` into error boundaries.
+// A `retry` prop is never provided, so the button must call `reset`.
+test("route + global error boundaries use the Next.js reset prop (not retry)", () => {
+  for (const [name, src] of [["error.tsx", routeError], ["global-error.tsx", globalError]] as const) {
+    assert.match(src, /reset: \(\) => void/, `${name} declares the reset prop`);
+    assert.match(src, /onClick=\{reset\}/, `${name} wires Try again to reset`);
+    assert.doesNotMatch(src, /\bretry\b/, `${name} has no leftover retry prop`);
+  }
+});
+
+test("error boundaries expose an alert landmark, a real heading, and a safe digest", () => {
+  for (const [name, src] of [["error.tsx", routeError], ["global-error.tsx", globalError]] as const) {
+    assert.match(src, /<h1/, `${name} renders the status as a heading`);
+    assert.match(src, /role="alert"/, `${name} announces the failure to assistive tech`);
+    assert.match(src, /aria-label=\{errorRegionLabel\(/, `${name} labels the landmark`);
+    assert.match(src, /sanitizeDigest\(error\.digest\)/, `${name} renders the digest only when safe`);
+    assert.match(src, /Error ID:/, `${name} shows the digest id for support`);
+  }
+  assert.match(routeError, /errorBody\("route"\)/, "route copy comes from the shared helper");
+  assert.match(globalError, /errorBody\("global"\)/, "global copy comes from the shared helper");
+});
+
+test("404 stays generic with heading semantics and two ways back", () => {
+  assert.match(notFound, /<h1/, "404 renders as a heading, not a div");
+  assert.match(notFound, /aria-label=\{errorRegionLabel\("not-found"\)\}/, "404 landmark is labelled");
+  assert.match(notFound, /errorBody\("not-found"\)/, "404 copy comes from the shared helper");
+  assert.doesNotMatch(notFound, /That token has not been launched here/, "404 no longer claims every bad URL is a token");
+  assert.ok(notFound.includes('href="/"'), "404 links home");
+  assert.ok(notFound.includes('href="/launch"'), "404 links to the launch flow");
+});

--- a/app/src/lib/error-copy.ts
+++ b/app/src/lib/error-copy.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helpers for the route/global error boundaries and the 404 page
+ * (node --test loads this; the .tsx pages stay thin).
+ *
+ * Next.js App Router injects `{ error, reset }` into `error.tsx` and
+ * `global-error.tsx` — never a `retry` prop. `sanitizeDigest` keeps the
+ * optional `error.digest` display safe: only short opaque ids render,
+ * everything else is dropped so creator-adjacent strings can never break
+ * out of the error paragraph.
+ */
+
+export type ErrorPageKind = "route" | "global" | "not-found";
+
+const DIGEST_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+/** Keep only short opaque digest ids; drop anything that looks like markup. */
+export function sanitizeDigest(digest: unknown): string | null {
+  if (typeof digest !== "string") return null;
+  const d = digest.trim();
+  if (d.length === 0 || d.length > 64) return null;
+  return DIGEST_RE.test(d) ? d : null;
+}
+
+/** Big numeric heading rendered on the error/404 pages. */
+export function errorHeading(kind: ErrorPageKind): "500" | "404" {
+  return kind === "not-found" ? "404" : "500";
+}
+
+/**
+ * Short human body copy. Route/global errors reassure that funds are
+ * on-chain (only the site broke); the 404 stays generic on purpose — it
+ * renders for every unknown route, not just token pages.
+ */
+export function errorBody(kind: ErrorPageKind): string {
+  if (kind === "not-found") return "Nothing here. The page you asked for does not exist.";
+  if (kind === "global") return "Something broke. Your funds are on-chain — this is only the site.";
+  return "Something broke on this page. Your funds are on-chain — this is only the site.";
+}
+
+/** Accessible label for the error/404 landmark region. */
+export function errorRegionLabel(kind: ErrorPageKind): string {
+  if (kind === "not-found") return "Page not found";
+  return "Page error";
+}


### PR DESCRIPTION
## Why

Route (`app/src/app/error.tsx`) and root (`app/src/app/global-error.tsx`) error boundaries declared a `retry` prop. Next.js App Router injects `{ error, reset }` — never `retry` — so `Try again` was wired to `undefined` and clicking it did nothing. Verified by reading both files on `upstream/main` at 092f9bb.

The 404 page also claimed every unknown URL was an unlaunched token, which is wrong for non-token routes.

## What

- `error.tsx`, `global-error.tsx`: `retry` → `reset` (prop type + `onClick`), status code as `<h1>`, failure paragraph with `role="alert"`, landmark `aria-label` via new shared helper, `error.digest` shown only when it is a short opaque id.
- `not-found.tsx`: generic copy for all unknown routes, `<h1>` semantics, labelled landmark, links to `/` and `/launch`.
- New `app/src/lib/error-copy.ts`: pure helpers (`sanitizeDigest`, `errorHeading`, `errorBody`, `errorRegionLabel`) so the copy and digest allowlist are unit-tested.
- New `app/src/lib/error-copy.test.ts`: helper edge cases (markup, overlong ids, non-strings) + source-contract tests asserting both boundaries declare `reset`, wire `onClick={reset}`, contain no `retry`, expose `role=alert`/`<h1>`/digest, and the 404 stays generic with two ways back.

No new dependencies. Design tokens unchanged (`btn.primary`/`btn.secondary`).

## Verified (real, local)

- `npm run lint` — clean
- `npx tsc --noEmit -p .` — clean
- `npm test` — 295 pass, 0 fail (290 baseline + 5 new)
- `npm run build` — succeeds, all routes emitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route-level and global error pages with clearer messaging and optional sanitized error IDs.
  * Updated error recovery controls for more reliable reset behavior.
  * Added a “Launch a token” link to the 404 page.

* **Accessibility**
  * Improved error-page headings, landmark labels, and alert announcements for assistive technologies.

* **Tests**
  * Added coverage for error-page content, accessibility, recovery behavior, digest safety, and 404 navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->