### PR TITLE
fix(app): ETH price keeps last good value on bad upstream reads

### DIFF
--- a/app/src/lib/launchpad/ethPrice.test.ts
+++ b/app/src/lib/launchpad/ethPrice.test.ts
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ETH_FETCH_TIMEOUT_MS,
+  ETH_PRICE_TTL_MS,
+  ETH_SPOT_URL,
+  ethUsd,
+  parseEthSpot,
+  resetEthPriceCache,
+} from "./ethPrice.ts";
+
+const okBody = (amount: string) => new Response(JSON.stringify({ data: { amount } }), { status: 200 });
+
+function clock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => void (t += ms) };
+}
+
+function mockFetch(res: Response, seen: { n: number; url?: string; signal?: unknown }) {
+  return async (input: string, init?: RequestInit) => {
+    seen.n += 1;
+    seen.url = input;
+    seen.signal = init?.signal;
+    return res;
+  };
+}
+
+test("parseEthSpot takes the live shape and rejects everything else", () => {
+  assert.equal(parseEthSpot({ data: { amount: "2476.12" } }), 2476.12);
+  assert.equal(parseEthSpot(null), null);
+  assert.equal(parseEthSpot(undefined), null);
+  assert.equal(parseEthSpot("2476"), null);
+  assert.equal(parseEthSpot({}), null);
+  assert.equal(parseEthSpot({ data: null }), null);
+  assert.equal(parseEthSpot({ data: {} }), null);
+  assert.equal(parseEthSpot({ data: { amount: 2476 } }), null, "number, not string");
+  assert.equal(parseEthSpot({ data: { amount: "abc" } }), null);
+  assert.equal(parseEthSpot({ data: { amount: "" } }), null);
+  assert.equal(parseEthSpot({ data: { amount: "0" } }), null);
+  assert.equal(parseEthSpot({ data: { amount: "-5" } }), null);
+  assert.equal(parseEthSpot({ data: { amount: "Infinity" } }), null);
+});
+
+test("cold fetch publishes the price and memoizes within the TTL", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  const v1 = await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), now: c.now });
+  assert.equal(v1, 2500);
+  assert.equal(seen.url, ETH_SPOT_URL);
+  const v2 = await ethUsd({ fetchFn: mockFetch(okBody("9999"), seen), now: c.now });
+  assert.equal(v2, 2500, "second call inside the TTL never hits the network");
+  assert.equal(seen.n, 1);
+});
+
+test("non-200 keeps the last good price instead of blanking USD (poisoning guard)", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), now: c.now }), 2500);
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  const v = await ethUsd({
+    fetchFn: mockFetch(new Response("rate limited", { status: 429 }), seen),
+    now: c.now,
+  });
+  assert.equal(v, 2500, "429 must not overwrite the good price with null");
+  assert.equal(seen.n, 2);
+});
+
+test("200 with an unusable body keeps the last good price", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), now: c.now }), 2500);
+  for (const bad of [
+    new Response("{}", { status: 200 }),
+    new Response("<html>error</html>", { status: 200, headers: { "content-type": "text/html" } }),
+    new Response(JSON.stringify({ data: { amount: "nope" } }), { status: 200 }),
+    new Response(JSON.stringify({ data: { amount: "-1" } }), { status: 200 }),
+  ]) {
+    c.advance(ETH_PRICE_TTL_MS + 1);
+    const v = await ethUsd({ fetchFn: mockFetch(bad, seen), now: c.now });
+    assert.equal(v, 2500, `bad shape must preserve stale, got ${v}`);
+  }
+});
+
+test("network throw keeps stale; cold failure is null (UI shows ETH only)", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const boom = async () => {
+    throw new Error("dns down");
+  };
+  assert.equal(await ethUsd({ fetchFn: boom, now: c.now }), null);
+  resetEthPriceCache();
+  const seen = { n: 0 };
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), now: c.now }), 2500);
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  assert.equal(await ethUsd({ fetchFn: boom, now: c.now }), 2500);
+});
+
+test("failures back off for one TTL and the request carries a timeout", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen: { n: number; signal?: unknown } = { n: 0 };
+  assert.equal(
+    await ethUsd({
+      fetchFn: mockFetch(new Response("x", { status: 500 }), seen),
+      now: c.now,
+    }),
+    null,
+  );
+  assert.equal(seen.n, 1);
+  assert.ok(seen.signal instanceof AbortSignal, "fetch runs under AbortSignal.timeout");
+  assert.equal(
+    await ethUsd({
+      fetchFn: mockFetch(okBody("2500"), seen),
+      now: c.now,
+    }),
+    null,
+    "failure advances the timestamp: no retry until the TTL lapses",
+  );
+  assert.equal(seen.n, 1);
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  assert.equal(
+    await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), now: c.now }),
+    2500,
+    "recovers on the next attempt after the TTL",
+  );
+  assert.equal(ETH_FETCH_TIMEOUT_MS, 5_000);
+});

--- a/app/src/lib/launchpad/ethPrice.ts
+++ b/app/src/lib/launchpad/ethPrice.ts
@@ -1,17 +1,61 @@
 import "server-only";
 
-/** ETH/USD spot, 60s memo, null when unavailable (UI then shows ETH only). */
+/**
+ * ETH/USD spot, 60s memo, null when unavailable (UI then shows ETH only).
+ *
+ * Stale-while-revalidate with a poisoning guard: a non-200 response, a body
+ * without a usable amount, or a thrown fetch/parse error keeps the last good
+ * price instead of overwriting it with null. Before this guard a single
+ * Coinbase 429 (or an HTML error page that parses to `{}`) blanked every USD
+ * figure on the site — layout, home, token pages, list/live/search/me APIs
+ * and the GITLAWB USD derivation — for a full TTL. Failures still advance
+ * the timestamp so a down upstream is retried at most once per TTL instead
+ * of on every request.
+ */
+export const ETH_SPOT_URL = "https://api.coinbase.com/v2/prices/ETH-USD/spot";
+export const ETH_PRICE_TTL_MS = 60_000;
+export const ETH_FETCH_TIMEOUT_MS = 5_000;
+
 let cached: { at: number; usd: number | null } = { at: 0, usd: null };
 
-export async function ethUsd(): Promise<number | null> {
-  if (Date.now() - cached.at < 60_000) return cached.usd;
+/** Test-only: drop the memo so each case starts cold. */
+export function resetEthPriceCache(): void {
+  cached = { at: 0, usd: null };
+}
+
+/** Pull a positive finite USD number out of a Coinbase spot body; null when unusable. */
+export function parseEthSpot(body: unknown): number | null {
+  if (typeof body !== "object" || body === null) return null;
+  const amount = (body as { data?: { amount?: unknown } }).data?.amount;
+  if (typeof amount !== "string") return null;
+  const v = Number(amount);
+  return Number.isFinite(v) && v > 0 ? v : null;
+}
+
+type FetchFn = (
+  input: string,
+  init?: RequestInit & { next?: { revalidate: number } },
+) => Promise<Response>;
+
+export async function ethUsd(
+  opts: { fetchFn?: FetchFn; now?: () => number } = {},
+): Promise<number | null> {
+  const now = opts.now ?? Date.now;
+  if (now() - cached.at < ETH_PRICE_TTL_MS) return cached.usd;
+  const fetchFn: FetchFn = opts.fetchFn ?? ((input, init) => fetch(input, init as RequestInit));
   try {
-    const res = await fetch("https://api.coinbase.com/v2/prices/ETH-USD/spot", { next: { revalidate: 60 } });
-    const j = (await res.json()) as { data?: { amount?: string } };
-    const v = Number(j.data?.amount);
-    cached = { at: Date.now(), usd: Number.isFinite(v) && v > 0 ? v : null };
+    const res = await fetchFn(ETH_SPOT_URL, {
+      next: { revalidate: 60 },
+      signal: AbortSignal.timeout(ETH_FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      cached = { at: now(), usd: cached.usd };
+      return cached.usd;
+    }
+    const v = parseEthSpot(await res.json());
+    cached = { at: now(), usd: v ?? cached.usd };
   } catch {
-    cached = { at: Date.now(), usd: cached.usd };
+    cached = { at: now(), usd: cached.usd };
   }
   return cached.usd;
 }


### PR DESCRIPTION
## Why

`ethUsd()` (`app/src/lib/launchpad/ethPrice.ts`) overwrote its 60s memo with `null` on any non-200 response or unparsable body — only a thrown exception preserved the previous value. A single Coinbase 429 / HTML error page therefore blanked every USD figure on the site for a full TTL: layout, home, token pages, list/live/search/me APIs, and the GITLAWB USD derivation (which awaits `ethUsd()` inside `Promise.all`). It also issued the fetch with no timeout, so one hung upstream held every hot read. Verified by reading `ethPrice.ts` on `upstream/main` at 092f9bb.

## What

- `res.ok` guard: non-200 keeps the last good price (still advances the memo timestamp → at most one retry per TTL).
- `parseEthSpot()` extracted as a pure, unit-tested helper: only a string `data.amount` that parses to a positive finite number is accepted.
- 200-with-bad-shape and fetch/parse throws keep stale instead of publishing `null`; cold-process failure still returns `null` (UI shows ETH only).
- 5s `AbortSignal.timeout` on the Coinbase read.
- `ethUsd({ fetchFn, now })` stays optional/backwards-compatible — all existing callers unchanged. `resetEthPriceCache()` is test-only.
- New `app/src/lib/launchpad/ethPrice.test.ts`: parser edge cases, TTL memoization, 429/500 guard, bad-shape guard (empty JSON, HTML, non-numeric, negative), throw-keeps-stale vs cold-null, backoff + timeout-signal assertions.

No new dependencies. Public API unchanged.

## Verified (real, local)

- `npm run lint` — clean
- `npx tsc --noEmit -p .` — clean
- `npm test` — 296 pass, 0 fail (290 baseline + 6 new)
- `npm run build` — succeeds, all routes emitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ETH price retrieval reliability with request timeouts and better handling of unsuccessful, malformed, or unavailable responses.
  - Preserved the most recent valid ETH price when temporary service or network issues occur, preventing unnecessary blank values.
  - Added cache revalidation and failure backoff behavior to reduce repeated requests while allowing prices to recover after service interruptions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->