### PR TITLE
eth price: Chainlink ETH/USD on Base as the second source, and a 15-minute bound on the stale value

### DIFF
--- a/app/src/lib/launchpad/ethPrice.test.ts
+++ b/app/src/lib/launchpad/ethPrice.test.ts
@@ -202,3 +202,34 @@ test("cold start with both sources down is null, and a thrown feed read is treat
   c.advance(ETH_PRICE_TTL_MS + 1);
   assert.equal(await ethUsd({ fetchFn: boom, feedFn: async () => null, now: c.now }), null, "a null round is not a price either");
 });
+
+test("the memo never extends a stale value past the bound (CodeRabbit, PR #25)", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  const down = mockFetch(new Response("x", { status: 503 }), seen);
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), feedFn: feedDown, now: c.now }), 2500);
+  c.advance(ETH_STALE_MAX_MS - 1);
+  assert.equal(await ethUsd({ fetchFn: down, feedFn: feedDown, now: c.now }), 2500, "one ms inside the bound: the stale value is served");
+  c.advance(2); // now one ms past the bound, still well inside the 60s memo
+  assert.equal(await ethUsd({ fetchFn: down, feedFn: feedDown, now: c.now }), null, "the TTL memo does not carry a stale value past the bound");
+  assert.equal(seen.n, 3, "the bound forced a refresh attempt inside the TTL");
+  assert.equal(await ethUsd({ fetchFn: down, feedFn: feedDown, now: c.now }), null);
+  assert.equal(seen.n, 3, "once null, the memo applies again until the TTL lapses");
+});
+
+test("concurrent callers share one refresh, so an earlier slow attempt cannot overwrite a newer result (CodeRabbit, PR #25)", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  let release: (r: Response) => void = () => {};
+  const slow = async () => { seen.n += 1; return new Promise<Response>((res) => { release = res; }); };
+  const first = ethUsd({ fetchFn: slow, feedFn: feedDown, now: c.now });
+  const second = ethUsd({ fetchFn: mockFetch(okBody("9999"), seen), feedFn: feedDown, now: c.now });
+  release(okBody("2500"));
+  assert.deepEqual(await Promise.all([first, second]), [2500, 2500], "the second caller joined the first refresh instead of starting its own");
+  assert.equal(seen.n, 1, "one network call for two concurrent callers");
+  assert.equal(ethPriceSource(), "coinbase");
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2600"), seen), feedFn: feedDown, now: c.now }), 2600, "after the TTL a new refresh runs");
+});

--- a/app/src/lib/launchpad/ethPrice.test.ts
+++ b/app/src/lib/launchpad/ethPrice.test.ts
@@ -1,15 +1,23 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  ETH_FEED_MAX_AGE_S,
   ETH_FETCH_TIMEOUT_MS,
   ETH_PRICE_TTL_MS,
   ETH_SPOT_URL,
+  ETH_STALE_MAX_MS,
+  ethPriceSource,
   ethUsd,
+  feedEthUsd,
   parseEthSpot,
   resetEthPriceCache,
 } from "./ethPrice.ts";
 
 const okBody = (amount: string) => new Response(JSON.stringify({ data: { amount } }), { status: 200 });
+/** Chainlink down: the tests below that predate the fallback assume only Coinbase exists. */
+const feedDown = async () => { throw new Error("rpc down"); };
+/** A Chainlink round `ageS` old at clock time `nowMs`, priced in 8 decimals. */
+const round = (usd: number, nowMs: number, ageS = 60) => ({ answer: BigInt(Math.round(usd * 1e8)), updatedAt: Math.floor(nowMs / 1000) - ageS });
 
 function clock(start = 1_000_000) {
   let t = start;
@@ -48,7 +56,7 @@ test("cold fetch publishes the price and memoizes within the TTL", async () => {
   const v1 = await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), now: c.now });
   assert.equal(v1, 2500);
   assert.equal(seen.url, ETH_SPOT_URL);
-  const v2 = await ethUsd({ fetchFn: mockFetch(okBody("9999"), seen), now: c.now });
+  const v2 = await ethUsd({ fetchFn: mockFetch(okBody("9999"), seen), feedFn: feedDown, now: c.now });
   assert.equal(v2, 2500, "second call inside the TTL never hits the network");
   assert.equal(seen.n, 1);
 });
@@ -61,6 +69,7 @@ test("non-200 keeps the last good price instead of blanking USD (poisoning guard
   c.advance(ETH_PRICE_TTL_MS + 1);
   const v = await ethUsd({
     fetchFn: mockFetch(new Response("rate limited", { status: 429 }), seen),
+    feedFn: feedDown,
     now: c.now,
   });
   assert.equal(v, 2500, "429 must not overwrite the good price with null");
@@ -79,7 +88,7 @@ test("200 with an unusable body keeps the last good price", async () => {
     new Response(JSON.stringify({ data: { amount: "-1" } }), { status: 200 }),
   ]) {
     c.advance(ETH_PRICE_TTL_MS + 1);
-    const v = await ethUsd({ fetchFn: mockFetch(bad, seen), now: c.now });
+    const v = await ethUsd({ fetchFn: mockFetch(bad, seen), feedFn: feedDown, now: c.now });
     assert.equal(v, 2500, `bad shape must preserve stale, got ${v}`);
   }
 });
@@ -90,12 +99,12 @@ test("network throw keeps stale; cold failure is null (UI shows ETH only)", asyn
   const boom = async () => {
     throw new Error("dns down");
   };
-  assert.equal(await ethUsd({ fetchFn: boom, now: c.now }), null);
+  assert.equal(await ethUsd({ fetchFn: boom, feedFn: feedDown, now: c.now }), null);
   resetEthPriceCache();
   const seen = { n: 0 };
   assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), now: c.now }), 2500);
   c.advance(ETH_PRICE_TTL_MS + 1);
-  assert.equal(await ethUsd({ fetchFn: boom, now: c.now }), 2500);
+  assert.equal(await ethUsd({ fetchFn: boom, feedFn: feedDown, now: c.now }), 2500);
 });
 
 test("failures back off for one TTL and the request carries a timeout", async () => {
@@ -105,6 +114,7 @@ test("failures back off for one TTL and the request carries a timeout", async ()
   assert.equal(
     await ethUsd({
       fetchFn: mockFetch(new Response("x", { status: 500 }), seen),
+      feedFn: feedDown,
       now: c.now,
     }),
     null,
@@ -127,4 +137,68 @@ test("failures back off for one TTL and the request carries a timeout", async ()
     "recovers on the next attempt after the TTL",
   );
   assert.equal(ETH_FETCH_TIMEOUT_MS, 5_000);
+});
+
+test("feedEthUsd: a positive round under the max age is a price; older, zero or negative is not", () => {
+  const nowS = 1_700_000_000;
+  assert.equal(feedEthUsd({ answer: 244134000000n, updatedAt: nowS - 488 }, nowS), 2441.34, "the round seen on-chain when the feed address was verified");
+  assert.equal(feedEthUsd({ answer: 244134000000n, updatedAt: nowS - ETH_FEED_MAX_AGE_S }, nowS), 2441.34, "exactly the max age still counts");
+  assert.equal(feedEthUsd({ answer: 244134000000n, updatedAt: nowS - ETH_FEED_MAX_AGE_S - 1 }, nowS), null, "one second past it does not");
+  assert.equal(feedEthUsd({ answer: 0n, updatedAt: nowS }, nowS), null);
+  assert.equal(feedEthUsd({ answer: -1n, updatedAt: nowS }, nowS), null);
+  assert.equal(feedEthUsd({ answer: 244134000000n, updatedAt: 0 }, nowS), null, "no update timestamp");
+  assert.equal(feedEthUsd(null, nowS), null);
+});
+
+test("Coinbase down, Chainlink up: the feed price is served and counts as fresh", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), feedFn: feedDown, now: c.now }), 2500);
+  assert.equal(ethPriceSource(), "coinbase");
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  const v = await ethUsd({ fetchFn: mockFetch(new Response("rate limited", { status: 429 }), seen), feedFn: async () => round(2441.34, c.now()), now: c.now });
+  assert.equal(v, 2441.34, "a live feed beats the stale Coinbase value");
+  assert.equal(ethPriceSource(), "chainlink");
+  // the feed value is a confirmed price: a long double outage afterwards is measured from it, not from the last Coinbase success
+  c.advance(ETH_STALE_MAX_MS - 1);
+  assert.equal(await ethUsd({ fetchFn: mockFetch(new Response("x", { status: 500 }), seen), feedFn: feedDown, now: c.now }), 2441.34);
+});
+
+test("Coinbase unusable body, Chainlink up: Chainlink wins over the stale value; a stale feed round does not", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), feedFn: feedDown, now: c.now }), 2500);
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  assert.equal(await ethUsd({ fetchFn: mockFetch(new Response("{}", { status: 200 }), seen), feedFn: async () => round(2440, c.now()), now: c.now }), 2440);
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  assert.equal(await ethUsd({ fetchFn: mockFetch(new Response("{}", { status: 200 }), seen), feedFn: async () => round(1000, c.now(), ETH_FEED_MAX_AGE_S + 1), now: c.now }), 2440, "a round past the max age is ignored; the last good value is served");
+  assert.equal(ethPriceSource(), "chainlink");
+});
+
+test("both sources down: the last good value for at most ETH_STALE_MAX_MS, then null, then recovery", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const seen = { n: 0 };
+  const down = mockFetch(new Response("x", { status: 503 }), seen);
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2500"), seen), feedFn: feedDown, now: c.now }), 2500);
+  c.advance(14 * 60_000);
+  assert.equal(await ethUsd({ fetchFn: down, feedFn: feedDown, now: c.now }), 2500, "14 minutes stale still serves");
+  c.advance(ETH_PRICE_TTL_MS + 1); // ~15m01s after the last good value
+  assert.equal(await ethUsd({ fetchFn: down, feedFn: feedDown, now: c.now }), null, "past the bound the honest answer is unknown");
+  assert.equal(ethPriceSource(), null);
+  assert.equal(await ethUsd({ fetchFn: mockFetch(okBody("2600"), seen), feedFn: feedDown, now: c.now }), null, "still inside the retry TTL: no new attempt yet");
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  assert.equal(await ethUsd({ fetchFn: down, feedFn: async () => round(2450, c.now()), now: c.now }), 2450, "recovers from either source on the next attempt");
+  assert.equal(ETH_STALE_MAX_MS, 15 * 60_000);
+});
+
+test("cold start with both sources down is null, and a thrown feed read is treated like a failed one", async () => {
+  resetEthPriceCache();
+  const c = clock();
+  const boom = async () => { throw new Error("dns down"); };
+  assert.equal(await ethUsd({ fetchFn: boom, feedFn: feedDown, now: c.now }), null);
+  c.advance(ETH_PRICE_TTL_MS + 1);
+  assert.equal(await ethUsd({ fetchFn: boom, feedFn: async () => null, now: c.now }), null, "a null round is not a price either");
 });

--- a/app/src/lib/launchpad/ethPrice.ts
+++ b/app/src/lib/launchpad/ethPrice.ts
@@ -31,10 +31,13 @@ export const ETH_STALE_MAX_MS = 15 * 60_000;
 export type EthPriceSource = "coinbase" | "chainlink";
 type Cache = { at: number; goodAt: number; usd: number | null; source: EthPriceSource | null };
 let cached: Cache = { at: 0, goodAt: 0, usd: null, source: null };
+/** One refresh at a time: concurrent callers share it, so a slow earlier attempt can never overwrite a newer result. */
+let inflight: Promise<number | null> | null = null;
 
 /** Test-only: drop the memo so each case starts cold. */
 export function resetEthPriceCache(): void {
   cached = { at: 0, goodAt: 0, usd: null, source: null };
+  inflight = null;
 }
 
 /** Test-only: which source the current value came from (null when none). */
@@ -98,10 +101,16 @@ export async function ethUsd(
 ): Promise<number | null> {
   const now = opts.now ?? Date.now;
   const t = now();
-  if (t - cached.at < ETH_PRICE_TTL_MS) return cached.usd;
+  // the memo never extends a stale value past its bound: once over it, refresh regardless of the TTL
+  const staleExpired = cached.usd !== null && t - cached.goodAt > ETH_STALE_MAX_MS;
+  if (t - cached.at < ETH_PRICE_TTL_MS && !staleExpired) return cached.usd;
   const fetchFn: FetchFn = opts.fetchFn ?? ((input, init) => fetch(input, init as RequestInit));
   const feedFn: FeedFn = opts.feedFn ?? readFeed;
+  inflight ??= refresh(fetchFn, feedFn, t).finally(() => { inflight = null; });
+  return inflight;
+}
 
+async function refresh(fetchFn: FetchFn, feedFn: FeedFn, t: number): Promise<number | null> {
   let source: EthPriceSource = "coinbase";
   let usd = await fromCoinbase(fetchFn);
   if (usd === null) {

--- a/app/src/lib/launchpad/ethPrice.ts
+++ b/app/src/lib/launchpad/ethPrice.ts
@@ -1,26 +1,45 @@
 import "server-only";
+import { publicClient } from "@/lib/chain";
+import { feedUsd } from "./baseStocks";
 
 /**
  * ETH/USD spot, 60s memo, null when unavailable (UI then shows ETH only).
  *
- * Stale-while-revalidate with a poisoning guard: a non-200 response, a body
- * without a usable amount, or a thrown fetch/parse error keeps the last good
- * price instead of overwriting it with null. Before this guard a single
- * Coinbase 429 (or an HTML error page that parses to `{}`) blanked every USD
- * figure on the site — layout, home, token pages, list/live/search/me APIs
- * and the GITLAWB USD derivation — for a full TTL. Failures still advance
- * the timestamp so a down upstream is retried at most once per TTL instead
- * of on every request.
+ * Order of preference on every refresh:
+ *   1. Coinbase spot (what people compare against on exchanges and screeners);
+ *   2. the Chainlink ETH/USD feed on Base, when its round is under ETH_FEED_MAX_AGE_S old (it updates on a 0.15%
+ *      move or every 20 minutes, so a normal answer can be that old; it fails independently of Coinbase);
+ *   3. the last good value, for at most ETH_STALE_MAX_MS after it was confirmed;
+ *   4. null.
+ * A non-200, an unusable body, or a thrown fetch/parse error therefore never blanks USD on its own (before the
+ * guard a single Coinbase 429 blanked every USD figure on the site for a TTL), and a long double outage never leaves
+ * a day-old dollar figure on every page either: past the bound the honest answer is "unknown". Failures still advance
+ * the attempt timestamp, so a dead upstream is retried once per TTL, not on every request.
+ * Display and sorting only: nothing on-chain reads any of this.
  */
 export const ETH_SPOT_URL = "https://api.coinbase.com/v2/prices/ETH-USD/spot";
 export const ETH_PRICE_TTL_MS = 60_000;
 export const ETH_FETCH_TIMEOUT_MS = 5_000;
+/** Chainlink ETH / USD on Base. Verified on-chain 2026-09-11: description() = "ETH / USD", decimals() = 8. */
+export const ETH_USD_FEED_BASE = "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70" as const;
+export const ETH_FEED_DECIMALS = 8;
+/** An ETH feed round older than this is not a price (the stock feeds allow days because equities close; ETH does not). */
+export const ETH_FEED_MAX_AGE_S = 30 * 60;
+/** How long the last good value is served once both live sources fail. */
+export const ETH_STALE_MAX_MS = 15 * 60_000;
 
-let cached: { at: number; usd: number | null } = { at: 0, usd: null };
+export type EthPriceSource = "coinbase" | "chainlink";
+type Cache = { at: number; goodAt: number; usd: number | null; source: EthPriceSource | null };
+let cached: Cache = { at: 0, goodAt: 0, usd: null, source: null };
 
 /** Test-only: drop the memo so each case starts cold. */
 export function resetEthPriceCache(): void {
-  cached = { at: 0, usd: null };
+  cached = { at: 0, goodAt: 0, usd: null, source: null };
+}
+
+/** Test-only: which source the current value came from (null when none). */
+export function ethPriceSource(): EthPriceSource | null {
+  return cached.source;
 }
 
 /** Pull a positive finite USD number out of a Coinbase spot body; null when unusable. */
@@ -32,30 +51,71 @@ export function parseEthSpot(body: unknown): number | null {
   return Number.isFinite(v) && v > 0 ? v : null;
 }
 
+export type FeedRound = { answer: bigint; updatedAt: number };
+
+/** USD from a Chainlink ETH/USD round: positive answer, updated within ETH_FEED_MAX_AGE_S of `nowS`; else null. */
+export function feedEthUsd(round: FeedRound | null, nowS: number): number | null {
+  return feedUsd(round, nowS, ETH_FEED_DECIMALS, ETH_FEED_MAX_AGE_S);
+}
+
+const AGGREGATOR_ABI = [
+  { type: "function", name: "latestRoundData", stateMutability: "view", inputs: [], outputs: [{ type: "uint80" }, { type: "int256" }, { type: "uint256" }, { type: "uint256" }, { type: "uint80" }] },
+] as const;
+
+/** The live Chainlink read, under the same timeout as the Coinbase call. */
+async function readFeed(): Promise<FeedRound | null> {
+  const timeout = new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`feed timeout after ${ETH_FETCH_TIMEOUT_MS}ms`)), ETH_FETCH_TIMEOUT_MS).unref?.());
+  const r = await Promise.race([publicClient("base").readContract({ address: ETH_USD_FEED_BASE, abi: AGGREGATOR_ABI, functionName: "latestRoundData" }), timeout]);
+  return { answer: r[1], updatedAt: Number(r[3]) };
+}
+
 type FetchFn = (
   input: string,
   init?: RequestInit & { next?: { revalidate: number } },
 ) => Promise<Response>;
+type FeedFn = () => Promise<FeedRound | null>;
+
+async function fromCoinbase(fetchFn: FetchFn): Promise<number | null> {
+  try {
+    const res = await fetchFn(ETH_SPOT_URL, { next: { revalidate: 60 }, signal: AbortSignal.timeout(ETH_FETCH_TIMEOUT_MS) });
+    if (!res.ok) return null;
+    return parseEthSpot(await res.json());
+  } catch {
+    return null;
+  }
+}
+
+async function fromChainlink(feedFn: FeedFn, nowMs: number): Promise<number | null> {
+  try {
+    return feedEthUsd(await feedFn(), Math.floor(nowMs / 1000));
+  } catch {
+    return null;
+  }
+}
 
 export async function ethUsd(
-  opts: { fetchFn?: FetchFn; now?: () => number } = {},
+  opts: { fetchFn?: FetchFn; feedFn?: FeedFn; now?: () => number } = {},
 ): Promise<number | null> {
   const now = opts.now ?? Date.now;
-  if (now() - cached.at < ETH_PRICE_TTL_MS) return cached.usd;
+  const t = now();
+  if (t - cached.at < ETH_PRICE_TTL_MS) return cached.usd;
   const fetchFn: FetchFn = opts.fetchFn ?? ((input, init) => fetch(input, init as RequestInit));
-  try {
-    const res = await fetchFn(ETH_SPOT_URL, {
-      next: { revalidate: 60 },
-      signal: AbortSignal.timeout(ETH_FETCH_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      cached = { at: now(), usd: cached.usd };
-      return cached.usd;
-    }
-    const v = parseEthSpot(await res.json());
-    cached = { at: now(), usd: v ?? cached.usd };
-  } catch {
-    cached = { at: now(), usd: cached.usd };
+  const feedFn: FeedFn = opts.feedFn ?? readFeed;
+
+  let source: EthPriceSource = "coinbase";
+  let usd = await fromCoinbase(fetchFn);
+  if (usd === null) {
+    source = "chainlink";
+    usd = await fromChainlink(feedFn, t);
   }
+  if (usd !== null) {
+    if (source !== cached.source && cached.source !== null) console.warn(`[eth-price] serving ${source} (${source === "chainlink" ? "Coinbase spot unavailable" : "Coinbase spot back"})`);
+    cached = { at: t, goodAt: t, usd, source };
+    return usd;
+  }
+  // both live sources failed: the last good value for a bounded time, then null
+  const stale = cached.usd !== null && t - cached.goodAt <= ETH_STALE_MAX_MS;
+  if (!stale && cached.usd !== null) console.warn(`[eth-price] Coinbase and Chainlink both unavailable for over ${ETH_STALE_MAX_MS / 60_000} minutes: USD figures off until one recovers`);
+  cached = { at: t, goodAt: cached.goodAt, usd: stale ? cached.usd : null, source: stale ? cached.source : null };
   return cached.usd;
 }


### PR DESCRIPTION
#23 made a bad Coinbase response keep the last good price instead of blanking USD, which was right, but with no upper bound a long outage left an old dollar figure on every page and every dollar-based sort, silently. Order on each refresh is now: fresh Coinbase spot; else the Chainlink ETH/USD feed on Base when its round is under 30 minutes old (it fails independently of Coinbase and updates on a 0.15% move or every 20 minutes); else the last good value for at most 15 minutes after it was confirmed; else null, which the UI already renders as ETH-only figures.

The feed address was verified on-chain before use: description() "ETH / USD", decimals() 8, and a live round within a few dollars of Coinbase. The read reuses the stock feeds' aggregator ABI and round-to-USD helper with a 30-minute max age instead of the equities' five days, under the same 5s timeout as the Coinbase call, and is injectable for tests like the fetch already was. One warning is logged when the source switches and one when both are down past the bound.

Tests: the existing six pin Chainlink down so they still describe Coinbase alone; new cases cover the feed conversion boundaries, Coinbase down with Chainlink up, an unusable Coinbase body with a live or a stale feed round, the 14/15-minute bound with recovery from either source, and a cold double outage. Display and sorting only: nothing on-chain reads these prices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - ETH pricing now falls back to an alternate market data source when the primary source is unavailable.
  - Prices are validated for freshness, positivity, and validity before use.
  - Recently verified prices may continue briefly during temporary outages, within defined limits.
  - Pricing recovers automatically when a reliable source becomes available again.
  - The active pricing source is tracked for improved transparency and reliability.
  - Concurrent requests now share refresh activity for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->