### PR TITLE
fix(app): reject non-finite usd in amountForUsd

### DIFF
--- a/app/src/lib/launchpad/first-buy.test.ts
+++ b/app/src/lib/launchpad/first-buy.test.ts
@@ -30,6 +30,10 @@ test("amountForUsd: short decimals parseUnits accepts, never more places than th
   assert.equal(amountForUsd(25, 1e12, 2), null, "rounds to nothing at 2 decimals");
   assert.equal(amountForUsd(0, 1, 6), null);
   assert.equal(amountForUsd(25, 0, 6), null);
+  assert.equal(amountForUsd(Infinity, 1, 18), null, "non-finite usd never becomes \"Infinity\" for parseUnits");
+  assert.equal(amountForUsd(NaN, 1, 18), null);
+  assert.equal(amountForUsd(25, Infinity, 18), null);
+  assert.equal(amountForUsd(25, NaN, 18), null);
   for (const [usd, dec] of [[2464.485, 18], [223.05, 18], [0.0000195, 18], [1, 6]] as const) {
     const a = amountForUsd(25, usd, dec)!;
     assert.ok(parseUnits(a, dec) > 0n, `parseUnits accepts ${a}`);

--- a/app/src/lib/launchpad/first-buy.ts
+++ b/app/src/lib/launchpad/first-buy.ts
@@ -28,7 +28,7 @@ function trimZeros(s: string): string {
 
 /** `usd` worth of a quote priced at `quoteUsd`, as a short decimal string that parseUnits accepts; null when it rounds to nothing. */
 export function amountForUsd(usd: number, quoteUsd: number, decimals: number): string | null {
-  if (!(usd > 0) || !(quoteUsd > 0) || !Number.isFinite(quoteUsd)) return null;
+  if (!(usd > 0) || !(quoteUsd > 0) || !Number.isFinite(usd) || !Number.isFinite(quoteUsd)) return null;
   const v = usd / quoteUsd;
   let s = v >= 1 ? v.toFixed(2) : v.toPrecision(2);
   if (/e/i.test(s)) s = v.toFixed(Math.min(decimals, 12));


### PR DESCRIPTION
amountForUsd(Infinity, 1, 18) returned the literal string "Infinity", which viem parseUnits rejects downstream in suggestFirstBuy.

Before: \`if (!(usd > 0) || !(quoteUsd > 0) || !Number.isFinite(quoteUsd))\` — Infinity passes \`usd > 0\`, divides to Infinity, toFixed(2) is "Infinity", trimZeros is a no-op, places=0 passes, returns "Infinity".

After: also require \`Number.isFinite(usd)\`, matching the quoteUsd guard. Adds regression coverage for Infinity/NaN on both inputs.

Verified locally on upstream/main base:
- npm run lint: pass
- npx tsc --noEmit -p .: pass
- full unit suite: 323 pass, 0 fail
- npm run build: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid purchase amount inputs.
  - Non-finite values such as `Infinity` and `NaN` are now safely rejected instead of causing invalid amount conversion errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->