### PR TITLE
perf(posts): memoised replies, paginated comments, persistent drafts

### DIFF
--- a/app/src/components/launchpad/Posts.tsx
+++ b/app/src/components/launchpad/Posts.tsx
@@ -54,10 +54,11 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
   const [now, setNow] = useState(0);
   const [shownCount, setShownCount] = useState(COMMENTS_PAGE);
   // Draft restores async after hydration so server and client render the same empty composer first.
+  // The loaded value is always assigned (even when empty) so text typed for one
+  // token can never leak into — and be submitted from — another token's composer.
   useEffect(() => {
     const t = setTimeout(() => {
-      const d = loadDraft(chain, token);
-      if (d) setBody(d.slice(0, POST_MAX));
+      setBody(loadDraft(chain, token).slice(0, POST_MAX));
       setShownCount(COMMENTS_PAGE);
     }, 0);
     return () => clearTimeout(t);

--- a/app/src/components/launchpad/Posts.tsx
+++ b/app/src/components/launchpad/Posts.tsx
@@ -10,7 +10,7 @@ import { useLive } from "./LiveProvider";
 import { toast } from "./TxToasts";
 import { btn } from "@/components/ui";
 import { buildModMessage, buildPostMessage, buildReportMessage, POST_MAX, REPORT_REASONS, validateBody, type ReportReason } from "@/lib/launchpad/posts";
-import { COMMENTS_PAGE, clearDraft, groupReplies, loadDraft, saveDraft, visibleTopIds } from "@/lib/launchpad/post-threads";
+import { COMMENTS_PAGE, clearDraft, groupReplies, loadCommentDraft, saveDraft, visibleTopIds } from "@/lib/launchpad/post-threads";
 import type { PostRow } from "@/lib/launchpad/postsServer";
 import { ago, nowMs } from "@/lib/launchpad/time";
 import { CHAINS, CHAIN_SHORT, shortAddr, type ChainKey } from "@/lib/chainPublic";
@@ -56,9 +56,13 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
   // Draft restores async after hydration so server and client render the same empty composer first.
   // The loaded value is always assigned (even when empty) so text typed for one
   // token can never leak into — and be submitted from — another token's composer.
+  // The reply destination restores with the body: otherwise a reload turns a
+  // reply draft into a top-level post (parentId: null).
   useEffect(() => {
     const t = setTimeout(() => {
-      setBody(loadDraft(chain, token).slice(0, POST_MAX));
+      const d = loadCommentDraft(chain, token);
+      setBody(d.body.slice(0, POST_MAX));
+      setReplyTo(d.parentId);
       setShownCount(COMMENTS_PAGE);
     }, 0);
     return () => clearTimeout(t);
@@ -97,6 +101,13 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
     [subscribe, chain, token, load],
   );
 
+  // A restored reply target may be gone (hidden, deleted, or another token's
+  // id). Derive the effective target during render so the draft posts
+  // top-level instead of 404ing — no set-state-in-effect, no flash of a stale
+  // "Replying to #". Before posts load we assume the target exists.
+  const replyMissing = replyTo !== null && posts.length > 0 && !posts.some((p) => p.id === replyTo);
+  const effectiveReplyTo = replyMissing ? null : replyTo;
+
   async function submit() {
     if (!address) return;
     const v = validateBody(body);
@@ -104,14 +115,16 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
       setErr(v.error);
       return;
     }
+    // Re-derive here: posts may have changed since the last render.
+    const target = replyTo !== null && posts.length > 0 && !posts.some((p) => p.id === replyTo) ? null : replyTo;
     setBusy(true);
     setErr(null);
     try {
       const n = nonce();
       const ts = nowMs();
-      const message = buildPostMessage({ chain, token, wallet: address, nonce: n, ts, parentId: replyTo, body: v.body });
+      const message = buildPostMessage({ chain, token, wallet: address, nonce: n, ts, parentId: target, body: v.body });
       const { signature } = await signed(config, chain, message);
-      const res = await fetch("/api/posts", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ chain, token, wallet: address, parentId: replyTo, body: v.body, nonce: n, ts, signature }) });
+      const res = await fetch("/api/posts", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ chain, token, wallet: address, parentId: target, body: v.body, nonce: n, ts, signature }) });
       const d = (await res.json()) as { ok?: boolean; post?: PostRow; error?: string };
       if (!res.ok || !d.post) throw new Error(d.error ?? "post rejected");
       setPosts((cur) => [d.post!, ...cur]);
@@ -186,12 +199,16 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
           </div>
         ) : (
           <div className="space-y-2">
-            {replyTo !== null ? (
+            {effectiveReplyTo !== null ? (
               <p className="text-[11px] text-muted">
-                Replying to #{replyTo}{" "}
-                <button type="button" className="underline hover:text-ink" onClick={() => setReplyTo(null)}>
+                Replying to #{effectiveReplyTo}{" "}
+                <button type="button" className="underline hover:text-ink" onClick={() => { setReplyTo(null); saveDraft(chain, token, body, null); }}>
                   cancel
                 </button>
+              </p>
+            ) : replyMissing ? (
+              <p className="text-[11px] text-muted" role="status">
+                The comment you were replying to is gone — posting as a top-level comment.
               </p>
             ) : null}
             <textarea
@@ -199,7 +216,7 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
               onChange={(e) => {
                 const next = e.target.value.slice(0, POST_MAX);
                 setBody(next);
-                saveDraft(chain, token, next);
+                saveDraft(chain, token, next, effectiveReplyTo);
               }}
               placeholder={`Say something about ${symbol}…`}
               aria-label={`Comment about ${symbol}`}
@@ -209,7 +226,7 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
             <div className="flex items-center justify-between gap-3">
               <span id={`comment-count-${chain}`} aria-live="polite" className="text-[11px] text-muted font-mono tnum">{POST_MAX - body.length}</span>
               <button type="button" onClick={() => void submit()} disabled={busy || !body.trim()} className={btn.primarySm}>
-                {busy ? "Sign in wallet…" : replyTo !== null ? "Reply" : "Post"}
+                {busy ? "Sign in wallet…" : effectiveReplyTo !== null ? "Reply" : "Post"}
               </button>
             </div>
             {err ? <p className="text-xs text-down-ink" role="alert">{err}</p> : null}
@@ -223,7 +240,7 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
           const thread = repliesById.get(p.id) ?? [];
           return (
           <li key={p.id} className="px-4 py-3">
-            <PostItem p={p} now={now} canReply={isConnected && !muted} onReply={() => setReplyTo(p.id)} onReport={address && p.wallet !== address.toLowerCase() ? (r) => void report(p, r) : undefined} />
+            <PostItem p={p} now={now} canReply={isConnected && !muted} onReply={() => { setReplyTo(p.id); saveDraft(chain, token, body, p.id); }} onReport={address && p.wallet !== address.toLowerCase() ? (r) => void report(p, r) : undefined} />
             {thread.length ? (
               <ul className="mt-2 ml-6 pl-3 border-l border-line space-y-2">
                 {thread.map((r) => (

--- a/app/src/components/launchpad/Posts.tsx
+++ b/app/src/components/launchpad/Posts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAccount, useConfig } from "wagmi";
 import { getWalletClient } from "wagmi/actions";
 import WalletAvatar from "@/components/WalletAvatar";
@@ -10,6 +10,7 @@ import { useLive } from "./LiveProvider";
 import { toast } from "./TxToasts";
 import { btn } from "@/components/ui";
 import { buildModMessage, buildPostMessage, buildReportMessage, POST_MAX, REPORT_REASONS, validateBody, type ReportReason } from "@/lib/launchpad/posts";
+import { COMMENTS_PAGE, clearDraft, groupReplies, loadDraft, saveDraft, visibleTopIds } from "@/lib/launchpad/post-threads";
 import type { PostRow } from "@/lib/launchpad/postsServer";
 import { ago, nowMs } from "@/lib/launchpad/time";
 import { CHAINS, CHAIN_SHORT, shortAddr, type ChainKey } from "@/lib/chainPublic";
@@ -51,6 +52,16 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [now, setNow] = useState(0);
+  const [shownCount, setShownCount] = useState(COMMENTS_PAGE);
+  // Draft restores async after hydration so server and client render the same empty composer first.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const d = loadDraft(chain, token);
+      if (d) setBody(d.slice(0, POST_MAX));
+      setShownCount(COMMENTS_PAGE);
+    }, 0);
+    return () => clearTimeout(t);
+  }, [chain, token]);
   const seenPosts = useRef<string>("");
   const isCreator = Boolean(address && address.toLowerCase() === launcher.toLowerCase());
 
@@ -104,6 +115,7 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
       if (!res.ok || !d.post) throw new Error(d.error ?? "post rejected");
       setPosts((cur) => [d.post!, ...cur]);
       setBody("");
+      clearDraft(chain, token);
       setReplyTo(null);
     } catch (e) {
       setErr(friendlyError(e));
@@ -145,8 +157,9 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
     }
   }
 
-  const top = posts.filter((p) => p.parent_id === null);
-  const replies = (id: number) => posts.filter((p) => p.parent_id === id).slice().reverse();
+  const { top, repliesById } = useMemo(() => groupReplies(posts), [posts]);
+  const visibleTop = useMemo(() => visibleTopIds(top, shownCount), [top, shownCount]);
+  const remaining = top.length - visibleTop.length;
 
   return (
     <section className={embedded ? "overflow-hidden bg-paper" : "rounded-2xl bg-card border border-line overflow-hidden"} id="comments">
@@ -182,29 +195,37 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
             ) : null}
             <textarea
               value={body}
-              onChange={(e) => setBody(e.target.value.slice(0, POST_MAX))}
+              onChange={(e) => {
+                const next = e.target.value.slice(0, POST_MAX);
+                setBody(next);
+                saveDraft(chain, token, next);
+              }}
               placeholder={`Say something about ${symbol}…`}
+              aria-label={`Comment about ${symbol}`}
+              aria-describedby={`comment-count-${chain}`}
               className="w-full rounded-xl bg-card border border-line-strong focus:border-brand focus:ring-4 focus:ring-brand/10 outline-none px-3 py-2 text-sm text-ink placeholder:text-faint min-h-16 resize-y"
             />
             <div className="flex items-center justify-between gap-3">
-              <span className="text-[11px] text-muted font-mono tnum">{POST_MAX - body.length}</span>
+              <span id={`comment-count-${chain}`} aria-live="polite" className="text-[11px] text-muted font-mono tnum">{POST_MAX - body.length}</span>
               <button type="button" onClick={() => void submit()} disabled={busy || !body.trim()} className={btn.primarySm}>
                 {busy ? "Sign in wallet…" : replyTo !== null ? "Reply" : "Post"}
               </button>
             </div>
-            {err ? <p className="text-xs text-down-ink">{err}</p> : null}
+            {err ? <p className="text-xs text-down-ink" role="alert">{err}</p> : null}
           </div>
         )}
       </div>
 
       <ul className="divide-y divide-line">
         {top.length === 0 ? <li className="px-4 py-8 text-center text-sm text-muted">No comments yet.</li> : null}
-        {top.map((p) => (
+        {visibleTop.map((p) => {
+          const thread = repliesById.get(p.id) ?? [];
+          return (
           <li key={p.id} className="px-4 py-3">
             <PostItem p={p} now={now} canReply={isConnected && !muted} onReply={() => setReplyTo(p.id)} onReport={address && p.wallet !== address.toLowerCase() ? (r) => void report(p, r) : undefined} />
-            {replies(p.id).length ? (
+            {thread.length ? (
               <ul className="mt-2 ml-6 pl-3 border-l border-line space-y-2">
-                {replies(p.id).map((r) => (
+                {thread.map((r) => (
                   <li key={r.id}>
                     <PostItem p={r} now={now} canReply={false} onReport={address && r.wallet !== address.toLowerCase() ? (x) => void report(r, x) : undefined} />
                   </li>
@@ -212,8 +233,22 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
               </ul>
             ) : null}
           </li>
-        ))}
+          );
+        })}
       </ul>
+      {remaining > 0 ? (
+        <div className="border-t border-line px-4 py-3 text-center">
+          <button
+            type="button"
+            onClick={() => setShownCount((n) => n + COMMENTS_PAGE)}
+            aria-label={`Show more comments, ${remaining} remaining`}
+            className="min-h-10 rounded-xl border border-line-strong px-4 text-sm font-medium text-ink hover:bg-card"
+          >
+            Show more comments ({visibleTop.length} of {top.length})
+          </button>
+          <p className="mt-1 text-[11px] text-muted" role="status">Showing {visibleTop.length} of {top.length} comments</p>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/app/src/components/launchpad/Posts.tsx
+++ b/app/src/components/launchpad/Posts.tsx
@@ -10,7 +10,7 @@ import { useLive } from "./LiveProvider";
 import { toast } from "./TxToasts";
 import { btn } from "@/components/ui";
 import { buildModMessage, buildPostMessage, buildReportMessage, POST_MAX, REPORT_REASONS, validateBody, type ReportReason } from "@/lib/launchpad/posts";
-import { COMMENTS_PAGE, clearDraft, groupReplies, loadCommentDraft, saveDraft, visibleTopIds } from "@/lib/launchpad/post-threads";
+import { COMMENTS_PAGE, clearDraft, groupReplies, loadCommentDraft, resolveReplyTarget, saveDraft, visibleTopIds } from "@/lib/launchpad/post-threads";
 import type { PostRow } from "@/lib/launchpad/postsServer";
 import { ago, nowMs } from "@/lib/launchpad/time";
 import { CHAINS, CHAIN_SHORT, shortAddr, type ChainKey } from "@/lib/chainPublic";
@@ -53,6 +53,11 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
   const [err, setErr] = useState<string | null>(null);
   const [now, setNow] = useState(0);
   const [shownCount, setShownCount] = useState(COMMENTS_PAGE);
+  // True once the first load() for the current chain/token has settled.
+  // A restored replyTo cannot be validated until then: posts starts empty, so
+  // an empty list must not read as "parent missing" before the fetch, nor as
+  // "parent exists" for signing. Submit of a restored reply blocks meanwhile.
+  const [postsLoaded, setPostsLoaded] = useState(false);
   // Draft restores async after hydration so server and client render the same empty composer first.
   // The loaded value is always assigned (even when empty) so text typed for one
   // token can never leak into — and be submitted from — another token's composer.
@@ -64,6 +69,9 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
       setBody(d.body.slice(0, POST_MAX));
       setReplyTo(d.parentId);
       setShownCount(COMMENTS_PAGE);
+      setPosts([]);
+      setPostsLoaded(false);
+      setErr(null);
     }, 0);
     return () => clearTimeout(t);
   }, [chain, token]);
@@ -80,6 +88,8 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
       setNow(nowMs());
     } catch {
       /* keep */
+    } finally {
+      setPostsLoaded(true);
     }
   }, [chain, token]);
 
@@ -102,11 +112,11 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
   );
 
   // A restored reply target may be gone (hidden, deleted, or another token's
-  // id). Derive the effective target during render so the draft posts
-  // top-level instead of 404ing — no set-state-in-effect, no flash of a stale
-  // "Replying to #". Before posts load we assume the target exists.
-  const replyMissing = replyTo !== null && posts.length > 0 && !posts.some((p) => p.id === replyTo);
-  const effectiveReplyTo = replyMissing ? null : replyTo;
+  // id). Resolve during render so the draft posts top-level instead of 404ing
+  // — no set-state-in-effect. Validation runs only after the first load
+  // settles, even when the loaded list is empty; before that a restored reply
+  // is pending and submit blocks instead of signing an unvalidated parent.
+  const { target: effectiveReplyTo, pending: validationPending, missing: replyMissing } = resolveReplyTarget(replyTo, posts, postsLoaded);
 
   async function submit() {
     if (!address) return;
@@ -115,8 +125,13 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
       setErr(v.error);
       return;
     }
-    // Re-derive here: posts may have changed since the last render.
-    const target = replyTo !== null && posts.length > 0 && !posts.some((p) => p.id === replyTo) ? null : replyTo;
+    // Re-resolve here: posts may have changed since the last render.
+    const resolved = resolveReplyTarget(replyTo, posts, postsLoaded);
+    if (resolved.pending) {
+      setErr("Loading comments — please try again in a moment.");
+      return;
+    }
+    const target = resolved.target;
     setBusy(true);
     setErr(null);
     try {
@@ -199,7 +214,11 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
           </div>
         ) : (
           <div className="space-y-2">
-            {effectiveReplyTo !== null ? (
+            {validationPending ? (
+              <p className="text-[11px] text-muted" role="status">
+                Checking reply target…
+              </p>
+            ) : effectiveReplyTo !== null ? (
               <p className="text-[11px] text-muted">
                 Replying to #{effectiveReplyTo}{" "}
                 <button type="button" className="underline hover:text-ink" onClick={() => { setReplyTo(null); saveDraft(chain, token, body, null); }}>
@@ -225,8 +244,8 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
             />
             <div className="flex items-center justify-between gap-3">
               <span id={`comment-count-${chain}`} aria-live="polite" className="text-[11px] text-muted font-mono tnum">{POST_MAX - body.length}</span>
-              <button type="button" onClick={() => void submit()} disabled={busy || !body.trim()} className={btn.primarySm}>
-                {busy ? "Sign in wallet…" : effectiveReplyTo !== null ? "Reply" : "Post"}
+              <button type="button" onClick={() => void submit()} disabled={busy || !body.trim() || validationPending} className={btn.primarySm}>
+                {busy ? "Sign in wallet…" : validationPending ? "Checking…" : effectiveReplyTo !== null ? "Reply" : "Post"}
               </button>
             </div>
             {err ? <p className="text-xs text-down-ink" role="alert">{err}</p> : null}

--- a/app/src/lib/launchpad/post-threads.test.ts
+++ b/app/src/lib/launchpad/post-threads.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { COMMENTS_PAGE, clearDraft, draftKey, groupReplies, loadDraft, saveDraft, visibleTopIds } from "./post-threads.ts";
+import { COMMENTS_PAGE, clearDraft, draftKey, groupReplies, loadCommentDraft, loadDraft, saveDraft, visibleTopIds } from "./post-threads.ts";
 import type { PostRow } from "./postsServer.ts";
 
 const post = (id: number, parent_id: number | null): PostRow => ({ id, chain: "base", token: "0xtoken", wallet: "0xwallet", parent_id, body: `body ${id}`, tag: null, created_at: "2026-01-01T00:00:00.000Z", reports: 0, hidden: false });
@@ -35,4 +35,54 @@ test("draft key is per token and lowercase; node loads empty and saves are no-op
   saveDraft("base", "0xabc", "hello");
   clearDraft("base", "0xabc");
   assert.equal(loadDraft("base", "0xabc"), "", "no localStorage in node: always empty, never throws");
+});
+
+function withMemoryStorage(): Map<string, string> {
+  const store = new Map<string, string>();
+  const g = globalThis as Record<string, unknown>;
+  g.localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  return store;
+}
+
+function withoutStorage(): void {
+  const g = globalThis as Record<string, unknown>;
+  delete g.localStorage;
+}
+
+test("draft restores both a top-level draft and a reply draft (PR #31)", () => {
+  const store = withMemoryStorage();
+  try {
+    saveDraft("base", "0xabc", "top-level hello");
+    assert.deepEqual(loadCommentDraft("base", "0xabc"), { body: "top-level hello", parentId: null });
+    assert.equal(loadDraft("base", "0xabc"), "top-level hello");
+
+    saveDraft("base", "0xabc", "reply hello", 42);
+    assert.deepEqual(loadCommentDraft("base", "0xabc"), { body: "reply hello", parentId: 42 });
+
+    clearDraft("base", "0xabc");
+    assert.deepEqual(loadCommentDraft("base", "0xabc"), { body: "", parentId: null });
+    assert.equal(store.size, 0);
+  } finally {
+    withoutStorage();
+  }
+});
+
+test("draft understands legacy plain-text drafts and rejects bad parent ids", () => {
+  const store = withMemoryStorage();
+  try {
+    store.set(draftKey("base", "0xabc"), "legacy hello");
+    assert.deepEqual(loadCommentDraft("base", "0xabc"), { body: "legacy hello", parentId: null });
+
+    store.set(draftKey("base", "0xabc"), JSON.stringify({ body: "x", parentId: -7 }));
+    assert.deepEqual(loadCommentDraft("base", "0xabc"), { body: "x", parentId: null });
+
+    store.set(draftKey("base", "0xabc"), JSON.stringify({ body: "x", parentId: "42" }));
+    assert.deepEqual(loadCommentDraft("base", "0xabc"), { body: "x", parentId: null });
+  } finally {
+    withoutStorage();
+  }
 });

--- a/app/src/lib/launchpad/post-threads.test.ts
+++ b/app/src/lib/launchpad/post-threads.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { COMMENTS_PAGE, clearDraft, draftKey, groupReplies, loadCommentDraft, loadDraft, saveDraft, visibleTopIds } from "./post-threads.ts";
+import { COMMENTS_PAGE, clearDraft, draftKey, groupReplies, loadCommentDraft, loadDraft, resolveReplyTarget, saveDraft, visibleTopIds } from "./post-threads.ts";
 import type { PostRow } from "./postsServer.ts";
 
 const post = (id: number, parent_id: number | null): PostRow => ({ id, chain: "base", token: "0xtoken", wallet: "0xwallet", parent_id, body: `body ${id}`, tag: null, created_at: "2026-01-01T00:00:00.000Z", reports: 0, hidden: false });
@@ -85,4 +85,13 @@ test("draft understands legacy plain-text drafts and rejects bad parent ids", ()
   } finally {
     withoutStorage();
   }
+});
+
+test("resolveReplyTarget blocks before first load and falls back on empty/missing parents (PR #31)", () => {
+  assert.deepEqual(resolveReplyTarget(null, [], false), { target: null, pending: false, missing: false }, "top-level never blocks");
+  assert.deepEqual(resolveReplyTarget(null, [], true), { target: null, pending: false, missing: false });
+  assert.deepEqual(resolveReplyTarget(42, [], false), { target: 42, pending: true, missing: false }, "restored reply is pending before validation, never signed");
+  assert.deepEqual(resolveReplyTarget(42, [], true), { target: null, pending: false, missing: true }, "empty loaded list means the parent is gone → top-level");
+  assert.deepEqual(resolveReplyTarget(42, [{ id: 42 }], true), { target: 42, pending: false, missing: false }, "present parent stays a reply");
+  assert.deepEqual(resolveReplyTarget(42, [{ id: 7 }], true), { target: null, pending: false, missing: true }, "hidden/deleted parent falls back instead of 404ing");
 });

--- a/app/src/lib/launchpad/post-threads.test.ts
+++ b/app/src/lib/launchpad/post-threads.test.ts
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { COMMENTS_PAGE, clearDraft, draftKey, groupReplies, loadDraft, saveDraft, visibleTopIds } from "./post-threads.ts";
+import type { PostRow } from "./postsServer.ts";
+
+const post = (id: number, parent_id: number | null): PostRow => ({ id, chain: "base", token: "0xtoken", wallet: "0xwallet", parent_id, body: `body ${id}`, tag: null, created_at: "2026-01-01T00:00:00.000Z", reports: 0, hidden: false });
+
+test("groupReplies splits top-level from one-level replies, newest reply last", () => {
+  const posts = [post(3, null), post(2, 3), post(1, 3), post(4, null)];
+  const { top, repliesById } = groupReplies(posts);
+  assert.deepEqual(top.map((p) => p.id), [3, 4]);
+  assert.deepEqual(repliesById.get(3)!.map((p) => p.id), [1, 2], "server order (newest first) reverses to oldest-first under the comment");
+  assert.equal(repliesById.get(4), undefined);
+});
+
+test("groupReplies on empty / replies-only input", () => {
+  assert.deepEqual(groupReplies([]).top, []);
+  const { top, repliesById } = groupReplies([post(9, 7)]);
+  assert.deepEqual(top, []);
+  assert.deepEqual(repliesById.get(7)!.map((p) => p.id), [9]);
+});
+
+test("visibleTopIds paginates the top level", () => {
+  const top = [post(1, null), post(2, null), post(3, null)];
+  assert.deepEqual(visibleTopIds(top, 2).map((p) => p.id), [1, 2]);
+  assert.deepEqual(visibleTopIds(top, 99).map((p) => p.id), [1, 2, 3]);
+  assert.deepEqual(visibleTopIds(top, 0), []);
+  assert.equal(COMMENTS_PAGE, 20);
+});
+
+test("draft key is per token and lowercase; node loads empty and saves are no-ops", () => {
+  assert.equal(draftKey("base", "0xABC"), "ol:comment-draft:base:0xabc");
+  assert.notEqual(draftKey("base", "0xabc"), draftKey("robinhood", "0xabc"));
+  assert.equal(loadDraft("base", "0xabc"), "");
+  saveDraft("base", "0xabc", "hello");
+  clearDraft("base", "0xabc");
+  assert.equal(loadDraft("base", "0xabc"), "", "no localStorage in node: always empty, never throws");
+});

--- a/app/src/lib/launchpad/post-threads.ts
+++ b/app/src/lib/launchpad/post-threads.ts
@@ -86,3 +86,24 @@ export function clearDraft(chain: string, token: string): void {
     /* ignore */
   }
 }
+
+/**
+ * Resolve a restored reply target against the loaded posts (PR #31).
+ *
+ * Draft restoration and the initial posts fetch race: posts starts empty, so
+ * an empty list must not read as "parent missing" before the fetch, nor as
+ * "parent exists" for signing. While !postsLoaded a non-null replyTo is
+ * pending (caller blocks submit instead of signing an unvalidated parent);
+ * after loading, membership decides — even when the list is empty — and a
+ * missing/hidden parent falls back to null (top-level).
+ */
+export function resolveReplyTarget(
+  replyTo: number | null,
+  posts: readonly { id: number }[],
+  postsLoaded: boolean,
+): { target: number | null; pending: boolean; missing: boolean } {
+  if (replyTo === null) return { target: null, pending: false, missing: false };
+  if (!postsLoaded) return { target: replyTo, pending: true, missing: false };
+  if (posts.some((p) => p.id === replyTo)) return { target: replyTo, pending: false, missing: false };
+  return { target: null, pending: false, missing: true };
+}

--- a/app/src/lib/launchpad/post-threads.ts
+++ b/app/src/lib/launchpad/post-threads.ts
@@ -36,20 +36,43 @@ export function draftKey(chain: string, token: string): string {
   return `ol:comment-draft:${chain}:${token.toLowerCase()}`;
 }
 
-export function loadDraft(chain: string, token: string): string {
+/** Composer draft: body plus the reply destination (null = top-level post). */
+export type CommentDraft = { body: string; parentId: number | null };
+
+function cleanParentId(v: unknown): number | null {
+  return typeof v === "number" && Number.isInteger(v) && v > 0 ? v : null;
+}
+
+/** Load the full draft (body + reply target). Understands the new JSON shape and legacy plain-text drafts. */
+export function loadCommentDraft(chain: string, token: string): CommentDraft {
   try {
-    if (typeof localStorage === "undefined") return "";
-    return localStorage.getItem(draftKey(chain, token)) ?? "";
+    if (typeof localStorage === "undefined") return { body: "", parentId: null };
+    const raw = localStorage.getItem(draftKey(chain, token));
+    if (!raw) return { body: "", parentId: null };
+    try {
+      const parsed = JSON.parse(raw) as { body?: unknown; parentId?: unknown };
+      if (parsed && typeof parsed === "object" && typeof parsed.body === "string") {
+        return { body: parsed.body, parentId: cleanParentId(parsed.parentId) };
+      }
+    } catch {
+      /* legacy plain-text draft falls through */
+    }
+    return { body: raw, parentId: null };
   } catch {
-    return "";
+    return { body: "", parentId: null };
   }
 }
 
-export function saveDraft(chain: string, token: string, body: string): void {
+export function loadDraft(chain: string, token: string): string {
+  return loadCommentDraft(chain, token).body;
+}
+
+export function saveDraft(chain: string, token: string, body: string, parentId: number | null = null): void {
   try {
     if (typeof localStorage === "undefined") return;
-    if (!body) localStorage.removeItem(draftKey(chain, token));
-    else localStorage.setItem(draftKey(chain, token), body.slice(0, 2000));
+    const pid = cleanParentId(parentId);
+    if (!body && pid === null) localStorage.removeItem(draftKey(chain, token));
+    else localStorage.setItem(draftKey(chain, token), JSON.stringify({ body: body.slice(0, 2000), parentId: pid }));
   } catch {
     /* storage blocked: the in-memory textarea state is what survives */
   }

--- a/app/src/lib/launchpad/post-threads.ts
+++ b/app/src/lib/launchpad/post-threads.ts
@@ -1,0 +1,65 @@
+import type { PostRow } from "./postsServer";
+
+/**
+ * Token-page comment threading + composer helpers (pure; unit-tested).
+ *
+ * TokenComments rendered every reply list with `posts.filter(p => p.parent_id
+ * === id)` per top-level post: O(n²) per render on a viral token. These
+ * helpers build the reply map once (O(n)) and own client pagination + draft
+ * persistence so the component stays thin.
+ */
+
+/** How many top-level comments render before "Show more". */
+export const COMMENTS_PAGE = 20;
+
+export function groupReplies(posts: PostRow[]): { top: PostRow[]; repliesById: Map<number, PostRow[]> } {
+  const top: PostRow[] = [];
+  const repliesById = new Map<number, PostRow[]>();
+  for (const p of posts) {
+    if (p.parent_id === null) top.push(p);
+    else {
+      const list = repliesById.get(p.parent_id);
+      if (list) list.push(p);
+      else repliesById.set(p.parent_id, [p]);
+    }
+  }
+  // Newest reply last under each comment (server sends newest first).
+  for (const list of repliesById.values()) list.reverse();
+  return { top, repliesById };
+}
+
+export function visibleTopIds(top: PostRow[], shownCount: number): PostRow[] {
+  return top.slice(0, Math.max(0, shownCount));
+}
+
+export function draftKey(chain: string, token: string): string {
+  return `ol:comment-draft:${chain}:${token.toLowerCase()}`;
+}
+
+export function loadDraft(chain: string, token: string): string {
+  try {
+    if (typeof localStorage === "undefined") return "";
+    return localStorage.getItem(draftKey(chain, token)) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function saveDraft(chain: string, token: string, body: string): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    if (!body) localStorage.removeItem(draftKey(chain, token));
+    else localStorage.setItem(draftKey(chain, token), body.slice(0, 2000));
+  } catch {
+    /* storage blocked: the in-memory textarea state is what survives */
+  }
+}
+
+export function clearDraft(chain: string, token: string): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.removeItem(draftKey(chain, token));
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
TokenComments did posts.filter(parent_id === id).slice().reverse() for every top-level post on every render (O(n^2)) and rendered all comments at once; the composer silently sliced at POST_MAX with no announcement and a failed signature flow could lose a typed 500-char draft.

This PR: new pure post-threads.ts (groupReplies O(n) + visibleTopIds pagination + per-token draft helpers) with 4 unit tests; TokenComments builds the reply map once via useMemo, paginates the top level at 20 with a Show more button + Showing X of Y status, persists/restores the draft per token, and adds aria-label/describedby, aria-live counter, and role=alert errors.

Verified locally on upstream/main base:
- npm run lint: pass
- npx tsc --noEmit -p .: pass
- full unit suite: 327 pass, 0 fail (323 existing + 4 new)
- npm run build: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comment drafts are automatically saved and restored for each token, including selected reply targets.
  * Comments support paginated top-level discussions with grouped replies.
  * Use “Show more” to load additional top-level comments.
* **Bug Fixes**
  * Replies display in chronological order within discussion threads.
  * Invalid or unavailable reply targets are handled safely, including when posts are truncated or fail to load.
  * Drafts are cleared after successful comment submission.
  * Switching between tokens no longer allows outdated posts or loading states to overwrite the current view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->