### PR TITLE
feat(app): add watchlists and a cleaner full-width UI

### DIFF
--- a/app/src/app/(home)/loading.tsx
+++ b/app/src/app/(home)/loading.tsx
@@ -38,17 +38,16 @@ export default function Loading() {
       </div>
       <div className="grid xl:grid-cols-[minmax(0,1fr)_17rem] gap-6 items-start">
         <section className="min-w-0">
-          <div className="flex h-12 items-center gap-6 border-b border-line">
-            <Sk className="h-4 w-24" /><Sk className="h-4 w-28" />
+          <div className="flex flex-col items-start justify-between gap-4 border-t border-line pb-5 pt-6 sm:flex-row sm:items-end">
+            <div className="space-y-2"><Sk className="h-2.5 w-20" /><Sk className="h-7 w-64 max-w-full" /><Sk className="h-3 w-72 max-w-full" /></div>
+            <Sk className="h-12 w-52 max-w-full rounded-xl" />
           </div>
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5 py-1.5 sm:flex sm:gap-2">
-            <Sk className="col-span-2 h-11 w-full min-w-0 rounded-lg sm:min-w-36 sm:flex-1 sm:basis-40" /><Sk className="h-11 w-28 shrink-0 rounded-lg" /><Sk className="h-11 w-24 shrink-0 rounded-lg" />
+          <div className="market-toolbar grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 pb-3 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+            <Sk className="col-span-2 h-11 w-full min-w-0 rounded-xl sm:col-span-1" /><Sk className="h-11 w-28 shrink-0 rounded-xl" /><Sk className="h-11 w-24 shrink-0 rounded-xl" />
           </div>
-          <div className="flex h-11 items-center gap-6 overflow-hidden border-b border-line">
-            {[0, 1, 2, 3, 4, 5].map((i) => <Sk key={i} className="h-3 w-12 shrink-0" />)}
-          </div>
-          <div className="flex h-8 items-center justify-between gap-3">
-            <Sk className="h-2.5 w-28" /><Sk className="h-2.5 w-24" />
+          <div className="flex min-h-11 flex-wrap items-center justify-between gap-3 pb-3">
+            <div className="flex gap-2 overflow-hidden">{[0, 1, 2, 3, 4, 5].map((i) => <Sk key={i} className="h-9 w-16 shrink-0 rounded-lg" />)}</div>
+            <Sk className="h-3 w-36" />
           </div>
           <LaunchListHeader window="all" />
           <ul>

--- a/app/src/app/(home)/loading.tsx
+++ b/app/src/app/(home)/loading.tsx
@@ -1,10 +1,11 @@
 import { Sk, SkPost, SkRow } from "@/components/Skeleton";
+import { LaunchListHeader } from "@/components/launchpad/LaunchRow";
 
-/** Home skeleton: hero + totals, list header, rows, side column. Same grid as page.tsx so nothing shifts. */
+/** The readable hero, open market toolbar and support rail follow page.tsx. */
 export default function Loading() {
   return (
-    <main className="relative mx-auto max-w-6xl px-4 pb-16 space-y-8" aria-busy="true" aria-label="loading">
-      <section className="pt-10 sm:pt-14 pb-2 grid lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] gap-x-8 gap-y-8 xl:gap-x-12 lg:gap-y-0 lg:grid-rows-[min-content_1fr]">
+    <main className="relative pb-16 space-y-8" aria-busy="true" aria-label="loading">
+      <section className="mx-auto max-w-6xl px-4 pt-10 sm:pt-14 pb-2 grid lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] gap-x-8 gap-y-8 xl:gap-x-12 lg:gap-y-0 lg:grid-rows-[min-content_1fr]">
         <div className="min-w-0 lg:col-start-1 lg:row-start-1">
           <div className="space-y-2">
             {[0, 1, 2].map((i) => <Sk key={i} className="h-11 sm:h-14 lg:h-12 xl:h-14 w-11/12" />)}
@@ -28,27 +29,36 @@ export default function Loading() {
           <Sk className="mt-5 h-3 w-44" />
         </div>
       </section>
-      <div className="space-y-3"><Sk className="h-4 w-40" /><Sk className="h-16 w-full rounded-xl" /></div>
+      <div className="workspace-shell space-y-6">
+      <div className="space-y-2">
+        <Sk className="h-4 w-40" />
+        <div className="grid grid-flow-col auto-cols-[minmax(15rem,1fr)] divide-x divide-line overflow-hidden border-y border-line lg:auto-cols-fr">
+          {[0, 1, 2].map((i) => <div key={i} className="space-y-3 px-4 py-3"><div className="flex items-center gap-2"><Sk className="size-7 shrink-0 rounded-lg" /><Sk className="h-3 w-28" /></div><div className="flex justify-between gap-4"><Sk className="h-4 w-20" /><Sk className="h-3 w-12" /></div><Sk className="h-2.5 w-full" /></div>)}
+        </div>
+      </div>
       <div className="grid xl:grid-cols-[minmax(0,1fr)_17rem] gap-6 items-start">
-        <section className="overflow-hidden rounded-2xl border border-line bg-paper">
-          <div className="flex flex-wrap items-center justify-between gap-3 px-4 pt-5">
-            <Sk className="h-7 w-32" />
-            <Sk className="h-11 w-full sm:w-64 rounded-xl" />
+        <section className="min-w-0">
+          <div className="flex h-12 items-center gap-6 border-b border-line">
+            <Sk className="h-4 w-24" /><Sk className="h-4 w-28" />
           </div>
-          <div className="space-y-4 px-4 py-4">
-            <Sk className="h-10 w-full max-w-md" />
-            <Sk className="h-11 w-64 max-w-full rounded-xl" />
-            <Sk className="h-10 w-64 max-w-full" />
-            <Sk className="h-3 w-36" />
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5 py-1.5 sm:flex sm:gap-2">
+            <Sk className="col-span-2 h-11 w-full min-w-0 rounded-lg sm:min-w-36 sm:flex-1 sm:basis-40" /><Sk className="h-11 w-28 shrink-0 rounded-lg" /><Sk className="h-11 w-24 shrink-0 rounded-lg" />
           </div>
+          <div className="flex h-11 items-center gap-6 overflow-hidden border-b border-line">
+            {[0, 1, 2, 3, 4, 5].map((i) => <Sk key={i} className="h-3 w-12 shrink-0" />)}
+          </div>
+          <div className="flex h-8 items-center justify-between gap-3">
+            <Sk className="h-2.5 w-28" /><Sk className="h-2.5 w-24" />
+          </div>
+          <LaunchListHeader window="all" />
           <ul>
             {Array.from({ length: 8 }, (_, i) => (
               <SkRow key={i} i={i} ledger />
             ))}
           </ul>
         </section>
-        <aside className="space-y-4">
-          <div className="rounded-2xl bg-card border border-line shadow-card overflow-hidden">
+        <aside className="grid min-w-0 gap-6 border-t border-line pt-4 md:grid-cols-2 xl:grid-cols-1 xl:border-t-0 xl:border-l xl:pt-0">
+          <div className="min-w-0">
             <div className="flex min-h-14 items-center justify-between border-b border-line px-4">
               <Sk className="h-4 w-14" />
               <Sk className="h-3 w-16" />
@@ -59,7 +69,8 @@ export default function Loading() {
               ))}
             </ul>
           </div>
-          <div className="rounded-2xl bg-card border border-line shadow-card overflow-hidden">
+          <div className="min-w-0 space-y-6">
+          <div>
             <div className="flex min-h-14 items-center justify-between gap-2 border-b border-line px-4">
               <Sk className="h-4 w-20" />
               <div className="flex items-center gap-2"><Sk className="h-3 w-14" /><Sk className="h-10 w-10 rounded-lg" /></div>
@@ -70,7 +81,15 @@ export default function Loading() {
               ))}
             </ul>
           </div>
+          <div className="space-y-4 border-t border-line px-4 pt-6">
+            <Sk className="h-4 w-24" />
+            <div className="space-y-2"><Sk className="h-3 w-full" /><Sk className="h-3 w-4/5" /></div>
+            <div className="space-y-3">{[0, 1].map((i) => <div key={i} className="flex justify-between gap-4"><Sk className="h-3 w-20" /><Sk className="h-3 w-12" /></div>)}</div>
+            <Sk className="h-3 w-4/5" />
+          </div>
+          </div>
         </aside>
+      </div>
       </div>
     </main>
   );

--- a/app/src/app/(home)/page.tsx
+++ b/app/src/app/(home)/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import LaunchHero from "@/components/launchpad/LaunchHero";
 import LaunchList from "@/components/launchpad/LaunchList";
+import LaunchBrowser from "@/components/launchpad/LaunchBrowser";
 import LaunchTape from "@/components/launchpad/LaunchTape";
 import { PostsFeed } from "@/components/launchpad/Posts";
 import { listFeed } from "@/lib/launchpad/postsServer";
@@ -28,28 +29,30 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ s
 
   return (
     <>
-      <main className="relative mx-auto max-w-6xl px-4 pb-16 space-y-8">
-        <LaunchHero configured={LAUNCHPAD_CONFIGURED} />
+      <main className="relative pb-16 space-y-8">
+        <div className="mx-auto max-w-6xl px-4"><LaunchHero configured={LAUNCHPAD_CONFIGURED} /></div>
+        <div className="workspace-shell space-y-6">
         <TrendingStrip initial={trending} />
         <div className="grid xl:grid-cols-[minmax(0,1fr)_17rem] gap-6 items-start">
-          <LaunchList initial={page.items} initialHasMore={page.hasMore} initialSort={sort} initialWindow={window} initialChain={chain} initialFilter={filter} hasDb={dbConfigured()} />
-          <aside aria-label="Launchpad activity and information" className="grid min-w-0 gap-4 md:grid-cols-2 xl:sticky xl:top-24 xl:grid-cols-1">
+          <LaunchBrowser><LaunchList initial={page.items} initialHasMore={page.hasMore} initialSort={sort} initialWindow={window} initialChain={chain} initialFilter={filter} hasDb={dbConfigured()} /></LaunchBrowser>
+          <aside aria-label="Launchpad activity and information" className="grid min-w-0 gap-6 border-t border-line pt-4 md:grid-cols-2 xl:sticky xl:top-24 xl:grid-cols-1 xl:border-t-0 xl:border-l xl:pt-0">
             <LaunchTape initial={feed} />
-            <div className="min-w-0 space-y-4">
+            <div className="min-w-0 space-y-6">
               <PostsFeed initial={posts} compact />
-              <section aria-labelledby="free-heading" className="rounded-2xl border border-line bg-paper p-4">
+              <section aria-labelledby="free-heading" className="border-t border-line px-4 pt-6">
                 <h2 id="free-heading" className="text-sm font-semibold text-ink">Why it&apos;s free</h2>
                 <p className="mt-2 text-pretty text-xs leading-relaxed text-muted">No fee address in the factory. No platform cut in the locker. On either chain.</p>
-                <dl className="mt-4 divide-y divide-line border-y border-line text-xs">
+                <dl className="mt-3 divide-y divide-line text-xs">
                   <div className="flex items-center justify-between gap-3 py-2.5"><dt className="text-muted">Platform fee</dt><dd className="font-mono font-bold text-up tnum">$0</dd></div>
                   <div className="flex items-center justify-between gap-3 py-2.5"><dt className="text-muted">Trading fee</dt><dd className="font-mono text-ink tnum">0 / 1 / 3%</dd></div>
                 </dl>
                 <p className="mt-3 text-pretty text-[11px] leading-relaxed text-muted">Creators choose the trading fee. It goes in full to their beneficiaries, or is burned.</p>
                 <a href="https://github.com/Gitlawb/openlaunch/tree/main/contracts/src" target="_blank" rel="noopener noreferrer" className="mt-3 inline-flex min-h-8 items-center text-xs font-medium text-body underline decoration-line-strong underline-offset-4 hover:text-ink">Read the contracts ↗</a>
-                <div className="mt-3 border-t border-line pt-3"><Link href="/agents" className="inline-flex min-h-8 items-center text-xs font-medium text-brand hover:underline underline-offset-4">Agents can launch too →</Link></div>
+                <div className="mt-2"><Link href="/agents" className="inline-flex min-h-8 items-center text-xs font-medium text-brand hover:underline underline-offset-4">Agents can launch too →</Link></div>
               </section>
             </div>
           </aside>
+        </div>
         </div>
       </main>
     </>

--- a/app/src/app/agents/page.tsx
+++ b/app/src/app/agents/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
-import { ArrowDown, ArrowRight, ArrowUpRight, Braces, FileCode2, Terminal } from "lucide-react";
+import { ArrowDown, ArrowUpRight, Braces, FileCode2, Terminal } from "lucide-react";
 import SectionIntro from "@/components/sections/SectionIntro";
+import DocumentationContents from "@/components/sections/DocumentationContents";
 import AgentsCodeBlock from "@/components/sections/AgentsCodeBlock";
+import { agentExamples } from "@/components/sections/agent-examples";
 import shell from "@/components/sections/SectionShell.module.css";
 import styles from "@/components/sections/Agents.module.css";
 import { launchpad } from "@/lib/launchpad/config";
@@ -24,13 +26,6 @@ const endpoints = [
 ] as const;
 
 export default function AgentsPage() {
-  const factory = launchpad("base").factory ?? "<factory>";
-  const locker = launchpad("base").locker ?? "<locker>";
-  const launchExample = `cast send ${factory} \\
-  "launch((string,string,string,address,uint256,int24,uint24,bytes32,(address,uint16)[]))" \\
-  "(My Token,MYT,,0x0000000000000000000000000000000000000000,0,184200,10000,0x$(openssl rand -hex 32),[(0xYourWallet,10000)])" \\
-  --rpc-url https://mainnet.base.org --private-key $PK`;
-
   return (
     <main className={`${shell.page} ${styles.page}`}>
       <SectionIntro eyebrow="Developer reference" title="Agents" description={<>No API key, no signup, no platform fee. A launch is one contract call from any wallet with a little ETH for gas. Everything the site shows is also JSON.</>}>
@@ -45,10 +40,7 @@ export default function AgentsPage() {
 
       <div className={styles.layout}>
         <aside className={styles.sidebar}>
-          <nav aria-label="Agent documentation sections">
-            <p className={styles.indexLabel}>On this page</p>
-            {sections.map(({ id, number, label }) => <a key={id} href={`#${id}`}><span>{number}</span>{label}<ArrowRight size={13} aria-hidden="true" /></a>)}
-          </nav>
+          <DocumentationContents sections={sections} aria-label="Agent documentation sections" />
           <p className={styles.sidebarNote}>Use the JSON API to read.<br />Use your wallet to write on-chain.</p>
         </aside>
 
@@ -67,13 +59,13 @@ export default function AgentsPage() {
                 </div>;
               })}
             </div>
-            <p className={styles.prose}>Call <code>launch(params)</code> on that chain&apos;s factory. The example below launches on Base with an ETH quote.</p>
-            <AgentsCodeBlock title="Launch on Base" language="Shell · cast" code={launchExample} />
-            <p className={styles.exampleNote}>Example only. Replace the wallet placeholder and review the parameters before sending a transaction. Never share your private key.</p>
+            <p className={styles.prose}>Call <code>launch(params)</code> on that chain&apos;s factory. Choose a network below to see its address and chain ID. Both examples use an ETH quote.</p>
+            <AgentsCodeBlock title="Launch parameters" language="JSON · parameter reference" examples={agentExamples("launch")} />
+            <p className={styles.exampleNote}>Example only, not an executable transaction. Replace the placeholders, create a unique salt and simulate the call with your own wallet tooling before signing. Copying does not connect a wallet or send anything. Never share your private key.</p>
             <div className={styles.reference}>
               <div className={styles.referenceHeading}><Braces size={16} aria-hidden="true" /><h3>Parameters, without the guesswork</h3></div>
               <dl className={styles.parameters}>
-                <div><dt><code>quote</code></dt><dd>ETH uses address zero. For GITLAWB use <code>0x5F980Dcfc4c0fa3911554cf5ab288ed0eb13DBa3</code> on Base or <code>0xd1b0d44E4f6ed940fcC7A9F59Bf30Daf62cCFe3D</code> on Robinhood Chain; for USDG on Robinhood Chain, <code>0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168</code>. For any ERC-20 quote call <code>findSalt(...)</code> first so the token address sorts above the quote.</dd></div>
+                <div><dt><code>quote</code></dt><dd>ETH uses address zero. {CHAIN_KEYS.map((chain) => <span key={chain}>{CHAIN_LABELS[chain]} quote addresses: {launchpad(chain).quotes.filter((quote) => quote.key !== "eth").map((quote, index) => <span key={quote.key}>{index > 0 ? "; " : ""}{quote.symbol} <code>{quote.address}</code></span>)}. </span>)}For any ERC-20 quote call <code>findSalt(...)</code> first so the token address sorts above the quote.</dd></div>
                 <div><dt><code>supply</code></dt><dd><code>0</code> means the default <code>1B</code> supply.</dd></div>
                 <div><dt><code>startTick</code></dt><dd>Sets the opening market cap. A multiple of <code>200</code>; <code>184200 ≈ 10 ETH</code> FDV for <code>1B</code> supply.</dd></div>
                 <div><dt><code>lpFee</code></dt><dd>In pips: <code>0</code>, <code>10000 = 1%</code>, or <code>30000 = 3%</code>.</dd></div>
@@ -97,7 +89,7 @@ export default function AgentsPage() {
                 <div><code className={styles.endpointPath}>{endpoint.path}</code><p>{endpoint.description}</p>{"query" in endpoint && <code className={styles.query}>{endpoint.query}</code>}</div>
               </div>)}
             </div>
-            <AgentsCodeBlock title="Read endpoints" language="HTTP reference" code={`GET ${SITE_URL}/api/launch/list?chain=base|robinhood&sort=live|new|mcap|volume|gainers|holders&window=1h|24h|all&limit=50\nGET ${SITE_URL}/api/launch/feed              # latest launches + trades\nGET ${SITE_URL}/api/launch/meta/<token>      # image / description / links\nGET ${SITE_URL}/llms.txt`} />
+            <AgentsCodeBlock title="Read endpoints" language="HTTP reference" examples={agentExamples("read")} />
             <div className={styles.dataNote}>
               <p>Raw token and quote amounts are decimal integer strings. Use <code>quote_decimals</code> for quote amounts, not a blanket <code>18</code> decimals. <code>price_quote</code> and <code>fdv_quote</code> are numbers in the token&apos;s quote asset; explicit <code>price_usd</code>, <code>fdv_usd</code> and <code>volume_usd</code> fields are USD values and may be <code>null</code> when pricing is unavailable.</p>
               <p>Poll modestly and back off on errors. Indexing and server-side caching mean responses are not a guarantee of the latest chain state, even when an HTTP response uses <code>no-store</code>.</p>
@@ -108,13 +100,13 @@ export default function AgentsPage() {
             <div className={styles.sectionHeading}><span className={styles.sectionNumber}>03</span><div><h2 id="agents-trade-title">Trade & collect</h2><p>Standard pools. Direct contract calls.</p></div></div>
             <div className={styles.tradeReference}>
               <div><span className={styles.tradeLabel}>Swap</span><h3>Speak Uniswap v4</h3><p className={styles.prose}>Pools are plain Uniswap v4, with tick spacing <code>200</code> and no hook. The quote can be ETH, GITLAWB (both chains), USDG (Robinhood Chain) or a supported issuer-registry stock token. Get the actual pool key with <code>poolKeyOf(token)</code> on the factory. Swap through the Universal Router with a <code>V4_SWAP</code> command, or any router that speaks v4.</p></div>
-              <div><span className={styles.tradeLabel}>Collect</span><h3>Pay out accrued fees</h3><p className={styles.prose}>Anyone may call <code>collect(tokenId)</code> on that chain&apos;s locker to pay out accrued fees. Base locker: <code>{locker}</code>. Use the matching chain address above.</p></div>
+              <div><span className={styles.tradeLabel}>Collect</span><h3>Pay out accrued fees</h3><p className={styles.prose}>Anyone may call <code>collect(tokenId)</code> on that chain&apos;s locker to pay out accrued fees. Use the matching chain address above. Simulate the call first; collecting still needs a signed transaction and network gas.</p></div>
             </div>
             <p className={styles.exampleNote}>Tokenized stocks are third-party securities offered under Regulation S, not to US persons. The site recognizes them from issuer registries, not on-chain names.</p>
             <div className={styles.metadata}>
               <div className={styles.subheading}><span className={styles.method}>POST</span><h3>Sync your transaction</h3></div>
               <p className={styles.prose}>After a transaction you sent, request immediate indexing with this endpoint. Background polling normally runs about every <code>15s</code>; receipt availability and RPC errors can delay indexing.</p>
-              <AgentsCodeBlock title="Transaction sync endpoint" language="HTTP reference" code={`POST ${SITE_URL}/api/launch/sync?chain=base|robinhood&tx=0x…`} />
+              <AgentsCodeBlock title="Transaction sync endpoint" language="HTTP reference" examples={agentExamples("sync")} />
             </div>
           </section>
         </div>

--- a/app/src/app/api/launch/watchlist/route.ts
+++ b/app/src/app/api/launch/watchlist/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { dbConfigured } from "@/lib/db";
+import { rateLimited } from "@/lib/launchpad/editServer";
+import { ethUsd } from "@/lib/launchpad/ethPrice";
+import { WatchlistInputError, getWatchlistData, parseWatchlistRequest, readWatchlistBody } from "@/lib/launchpad/watchlistData";
+
+export const dynamic = "force-dynamic";
+
+/** Read-only POST keeps the user's device-local token list out of URLs. Nothing is persisted. */
+export async function POST(req: Request) {
+  const headers = { "cache-control": "no-store" };
+  const ip = (req.headers.get("fly-client-ip") || req.headers.get("x-forwarded-for") || "").split(",")[0].trim() || "0.0.0.0";
+  if (rateLimited(`watchlist:ip:${ip}`, 60)) {
+    return NextResponse.json({ error: "Too many refreshes. Try again shortly." }, { status: 429, headers: { ...headers, "retry-after": "60" } });
+  }
+  try {
+    const body = await readWatchlistBody(req);
+    const at = Date.now();
+    const items = parseWatchlistRequest(body, at);
+    if (!dbConfigured()) return NextResponse.json({ error: "Watchlist activity is unavailable.", indexed: false }, { status: 503, headers });
+    const data = await getWatchlistData(items, at, items.length ? await ethUsd() : null);
+    return NextResponse.json(data, { status: data.indexed ? 200 : 503, headers });
+  } catch (error) {
+    if (error instanceof WatchlistInputError) return NextResponse.json({ error: error.message }, { status: error.status, headers });
+    return NextResponse.json({ error: "Watchlist activity could not be refreshed. Your saved tokens are unchanged.", indexed: false }, { status: 503, headers });
+  }
+}

--- a/app/src/app/feed/loading.tsx
+++ b/app/src/app/feed/loading.tsx
@@ -10,11 +10,11 @@ export default function Loading() {
   return (
     <main className={shell.page} aria-busy="true" aria-label="Loading posts">
       <header className={shell.intro}>
-        <div className="flex h-4 items-center"><Sk className="h-3 w-36" /></div>
         <div className={shell.introRow}>
           <div className={`${shell.introCopy} w-full`}>
             <Sk className="h-9 w-72 max-w-full sm:h-[50px]" />
-            <div className="mt-4">
+            <div className={shell.eyebrow}><Sk className="h-[18px] w-36" /></div>
+            <div className="mt-2.5">
               <div className="flex h-[26px] items-center sm:h-[27px]"><Sk className="h-4 w-full max-w-[620px]" /></div>
               <div className="flex h-[26px] items-center sm:h-[27px]"><Sk className="h-4 w-3/4 max-w-[460px]" /></div>
             </div>
@@ -24,9 +24,11 @@ export default function Loading() {
       </header>
       <div className={styles.layout}>
         <section className={shell.panel} aria-label="Loading recent community posts">
-          <div className={styles.toolbar}><Sk className="h-4 w-44 max-w-full" /><Sk className="h-11 w-11 rounded-full" /></div>
-          <div className={styles.filters}><Sk className="h-[54px] w-60 max-w-full rounded-xl" /><Sk className="h-11 min-w-[180px] flex-1" /></div>
-          <div className={styles.resultLine}><p className="flex h-4 items-center"><Sk className="h-3 w-24" /></p><span className="flex h-4 items-center"><Sk className="h-3 w-36" /></span></div>
+          <header className={styles.controls}>
+            <div className={styles.toolbar}><Sk className="h-4 w-36 max-w-full" /></div>
+            <div className={styles.filters}><Sk className="h-11 w-32 rounded-lg" /><div className={styles.search}><Sk className="h-3 w-36 max-w-full" /></div><Sk className="h-11 w-11 rounded-lg" /></div>
+            <div className={styles.resultLine}><p className="flex h-4 items-center"><Sk className="h-3 w-20" /></p><span className="flex h-4 items-center"><Sk className="h-3 w-36" /></span></div>
+          </header>
           <ul>
             {Array.from({ length: 6 }, (_, i) => (
               <SkFeedPost key={i} i={i} />
@@ -36,8 +38,8 @@ export default function Loading() {
         </section>
         <aside className={styles.aside} aria-hidden="true">
           <section className={styles.guide}>
-            <Sk className="h-3 w-44" />
-            <div className="mt-3.5 flex h-[30px] items-center"><Sk className="h-6 w-48 max-w-full" /></div>
+            <div className="flex h-[28px] items-center"><Sk className="h-6 w-48 max-w-full" /></div>
+            <div className={styles.asideEyebrow}><Sk className="h-[18px] w-44 max-w-full" /></div>
             <div className="mt-3">
               <div className="flex h-[23px] items-center"><Sk className="h-3.5 w-full" /></div>
               <div className="flex h-[23px] items-center"><Sk className="h-3.5 w-5/6" /></div>

--- a/app/src/app/fonts.ts
+++ b/app/src/app/fonts.ts
@@ -1,4 +1,4 @@
-import { Inter, Space_Mono, Unbounded } from "next/font/google";
+import { Geist_Mono, Inter, Unbounded } from "next/font/google";
 
 /**
  * Font loaders shared by the root layout and global-error.tsx.
@@ -6,5 +6,5 @@ import { Inter, Space_Mono, Unbounded } from "next/font/google";
  * these variables — it imports them from here instead of duplicating them.
  */
 export const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
-export const spaceMono = Space_Mono({ subsets: ["latin"], weight: ["400", "700"], variable: "--font-space-mono", display: "swap" });
+export const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono", display: "swap" });
 export const unbounded = Unbounded({ subsets: ["latin"], weight: ["600", "700"], variable: "--font-unbounded", display: "swap" });

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect } from "react";
 import "./globals.css";
-import { inter, spaceMono, unbounded } from "./fonts";
+import { inter, geistMono, unbounded } from "./fonts";
 import { errorBody, errorRegionLabel, sanitizeDigest } from "@/lib/error-copy";
 
 /**
@@ -24,7 +24,7 @@ export default function GlobalError({
   }, [error]);
   const digest = sanitizeDigest(error.digest);
   return (
-    <html lang="en" className={`${inter.variable} ${spaceMono.variable} ${unbounded.variable}`}>
+    <html lang="en" className={`${inter.variable} ${geistMono.variable} ${unbounded.variable}`}>
       <body className="min-h-screen flex flex-col">
         <main aria-label={errorRegionLabel("global")} className="mx-auto max-w-3xl px-4 py-24 text-center space-y-5">
           <h1 className="font-display font-bold text-7xl">500</h1>

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -60,6 +60,30 @@
 
 :root {
   color-scheme: light;
+  --workspace-gutter: 16px;
+}
+
+/* Operating surfaces use the screen; prose and the home introduction keep
+   their own readable measure. Header and footer share these edge gutters. */
+.workspace-shell {
+  width: 100%;
+  min-width: 0;
+  padding-inline: var(--workspace-gutter);
+}
+@media (min-width: 640px) { :root { --workspace-gutter: 24px; } }
+@media (min-width: 1280px) { :root { --workspace-gutter: 32px; } }
+
+/* One track definition for the ledger header, rows and loading state.
+   Wider screens distribute space across the figures, not just the name. */
+@media (min-width: 640px) {
+  .launch-ledger {
+    grid-template-columns: minmax(0, 1.8fr) minmax(6rem, 1fr) minmax(5rem, .8fr) minmax(4.5rem, .7fr);
+  }
+}
+@media (min-width: 1024px) {
+  .launch-ledger {
+    grid-template-columns: minmax(0, 2.2fr) minmax(6.5rem, 1fr) minmax(5.5rem, .8fr) minmax(6rem, 1fr) minmax(5rem, .8fr) minmax(2.5rem, .45fr);
+  }
 }
 
 /* ── Dark: black ground, alpha ramp of white, near-zero chroma greys. The blue

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -11,7 +11,7 @@
 /* Chart code reads tokens at runtime; retain even tokens with no utility class. */
 @theme static {
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  --font-mono: var(--font-space-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
   --font-display: var(--font-unbounded), var(--font-inter), ui-sans-serif, system-ui, sans-serif;
 
   /* surfaces */
@@ -61,6 +61,43 @@
 :root {
   color-scheme: light;
   --workspace-gutter: 16px;
+  --ui-control-duration: 160ms;
+  --ui-panel-duration: 220ms;
+  --ui-ease-out: cubic-bezier(.22, 1, .36, 1);
+}
+
+/* Shared, finite interaction feedback. Only opted-in controls move. */
+.ui-pressable {
+  transition-property: color, background-color, border-color, transform;
+  transition-duration: var(--ui-control-duration);
+  transition-timing-function: var(--ui-ease-out);
+}
+.ui-pressable:active:not(:disabled):not([aria-disabled="true"]) { transform: scale(.97); }
+.ui-tab-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  width: var(--active-tab-width);
+  transform: translateX(var(--active-tab-left));
+  background: var(--color-brand);
+  pointer-events: none;
+  transition: transform var(--ui-panel-duration) var(--ui-ease-out);
+}
+.ui-sort-tab { position: relative; transition: color var(--ui-control-duration) ease; }
+.ui-sort-tab::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -2px;
+  height: 2px;
+  background: var(--color-brand);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--ui-control-duration) var(--ui-ease-out);
+}
+.ui-sort-tab[aria-pressed="true"]::after { transform: scaleX(1); }
+@media (prefers-reduced-motion: reduce) {
+  .ui-pressable:active:not(:disabled):not([aria-disabled="true"]) { transform: none; }
 }
 
 /* Operating surfaces use the screen; prose and the home introduction keep
@@ -77,12 +114,12 @@
    Wider screens distribute space across the figures, not just the name. */
 @media (min-width: 640px) {
   .launch-ledger {
-    grid-template-columns: minmax(0, 1.8fr) minmax(6rem, 1fr) minmax(5rem, .8fr) minmax(4.5rem, .7fr);
+    grid-template-columns: minmax(0, 1.65fr) minmax(7rem, .72fr) minmax(9.5rem, .9fr);
   }
 }
 @media (min-width: 1024px) {
   .launch-ledger {
-    grid-template-columns: minmax(0, 2.2fr) minmax(6.5rem, 1fr) minmax(5.5rem, .8fr) minmax(6rem, 1fr) minmax(5rem, .8fr) minmax(2.5rem, .45fr);
+    grid-template-columns: minmax(20rem, 36rem) minmax(8.5rem, 1fr) minmax(7.5rem, .8fr) minmax(10rem, 1fr);
   }
 }
 

--- a/app/src/app/launch/loading.tsx
+++ b/app/src/app/launch/loading.tsx
@@ -2,26 +2,26 @@ import { Sk } from "@/components/Skeleton";
 
 export default function Loading() {
   return (
-    <main className="mx-auto max-w-6xl px-4 pt-8 sm:pt-10 pb-16 space-y-6" aria-busy="true" aria-label="loading launch form">
+    <main className="workspace-shell pt-6 sm:pt-10 pb-16 space-y-8 sm:space-y-10" aria-busy="true" aria-label="loading launch form">
       <header className="space-y-3">
         <Sk className="h-10 w-72 max-w-full" />
         <Sk className="h-5 w-3/4 max-w-2xl" />
       </header>
-      <div className="grid lg:grid-cols-[minmax(0,1fr)_22rem] gap-6 lg:gap-8 items-start">
-        <div className="space-y-6">
+      <div className="grid items-start gap-12 lg:grid-cols-[minmax(0,1fr)_22rem] xl:gap-16">
+        <div className="divide-y divide-line">
           {Array.from({ length: 3 }, (_, i) => (
-            <div key={i} className="rounded-2xl bg-card border border-line shadow-card p-5 space-y-4">
+            <div key={i} className="space-y-5 py-8 first:pt-0">
               <Sk className="h-5 w-24" />
               <div className="grid sm:grid-cols-2 gap-4">
-                <Sk className="h-24 rounded-xl" />
-                <Sk className="h-24 rounded-xl" />
+                <Sk className="h-24 rounded-lg" />
+                <Sk className="h-24 rounded-lg" />
               </div>
-              <Sk className="h-12 w-full rounded-xl" />
+              <Sk className="h-12 w-full rounded-lg" />
             </div>
           ))}
         </div>
-        <aside className="rounded-2xl bg-card border border-line shadow-card p-4 space-y-3">
-          <Sk className="h-3 w-16" />
+        <aside className="space-y-5 border-t border-line pt-6 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+          <Sk className="h-5 w-16" />
           <div className="flex items-center gap-3">
             <Sk className="h-12 w-12 rounded-xl" />
             <div className="space-y-2 flex-1">
@@ -29,9 +29,9 @@ export default function Loading() {
               <Sk className="h-3 w-16" />
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-2.5">
+          <div className="grid grid-cols-2 gap-x-5 border-b border-line">
             {Array.from({ length: 4 }, (_, i) => (
-              <Sk key={i} className="h-20 rounded-xl" />
+              <div key={i} className="space-y-2 border-t border-line py-4"><Sk className="h-3 w-16" /><Sk className="h-5 w-full" /><Sk className="h-3 w-20 max-w-full" /></div>
             ))}
           </div>
         </aside>

--- a/app/src/app/launch/page.tsx
+++ b/app/src/app/launch/page.tsx
@@ -16,7 +16,7 @@ export default async function LaunchPage({ searchParams }: { searchParams: Promi
   const [usd, gitlawb] = await Promise.all([ethUsd(), gitlawbUsd()]);
   return (
     <>
-      <main className="relative mx-auto max-w-6xl px-4 pt-6 sm:pt-10 pb-16 space-y-5 sm:space-y-6">
+      <main className="workspace-shell relative pt-6 sm:pt-10 pb-16 space-y-8 sm:space-y-10">
         <header className="max-w-2xl">
           <h1 className="font-display font-bold tracking-[-0.02em] text-ink text-3xl sm:text-4xl">Launch a token</h1>
           <p className="mt-2 text-base text-body">Pick a chain, fill this in, sign once, done. No platform fee. You only pay gas.</p>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -13,7 +13,7 @@ import Footer from "@/components/Footer";
 import RouteProgress from "@/components/RouteProgress";
 import ThemeProvider from "@/components/ThemeProvider";
 import { Suspense } from "react";
-import { inter, spaceMono, unbounded } from "./fonts";
+import { inter, geistMono, unbounded } from "./fonts";
 
 const TITLE = SITE_TITLE;
 const DESCRIPTION = SITE_DESCRIPTION;
@@ -38,7 +38,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const usd = await ethUsd();
   const [feed, totals] = await Promise.all([getLaunchFeed(24, usd).catch(() => []), getLaunchTotals(usd)]);
   return (
-    <html lang="en" className={`${inter.variable} ${spaceMono.variable} ${unbounded.variable}`} suppressHydrationWarning>
+    <html lang="en" className={`${inter.variable} ${geistMono.variable} ${unbounded.variable}`} suppressHydrationWarning>
       <body id="site-top" tabIndex={-1} className="min-h-screen flex flex-col">
         <ThemeProvider nonce={nonce}>
         <Web3Provider>

--- a/app/src/app/rules/page.tsx
+++ b/app/src/app/rules/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowDown, ArrowRight, ArrowUpRight, ChevronDown, FileCode2, LockKeyhole } from "lucide-react";
 import SectionIntro from "@/components/sections/SectionIntro";
+import DocumentationContents from "@/components/sections/DocumentationContents";
 import shell from "@/components/sections/SectionShell.module.css";
 import styles from "@/components/sections/RulesGuide.module.css";
 import { launchpad } from "@/lib/launchpad/config";
@@ -27,6 +28,7 @@ const FIXED = [
 const CONTENTS = [
   ["launchpad", "The launch"], ["fees", "Fees & routing"], ["immutable", "What stays fixed"], ["know", "Before you begin"], ["contracts", "Contracts"],
 ] as const;
+const CONTENT_LINKS = CONTENTS.map(([id, label], i) => ({ id, label, number: String(i + 1).padStart(2, "0") }));
 
 /** Verification records stay chain-specific and point to each deployed contract. */
 const VERIFIERS: Record<(typeof CHAIN_KEYS)[number], { name: string; url: (addr: string) => string }[]> = {
@@ -51,12 +53,7 @@ export default function RulesPage() {
 
       <div className={styles.layout}>
         <aside className={styles.contents}>
-          <nav aria-label="On this page">
-            <p className={styles.eyebrow}>In this guide</p>
-            <ol>
-              {CONTENTS.map(([id, title], i) => <li key={id}><a href={`#${id}`}><span>{String(i + 1).padStart(2, "0")}</span>{title}</a></li>)}
-            </ol>
-          </nav>
+          <DocumentationContents sections={CONTENT_LINKS} title="In this guide" aria-label="On this page" />
           <a href={BRAND_GITHUB} target="_blank" rel="noreferrer" className={styles.sourceLink}><FileCode2 size={16} aria-hidden="true" /> Read the source <ArrowUpRight size={13} aria-hidden="true" /></a>
         </aside>
 

--- a/app/src/app/rules/page.tsx
+++ b/app/src/app/rules/page.tsx
@@ -63,7 +63,7 @@ export default function RulesPage() {
         <div className={styles.article}>
           <section className={shell.anchorSection} id="launchpad" aria-labelledby="launch-heading">
             <div className={styles.sectionHeading}>
-              <div><p className={styles.eyebrow}>01 / The launch</p><h2 id="launch-heading">One signature.<br />Four things happen.</h2></div>
+              <div><h2 id="launch-heading">One signature.<br />Four things happen.</h2><p className={styles.eyebrow}>01 / The launch</p></div>
               <p>All in the same transaction.<br />No separate setup. No platform fee.</p>
             </div>
             <ol className={styles.steps}>
@@ -79,7 +79,7 @@ export default function RulesPage() {
           </section>
 
           <section className={shell.anchorSection} id="fees" aria-labelledby="fees-heading">
-            <div className={styles.sectionHeading}><div><p className={styles.eyebrow}>02 / Fees & routing</p><h2 id="fees-heading">Know where it goes.</h2></div></div>
+            <div className={styles.sectionHeading}><div><h2 id="fees-heading">Know where it goes.</h2><p className={styles.eyebrow}>02 / Fees & routing</p></div></div>
             <div className={styles.feePanel}>
               <div className={styles.platformFee}><span className={styles.eyebrow}>Platform fee</span><strong>0%</strong><p>We take nothing.<br />Gas is paid to the network.</p><a href="#contracts">Check the code <ArrowUpRight size={13} aria-hidden="true" /></a></div>
               <div className={styles.tradingFees}>
@@ -98,12 +98,12 @@ export default function RulesPage() {
           </section>
 
           <section className={shell.anchorSection} id="immutable" aria-labelledby="fixed-heading">
-            <div className={styles.sectionHeading}><div><p className={styles.eyebrow}>03 / What stays fixed</p><h2 id="fixed-heading">Code, not a promise.</h2></div><a href="#contracts" className={shell.textLink}>Read the contracts <ArrowUpRight size={14} aria-hidden="true" /></a></div>
+            <div className={styles.sectionHeading}><div><h2 id="fixed-heading">Code, not a promise.</h2><p className={styles.eyebrow}>03 / What stays fixed</p></div><a href="#contracts" className={shell.textLink}>Read the contracts <ArrowUpRight size={14} aria-hidden="true" /></a></div>
             <ul className={styles.fixedList}>{FIXED.map(([title, description]) => <li key={title}><span className={styles.fixedMark} aria-hidden="true">×</span><div><h3>{title}</h3><p>{description}</p></div></li>)}</ul>
           </section>
 
           <section className={shell.anchorSection} id="know" aria-labelledby="know-heading">
-            <div className={styles.sectionHeading}><div><p className={styles.eyebrow}>04 / Before you begin</p><h2 id="know-heading">Locked liquidity.<br />Not a guarantee of value.</h2></div></div>
+            <div className={styles.sectionHeading}><div><h2 id="know-heading">Locked liquidity.<br />Not a guarantee of value.</h2><p className={styles.eyebrow}>04 / Before you begin</p></div></div>
             <p className={styles.riskIntro}>Tokens launched here are created by their launchers, not by openlaunch. Do your own research; a locked pool does not make a token valuable. Nothing is refundable.</p>
             <div className={styles.questions}>
               <details open><summary>How does the price move?<ChevronDown size={17} aria-hidden="true" /></summary><div><p>Price follows a single-sided Uniswap v4 curve: the first buyers get the most tokens per unit of the quote asset, and every buy moves the price up. Sells move it down.</p><p>There is no anti-snipe mechanism. Bots can buy in the first block like anyone else.</p><p>The launch form suggests a small first buy (about $25) so your token opens with a holder and a price; clear it and the launch stays free.</p></div></details>
@@ -115,7 +115,7 @@ export default function RulesPage() {
           </section>
 
           <section className={shell.anchorSection} id="contracts" aria-labelledby="contracts-heading">
-            <div className={styles.sectionHeading}><div><p className={styles.eyebrow}>05 / The source of truth</p><h2 id="contracts-heading">Don&apos;t take our word for it.</h2></div><FileCode2 size={28} className={styles.contractIcon} aria-hidden="true" /></div>
+            <div className={styles.sectionHeading}><div><h2 id="contracts-heading">Don&apos;t take our word for it.</h2><p className={styles.eyebrow}>05 / The source of truth</p></div><FileCode2 size={28} className={styles.contractIcon} aria-hidden="true" /></div>
             <p className={styles.contractIntro}>Contracts, addresses and source verification. The same contract design on both chains, with chain-specific Uniswap deployments.</p>
             <div className={styles.registry}>
               {CHAIN_KEYS.map((chain) => {
@@ -133,7 +133,7 @@ export default function RulesPage() {
             <p className={styles.contractNote}>Uniswap v4&apos;s PoolManager, PositionManager, Permit2 and Universal Router are Uniswap&apos;s canonical deployments. MIT-licensed source on <a href={BRAND_GITHUB} target="_blank" rel="noreferrer">GitHub ↗</a>; the verification records for each chain are linked above.</p>
           </section>
 
-          <div className={styles.closing}><div><p className={styles.eyebrow}>Your next move</p><h2>Make something of your own.</h2></div><Link href="/launch" className={shell.action}>Launch a token <ArrowRight size={15} aria-hidden="true" /></Link></div>
+          <div className={styles.closing}><div><h2>Make something of your own.</h2><p className={styles.eyebrow}>Your next move</p></div><Link href="/launch" className={shell.action}>Launch a token <ArrowRight size={15} aria-hidden="true" /></Link></div>
         </div>
       </div>
     </main>

--- a/app/src/app/t/[chain]/[token]/loading.tsx
+++ b/app/src/app/t/[chain]/[token]/loading.tsx
@@ -1,17 +1,17 @@
 import { Sk } from "@/components/Skeleton";
 
 export default function Loading() {
-  return <main className="mx-auto max-w-6xl space-y-6 px-4 pt-7 pb-28" aria-busy="true" aria-label="Loading token market">
+  return <main className="workspace-shell space-y-6 pt-7 pb-28" aria-busy="true" aria-label="Loading token market">
     <Sk className="h-5 w-24" />
-    <header className="flex items-center gap-4"><Sk className="size-14 shrink-0 rounded-2xl" /><div className="space-y-2"><Sk className="h-8 w-48" /><Sk className="h-3 w-60 max-w-full" /></div></header>
-    <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_21rem]">
+    <header className="flex items-center gap-4"><Sk className="size-14 shrink-0 rounded-2xl" /><div className="min-w-0 space-y-2"><Sk className="h-8 w-48 max-w-full" /><Sk className="h-3 w-60 max-w-full" /></div></header>
+    <div className="grid items-start gap-7 lg:grid-cols-[minmax(0,1fr)_21rem] lg:gap-8">
       <div className="min-w-0 space-y-4">
-        <div className="overflow-hidden rounded-2xl border border-line p-5"><Sk className="h-3 w-24" /><Sk className="mt-3 h-10 w-44" /><Sk className="mt-6 h-10 w-full" /><Sk className="mt-3 h-72 w-full sm:h-[360px] xl:h-[390px]" /></div>
-        <div className="grid grid-cols-2 gap-4 rounded-xl border border-line bg-card p-4 sm:grid-cols-4">{Array.from({ length: 4 }, (_, i) => <div key={i} className="space-y-2"><Sk className="h-3 w-16" /><Sk className="h-5 w-full" /></div>)}</div>
+        <div><Sk className="h-3 w-24" /><Sk className="mt-3 h-10 w-44 max-w-full" /><Sk className="mt-6 h-10 w-full" /><Sk className="mt-3 h-[390px] w-full max-sm:h-[340px] xl:h-[clamp(430px,50dvh,620px)]" /></div>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-4 border-y border-line py-4 sm:grid-cols-4">{Array.from({ length: 4 }, (_, i) => <div key={i} className="space-y-2"><Sk className="h-3 w-16" /><Sk className="h-5 w-full" /></div>)}</div>
       </div>
-      <aside className="space-y-4">
-        <div className="space-y-5 rounded-2xl border border-line-strong p-5"><Sk className="h-5 w-24" /><Sk className="h-11 w-full" /><Sk className="h-32 w-full rounded-xl" /><Sk className="h-24 w-full rounded-xl" /><Sk className="h-12 w-full rounded-xl" /></div>
-        <Sk className="h-60 w-full rounded-2xl" />
+      <aside className="space-y-6">
+        <div className="space-y-5 rounded-xl bg-card p-5"><Sk className="h-5 w-24" /><Sk className="h-11 w-full" /><Sk className="h-32 w-full rounded-lg" /><Sk className="h-24 w-full rounded-lg" /><Sk className="h-12 w-full rounded-lg" /></div>
+        <div className="space-y-4 border-t border-line pt-5"><Sk className="h-4 w-32" /><Sk className="h-16 w-full" /><Sk className="h-10 w-full" /></div>
       </aside>
     </div>
   </main>;

--- a/app/src/app/t/[chain]/[token]/page.tsx
+++ b/app/src/app/t/[chain]/[token]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { isAddress, type Address } from "viem";
 import { ArrowLeft, ArrowUpRight, Globe, Share2 } from "lucide-react";
 import TokenAvatar from "@/components/launchpad/TokenAvatar";
+import WatchButton from "@/components/launchpad/WatchButton";
 import { feeModeOf } from "@/components/launchpad/FeeChip";
 import TradePanel from "@/components/launchpad/TradePanel";
 import CollectPanel from "@/components/launchpad/CollectPanel";
@@ -102,7 +103,7 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />
-      <main className="mx-auto max-w-6xl px-4 pt-5 pb-28 sm:pt-7 lg:pb-16">
+      <main className="workspace-shell pt-5 pb-28 sm:pt-7 lg:pb-16">
         <nav aria-label="Breadcrumb" className="mb-5 flex min-h-8 items-center justify-between gap-3 text-xs text-muted">
           <Link href="/#launches" className="inline-flex items-center gap-2 hover:text-ink"><ArrowLeft size={13} /> All launches</Link>
           <span className="flex items-center gap-2"><span>{chainLabel}</span><span aria-hidden>·</span><span>Uniswap v4</span></span>
@@ -117,16 +118,17 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
             </div>
           </div>
           <div className="flex max-w-full flex-wrap items-center gap-2">
+            <WatchButton token={l} labelled />
             <CopyChip value={l.token} className="!min-h-9 !rounded-lg" />
             <a href={explorerAddress(chain, l.token)} target="_blank" rel="noreferrer" className={utility}>{explorerName(chain)}<ArrowUpRight size={12} /></a>
             <a href={`https://x.com/intent/post?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(`${SITE_URL}/t/${chain}/${l.token}`)}`} target="_blank" rel="noreferrer" className={utility} aria-label="Share token on X"><Share2 size={13} /> Share</a>
           </div>
         </header>
 
-        <div className="grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_21rem] lg:gap-6 lg:grid-rows-[min-content_1fr]">
+        <div className="grid items-start gap-7 lg:grid-cols-[minmax(0,1fr)_21rem] lg:gap-x-8 lg:gap-y-7 lg:grid-rows-[min-content_1fr]">
           <div className="min-w-0 lg:col-start-1 lg:row-start-1">
             <PriceChart key={`${chain}:${l.token}`} chain={chain} token={l.token} symbol={l.symbol} launchedAt={l.block_time} />
-            <dl className="mt-4 grid grid-cols-2 divide-x divide-line overflow-hidden rounded-xl border border-line bg-card sm:grid-cols-4">
+            <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-4 border-y border-line py-4 sm:grid-cols-4">
               <Stat k={priceUsd !== null ? "Price / USD" : `Price / ${quote.symbol}`} v={priceUsd !== null ? fmtUsd(priceUsd) : `${fmtPrice(l.price_quote)} ${quote.symbol}`} sub={`${fmtPrice(l.price_quote)} ${quote.symbol}`} />
               <Stat k="Volume / all time" v={l.volume_usd !== null ? marketUsd(l.volume_usd) : fmtQuote(l.volume_quote, quote.decimals, quote.symbol)} sub={fmtQuote(l.volume_quote, quote.decimals, quote.symbol)} />
               <Stat k="Buys / sells" v={<><span className="text-up">{count(l.buys)}</span><span className="px-1 text-muted">/</span><span className="text-down-ink">{count(l.sells)}</span></>} sub={`${count(l.buys + l.sells)} total trades`} />
@@ -134,7 +136,7 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
             </dl>
           </div>
 
-          <aside className="min-w-0 space-y-4 lg:sticky lg:top-24 lg:col-start-2 lg:row-span-2 lg:row-start-1">
+          <aside className="min-w-0 space-y-6 lg:sticky lg:top-24 lg:col-start-2 lg:row-span-2 lg:row-start-1">
             <TradePanel chain={chain} token={l.token as Address} symbol={l.symbol} poolKey={poolKey} quote={quote} ethUsd={usd} />
             <LaunchReceipt chain={chain} symbol={l.symbol} supply={supplyLabel} txHash={l.tx_hash} />
             <CollectPanel chain={chain} quote={quote} tokenId={l.token_id} symbol={l.symbol} lpFee={l.lp_fee} recipients={l.recipients} collectedQuote={l.fees_quote_collected} burnedQuote={l.fees_quote_burned} burnedToken={l.fees_token_burned} ethUsd={usd} />
@@ -145,7 +147,7 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
               trades={<TokenTrades chain={chain} symbol={l.symbol} quote={quote} swaps={swaps} now={now} />}
               holders={<HoldersPanel chain={chain} symbol={l.symbol} p={holders} embedded />}
               conversation={<TokenComments chain={chain} token={l.token} symbol={l.symbol} launcher={l.launcher} embedded />}
-              about={<section className="p-5">
+              about={<section className="py-6">
                 <h2 className="text-base font-semibold text-ink">Behind {l.symbol}</h2>
                 <p className="mt-2 max-w-xl whitespace-pre-wrap break-words text-sm leading-relaxed text-body text-pretty">{l.description || "The creator has not added a description yet. The contract details below are recorded on-chain."}</p>
                 <div className="mt-4 flex flex-wrap gap-2">
@@ -176,7 +178,7 @@ export default async function TokenPage({ params }: { params: Promise<{ chain: s
 }
 
 function Stat({ k, v, sub }: { k: string; v: React.ReactNode; sub: string }) {
-  return <div className="min-w-0 px-4 py-3"><dt className="text-[10px] text-muted">{k}</dt><dd className="mt-1 truncate font-mono text-sm font-bold text-ink tnum">{v}</dd><dd className="mt-1 truncate font-mono text-[10px] text-muted tnum" title={sub}>{sub}</dd></div>;
+  return <div className="min-w-0"><dt className="text-[11px] text-muted">{k}</dt><dd className="mt-1.5 truncate font-mono text-sm font-bold text-ink tnum">{v}</dd><dd className="mt-1 truncate font-mono text-[10px] text-muted tnum" title={sub}>{sub}</dd></div>;
 }
 function Row({ k, v }: { k: string; v: React.ReactNode }) {
   return <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 py-3"><dt className="text-muted">{k}</dt><dd className="min-w-0 break-words text-right font-mono text-body tnum">{v}</dd></div>;

--- a/app/src/components/Footer.module.css
+++ b/app/src/components/Footer.module.css
@@ -1,6 +1,6 @@
-.footer { margin-top: 48px; padding: 0 16px 24px; scroll-margin-top: 80px; color: var(--color-body); }
-.shell { max-width: 1120px; margin-inline: auto; border-top: 1px solid var(--color-line-strong); }
-.main { display: grid; grid-template-columns: 1.1fr 1fr; gap: 64px; padding: 48px 0 40px; }
+.footer { margin-top: 48px; padding: 0 var(--workspace-gutter) 24px; scroll-margin-top: 80px; color: var(--color-body); }
+.shell { border-top: 1px solid var(--color-line-strong); }
+.main { display: grid; grid-template-columns: 1.1fr 1fr; max-width: 1120px; margin-inline: auto; gap: 64px; padding: 48px 0 40px; }
 .eyebrow { display: flex; align-items: center; gap: 10px; color: var(--color-muted); font-size: 12px; }
 .eyebrow > span { display: flex; }
 .heading { margin-top: 20px; color: var(--color-ink); font-size: 36px; font-weight: 650; line-height: 1.12; letter-spacing: -.045em; }
@@ -19,7 +19,7 @@
 .navLink:is(:hover, :focus-visible) svg { color: var(--color-brand); transform: translateX(2px); }
 .internalArrow { opacity: 0; }
 .navLink:is(:hover, :focus-visible) .internalArrow { opacity: 1; }
-.proof { display: grid; grid-template-columns: 1.1fr 1fr 1fr; border-block: 1px solid var(--color-line); padding-block: 24px; gap: 28px; }
+.proof { display: grid; grid-template-columns: 1.1fr 1fr 1fr; max-width: 1120px; margin-inline: auto; border-block: 1px solid var(--color-line); padding-block: 24px; gap: 28px; }
 .proofIntro { display: flex; align-items: center; gap: 12px; }
 .proofIntro > svg { flex-shrink: 0; color: var(--color-muted); }
 .proofTitle { color: var(--color-ink); font-size: 13px; font-weight: 500; }

--- a/app/src/components/HeaderNav.tsx
+++ b/app/src/components/HeaderNav.tsx
@@ -24,23 +24,21 @@ const NAV = [
 type Pulse = { visits: number; online: number };
 
 /**
- * Site header: a floating instrument strip. Full-width hairline row at rest;
- * past 100px of scroll the navigation shell contracts it into a
- * centred pill that rides over the content, keeping the launch CTA and wallet
- * one reach away. `Navbar` injects `visible` into its direct children, which
- * is how the strip knows to drop the wordmark and shorten the CTA when it is
- * floating and has ~800px to work with.
+ * Market pages keep a docked, edge-aligned instrument strip. Reading and
+ * account pages retain the floating navigation. `Navbar` injects `visible`
+ * into its direct children to signal the compact floating state.
  */
 export default function HeaderNav({ pulse }: { pulse: Pulse }) {
   const pathname = usePathname();
+  const workspace = pathname === "/" || pathname.startsWith("/t/");
   const isActive = (href: string) => (href === "/" ? pathname === "/" || pathname.startsWith("/t/") : pathname.startsWith(href));
   const heroCtaOnScreen = useHeroCtaOnScreen(pathname);
 
   return (
     <MotionConfig reducedMotion="user">
-      <Navbar className="top-0">
-        <Desktop pulse={pulse} isActive={isActive} quietCta={heroCtaOnScreen} />
-        <Mobile key={pathname} pulse={pulse} isActive={isActive} />
+      <Navbar className="top-0" docked={workspace}>
+        <Desktop workspace={workspace} pulse={pulse} isActive={isActive} quietCta={heroCtaOnScreen} />
+        <Mobile key={pathname} workspace={workspace} pulse={pulse} isActive={isActive} />
       </Navbar>
     </MotionConfig>
   );
@@ -70,16 +68,17 @@ function useHeroCtaOnScreen(pathname: string) {
 
 // ── desktop ──────────────────────────────────────────────────────────────────
 
-function Desktop({ visible = false, pulse, isActive, quietCta }: { visible?: boolean; pulse: Pulse; isActive: (href: string) => boolean; quietCta: boolean }) {
+function Desktop({ visible = false, workspace, pulse, isActive, quietCta }: { visible?: boolean; workspace: boolean; pulse: Pulse; isActive: (href: string) => boolean; quietCta: boolean }) {
   return (
     <NavBody
       visible={visible}
       className={cn(
         "border border-line transition-colors",
-        // At rest: a full-width hairline ROW, content padded to the page column
-        // (max-w-6xl minus its px-4). Floating: a bordered card pill over the
-        // content. The shell animates the width and corner radius together.
-        visible
+        // Workspaces share the market gutters; other routes retain their
+        // readable page-column alignment and floating pill.
+        workspace
+          ? "workspace-shell max-w-none border-x-0 border-t-0 bg-paper dark:bg-paper"
+          : visible
           ? "max-w-6xl px-3 bg-card/90 dark:bg-card/90"
           : "max-w-none border-x-0 border-t-0 px-[max(16px,calc((100vw-1120px)/2))] bg-paper dark:bg-paper",
       )}
@@ -97,7 +96,7 @@ function Desktop({ visible = false, pulse, isActive, quietCta }: { visible?: boo
 
       <NavLinks isActive={isActive} compact={visible} />
 
-      <div className="relative z-20 ml-auto flex items-center gap-2">
+      <div className={cn("relative z-20 flex items-center gap-2", !workspace && "ml-auto")}>
         <ThemeToggle />
         <ConnectButton />
         {/* while the hero's CTA is on screen it owns the one filled blue; this one fills in once that has scrolled away */}
@@ -202,7 +201,7 @@ function XLink({ block = false }: { block?: boolean }) {
 
 // ── mobile ───────────────────────────────────────────────────────────────────
 
-function Mobile({ visible = false, pulse, isActive }: { visible?: boolean; pulse: Pulse; isActive: (href: string) => boolean }) {
+function Mobile({ visible = false, workspace, pulse, isActive }: { visible?: boolean; workspace: boolean; pulse: Pulse; isActive: (href: string) => boolean }) {
   const [open, setOpen] = useState(false);
   const menuToggle = useRef<HTMLButtonElement>(null);
   const dismissMenu = useCallback(() => {
@@ -212,10 +211,11 @@ function Mobile({ visible = false, pulse, isActive }: { visible?: boolean; pulse
   return (
     <MobileNav
       visible={visible}
+      docked={workspace}
       className={cn(
         "border border-line transition-colors",
         // same story as desktop: full-bleed hairline row at rest, pill while floating
-        visible ? "max-w-[calc(100vw-2rem)] bg-card/90 dark:bg-card/90" : "max-w-none border-x-0 border-t-0 bg-paper dark:bg-paper",
+        workspace ? "workspace-shell max-w-none border-x-0 border-t-0 bg-paper dark:bg-paper" : visible ? "max-w-[calc(100vw-2rem)] bg-card/90 dark:bg-card/90" : "max-w-none border-x-0 border-t-0 bg-paper dark:bg-paper",
       )}
     >
       <MobileNavHeader>

--- a/app/src/components/Skeleton.tsx
+++ b/app/src/components/Skeleton.tsx
@@ -10,12 +10,13 @@ export function Sk({ className = "", style }: { className?: string; style?: Reac
 /** One launch row, matching LaunchRow's grid. */
 export function SkRow({ i, ledger = false }: { i: number; ledger?: boolean }) {
   if (ledger) return (
-    <li className="border-t border-line px-4 py-3.5">
-      <div className="grid grid-cols-[minmax(0,1fr)_7rem] items-center gap-3 md:grid-cols-[minmax(0,1fr)_6.5rem_5.5rem_6rem_5rem_2.5rem]">
+    <li className="relative border-t border-line pl-11 pr-2 py-3">
+      <Sk className="absolute left-3 top-6 h-4 w-4" />
+      <div className="launch-ledger grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3">
         <div className="flex min-w-0 items-center gap-2.5"><Sk className="h-9 w-9 shrink-0 rounded-lg" /><div className="min-w-0 flex-1 space-y-2"><Sk className="h-3.5 w-3/4" /><Sk className="h-2.5 w-full max-w-32" /><Sk className="h-2.5 w-2/3" /></div></div>
         <div className="space-y-2"><Sk className="ml-auto h-3.5 w-16" /><Sk className="ml-auto h-2.5 w-14" /></div>
-        {[0, 1, 2, 3].map((n) => <Sk key={n} className="ml-auto hidden h-3 w-full max-w-12 md:block" />)}
-        <div className="col-span-2 grid grid-cols-4 gap-4 border-t border-line pt-3 md:hidden">{[0, 1, 2, 3].map((n) => <div key={n} className="space-y-2"><Sk className="h-2 w-full" /><Sk className="h-3 w-3/4" /></div>)}</div>
+        {[0, 1, 2, 3].map((n) => <Sk key={n} className={`ml-auto hidden h-3 w-full max-w-12 ${n === 0 || n === 3 ? "lg:block" : "sm:block"}`} />)}
+        <div className="col-span-2 grid grid-cols-4 gap-2 pt-1 sm:hidden">{[0, 1, 2, 3].map((n) => <div key={n} className="space-y-2"><Sk className="h-2 w-full" /><Sk className="h-3 w-3/4" /></div>)}</div>
       </div>
     </li>
   );
@@ -67,13 +68,13 @@ export function SkPost({ i = 0, avatar = "round" }: { i?: number; avatar?: "roun
 
 /**
  * One community-feed post (CommunityFeed.tsx `.post`): 40px wallet avatar + author heading, a 15px body
- * (26px line pitch), the 20px token tile line and the "Open conversation" line. Same 24px padding
- * (20px 16px on phones) so the real post lands exactly where its placeholder was.
+ * (26px line pitch), the 20px token tile line and the "Open conversation" line.
+ * Open rows use 28px vertical padding, 24px on phones, with no inset container.
  */
 export function SkFeedPost({ i }: { i: number }) {
   const lines = 1 + (i % 2);
   return (
-    <li className="border-t border-line first:border-t-0 px-4 py-5 sm:p-6">
+    <li className="border-t border-line first:border-t-0 py-6 sm:py-7">
       <div className="flex items-center gap-3">
         <Sk className="h-10 w-10 shrink-0 rounded-full" />
         <div className="min-w-0 flex-1">

--- a/app/src/components/Skeleton.tsx
+++ b/app/src/components/Skeleton.tsx
@@ -10,13 +10,15 @@ export function Sk({ className = "", style }: { className?: string; style?: Reac
 /** One launch row, matching LaunchRow's grid. */
 export function SkRow({ i, ledger = false }: { i: number; ledger?: boolean }) {
   if (ledger) return (
-    <li className="relative border-t border-line pl-11 pr-2 py-3">
+    <li className="relative min-h-[5.25rem] border-b border-line py-3 pl-12 pr-3 sm:min-h-[5.5rem]">
       <Sk className="absolute left-3 top-6 h-4 w-4" />
-      <div className="launch-ledger grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3">
-        <div className="flex min-w-0 items-center gap-2.5"><Sk className="h-9 w-9 shrink-0 rounded-lg" /><div className="min-w-0 flex-1 space-y-2"><Sk className="h-3.5 w-3/4" /><Sk className="h-2.5 w-full max-w-32" /><Sk className="h-2.5 w-2/3" /></div></div>
-        <div className="space-y-2"><Sk className="ml-auto h-3.5 w-16" /><Sk className="ml-auto h-2.5 w-14" /></div>
-        {[0, 1, 2, 3].map((n) => <Sk key={n} className={`ml-auto hidden h-3 w-full max-w-12 ${n === 0 || n === 3 ? "lg:block" : "sm:block"}`} />)}
-        <div className="col-span-2 grid grid-cols-4 gap-2 pt-1 sm:hidden">{[0, 1, 2, 3].map((n) => <div key={n} className="space-y-2"><Sk className="h-2 w-full" /><Sk className="h-3 w-3/4" /></div>)}</div>
+      <div className="launch-ledger grid grid-cols-[minmax(0,1fr)_6.5rem] items-center gap-x-3 gap-y-2">
+        <div className="flex min-w-0 items-center gap-3"><Sk className="h-11 w-11 shrink-0 rounded-xl" /><div className="min-w-0 flex-1 space-y-1.5"><Sk className="h-3.5 w-3/4" /><Sk className="h-2.5 w-full max-w-36" /><Sk className="hidden h-2.5 w-4/5 sm:block" /></div></div>
+        <div className="space-y-1.5"><div className="flex justify-end gap-2"><Sk className="h-4 w-16" /><Sk className="h-3 w-8" /></div><Sk className="ml-auto h-2.5 w-14" /></div>
+        <div className="hidden space-y-1.5 lg:block"><Sk className="ml-auto h-3.5 w-14" /><Sk className="ml-auto h-2.5 w-10" /></div>
+        <div className="ml-auto hidden space-y-1.5 sm:block"><Sk className="ml-auto h-3 w-24" /><Sk className="ml-auto h-2.5 w-28" /></div>
+        <Sk className="col-span-2 h-2.5 w-4/5 sm:hidden" />
+        <div className="col-span-2 grid grid-cols-2 items-end gap-3 sm:hidden"><div className="space-y-1.5"><Sk className="h-2 w-16" /><Sk className="h-3 w-12" /></div><div className="space-y-1.5"><Sk className="ml-auto h-3 w-24" /><Sk className="ml-auto h-2.5 w-16" /></div></div>
       </div>
     </li>
   );

--- a/app/src/components/feed-loading.test.ts
+++ b/app/src/components/feed-loading.test.ts
@@ -24,12 +24,12 @@ test("the /feed skeleton mirrors every layout region of FeedPage + CommunityFeed
   for (const cls of ["shell.page", "shell.intro", "shell.introRow", "shell.introCopy", "shell.panel"]) {
     assert.match(loading, new RegExp(`className=\\{[^}]*\\b${cls.replace(".", "\\.")}\\b`), `loader uses ${cls}`);
   }
-  for (const cls of ["layout", "toolbar", "filters", "resultLine", "feedFoot", "aside", "guide", "steps", "note", "caution"]) {
+  for (const cls of ["layout", "controls", "toolbar", "filters", "resultLine", "feedFoot", "aside", "guide", "steps", "note", "caution"]) {
     assert.match(loading, new RegExp(`\\bstyles\\.${cls}\\b`), `loader uses styles.${cls}`);
     assert.match(feed, new RegExp(`\\bstyles\\.${cls}\\b`), `CommunityFeed still defines the region styles.${cls}`);
   }
   // Regions appear in the same order as the real markup.
-  const order = ["shell.intro", "styles.layout", "shell.panel", "styles.toolbar", "styles.filters", "styles.resultLine", "<SkFeedPost", "styles.feedFoot", "styles.aside", "styles.guide", "styles.note"];
+  const order = ["shell.intro", "styles.layout", "shell.panel", "styles.controls", "styles.toolbar", "styles.filters", "styles.resultLine", "<SkFeedPost", "styles.feedFoot", "styles.aside", "styles.guide", "styles.note"];
   const positions = order.map((token) => loading.indexOf(token));
   assert.ok(positions.every((p) => p >= 0));
   assert.deepEqual(positions, [...positions].sort((a, b) => a - b), "loader regions are in page order");
@@ -47,7 +47,8 @@ test("SkFeedPost matches the real post anatomy: 40px round avatar, body, 20px to
   assert.ok(block.length > 0);
   assert.match(block, /h-10 w-10 shrink-0 rounded-full/, "40px wallet avatar");
   assert.match(block, /h-5 w-5 shrink-0 rounded-md/, "20px token tile");
-  assert.match(block, /px-4 py-5 sm:p-6/, "24px padding, 20px 16px on phones, like .postLink");
+  assert.match(block, /py-6 sm:py-7/, "open rows match the feed spacing");
+  assert.doesNotMatch(block, /px-[1-9]|sm:p-[1-9]/, "post loading has no horizontal card inset");
   assert.match(feed, /<WalletAvatar address=\{post\.wallet\} size=\{40\}/);
   assert.match(feed, /<TokenAvatar[^>]*size=\{20\}/);
   assert.match(block, /mt-\[18px\]/, "body and meta keep the 18px rhythm of .postBody / .postMeta");

--- a/app/src/components/launchpad/ChainSelector.tsx
+++ b/app/src/components/launchpad/ChainSelector.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronDown, Layers2 } from "lucide-react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/vendor/toggle-group";
+import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from "@/components/vendor/popover";
+import { CHAIN_SHORT, type ChainKey } from "@/lib/chainPublic";
+
+/** Compact, keyboard-accessible network selection shared by browsing surfaces. */
+export default function ChainSelector({ value, onChange, label = "Chain" }: { value: ChainKey | null; onChange: (chain: ChainKey | null) => void; label?: string }) {
+  const [open, setOpen] = useState(false);
+  return <Popover open={open} onOpenChange={setOpen}>
+    <PopoverTrigger aria-label={`${label}: ${value ? CHAIN_SHORT[value] : "All chains"}`} className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-lg px-3 text-xs font-medium text-body transition-colors hover:bg-card hover:text-ink data-popup-open:bg-card motion-reduce:transition-none">
+      <Layers2 size={14} aria-hidden="true" /><span>{value ? CHAIN_SHORT[value] : "All chains"}</span><ChevronDown size={13} aria-hidden="true" className="text-muted" />
+    </PopoverTrigger>
+    <PopoverContent className="w-56 p-2">
+      <PopoverTitle className="px-3 pb-2 pt-2 text-xs font-semibold text-muted">{label}</PopoverTitle>
+      <ToggleGroup aria-label={label} orientation="vertical" value={[value ?? "all"]} onValueChange={(values) => { if (!values[0]) return; onChange(values[0] === "all" ? null : values[0] as ChainKey); setOpen(false); }} className="flex w-full flex-col items-stretch gap-1">
+        {([null, "base", "robinhood"] as const).map((chain) => <ToggleGroupItem key={chain ?? "all"} value={chain ?? "all"} className="min-h-11 w-full justify-between px-3 text-sm">
+          {chain ? CHAIN_SHORT[chain] : "All chains"}{chain === value ? <Check size={14} aria-hidden="true" /> : null}
+        </ToggleGroupItem>)}
+      </ToggleGroup>
+    </PopoverContent>
+  </Popover>;
+}

--- a/app/src/components/launchpad/ChainSelector.tsx
+++ b/app/src/components/launchpad/ChainSelector.tsx
@@ -10,7 +10,7 @@ import { CHAIN_SHORT, type ChainKey } from "@/lib/chainPublic";
 export default function ChainSelector({ value, onChange, label = "Chain" }: { value: ChainKey | null; onChange: (chain: ChainKey | null) => void; label?: string }) {
   const [open, setOpen] = useState(false);
   return <Popover open={open} onOpenChange={setOpen}>
-    <PopoverTrigger aria-label={`${label}: ${value ? CHAIN_SHORT[value] : "All chains"}`} className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-lg px-3 text-xs font-medium text-body transition-colors hover:bg-card hover:text-ink data-popup-open:bg-card motion-reduce:transition-none">
+    <PopoverTrigger aria-label={`${label}: ${value ? CHAIN_SHORT[value] : "All chains"}`} className="ui-pressable inline-flex min-h-11 shrink-0 items-center gap-2 rounded-lg px-3 text-[13px] font-medium text-body hover:bg-card hover:text-ink data-popup-open:bg-card motion-reduce:transition-none">
       <Layers2 size={14} aria-hidden="true" /><span>{value ? CHAIN_SHORT[value] : "All chains"}</span><ChevronDown size={13} aria-hidden="true" className="text-muted" />
     </PopoverTrigger>
     <PopoverContent className="w-56 p-2">

--- a/app/src/components/launchpad/CollectPanel.tsx
+++ b/app/src/components/launchpad/CollectPanel.tsx
@@ -100,7 +100,7 @@ export default function CollectPanel({
   const myClaimable = (mine.data as bigint | undefined) ?? 0n;
 
   return (
-    <section className="rounded-2xl bg-paper border border-line p-5 space-y-3">
+    <section className="space-y-4 border-t border-line pt-5">
       <div className="flex items-baseline justify-between gap-3">
         <h2 className="text-sm font-semibold text-ink">Where the fees go</h2>
         <span className="font-mono font-bold text-ink tnum">{pipsToPct(lpFee)}</span>
@@ -131,15 +131,15 @@ export default function CollectPanel({
               );
             })}
           </ul>
-          <dl className="grid grid-cols-2 gap-2 pt-1">
-            <div className="rounded-xl bg-paper border border-line px-3 py-2.5">
+          <dl className="grid grid-cols-2 gap-4 border-y border-line py-4">
+            <div className="min-w-0 space-y-1">
               <dt className="text-[11px] text-muted">{isBurnOnly ? "Burned so far" : "Collected so far"}</dt>
-              <dd className="font-mono font-bold text-sm tnum text-ink">{fq(isBurnOnly ? burned : collected)}</dd>
+              <dd className="break-words font-mono font-bold text-sm tnum text-ink">{fq(isBurnOnly ? burned : collected)}</dd>
               {usd(isBurnOnly ? burned : collected) ? <dd className="text-[11px] font-mono text-muted tnum">{usd(isBurnOnly ? burned : collected)}</dd> : null}
             </div>
-            <div className="rounded-xl bg-paper border border-line px-3 py-2.5">
+            <div className="min-w-0 space-y-1 border-l border-line pl-4">
               <dt className="text-[11px] text-muted">{isBurnOnly ? `${symbol} burned` : "Burned"}</dt>
-              <dd className="font-mono font-bold text-sm tnum text-warm-ink">{isBurnOnly ? fmtTokens(BigInt(burnedToken)) : fq(burned)}</dd>
+              <dd className="break-words font-mono font-bold text-sm tnum text-warm-ink">{isBurnOnly ? fmtTokens(BigInt(burnedToken)) : fq(burned)}</dd>
               {!isBurnOnly ? <dd className="text-[11px] font-mono text-muted tnum">to people: {fq(toPeople)}</dd> : null}
             </div>
           </dl>
@@ -159,7 +159,7 @@ export default function CollectPanel({
         </>
       )}
       {phase.k === "error" ? (
-        <p className="rounded-xl bg-down-soft border border-down/20 text-down-ink text-xs px-3 py-2" role="alert">
+        <p className="rounded-lg bg-down-soft text-down-ink text-xs px-3 py-2" role="alert">
           {phase.message}
         </p>
       ) : null}

--- a/app/src/components/launchpad/LaunchBrowser.module.css
+++ b/app/src/components/launchpad/LaunchBrowser.module.css
@@ -1,0 +1,114 @@
+.market {
+  position: relative;
+  isolation: isolate;
+}
+
+.market::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: 0 -1rem auto;
+  height: 13rem;
+  background:
+    radial-gradient(circle at 8% 0%, color-mix(in srgb, var(--color-brand) 9%, transparent), transparent 42%),
+    linear-gradient(180deg, color-mix(in srgb, var(--color-card) 55%, transparent), transparent 88%);
+  pointer-events: none;
+}
+
+.header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem 0 1.25rem;
+  border-top: 1px solid var(--color-line);
+}
+
+.kicker {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+  margin-bottom: .45rem;
+  color: var(--color-muted);
+  font-size: .72rem;
+  font-weight: 600;
+  letter-spacing: .045em;
+  text-transform: uppercase;
+}
+
+.liveDot {
+  position: relative;
+  width: .42rem;
+  height: .42rem;
+  border-radius: 999px;
+  background: var(--color-up);
+}
+
+.title {
+  color: var(--color-ink);
+  font-size: clamp(1.45rem, 2.1vw, 2rem);
+  font-weight: 650;
+  line-height: 1.05;
+  letter-spacing: -.035em;
+  text-wrap: balance;
+}
+
+.subtitle {
+  max-width: 34rem;
+  margin-top: .55rem;
+  color: var(--color-muted);
+  font-size: .82rem;
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
+.viewTabs {
+  flex: 0 0 auto;
+  background: transparent;
+}
+
+.viewTabs :global(.ui-tab-indicator) {
+  z-index: 0;
+  bottom: -1px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--color-brand);
+}
+
+.viewTab {
+  position: relative;
+  z-index: 1;
+  min-height: 2.75rem;
+  border-radius: 0;
+  color: var(--color-muted);
+  font-size: .78rem;
+  font-weight: 600;
+}
+
+.savedCount {
+  min-width: .8rem;
+  color: var(--color-muted);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: .68rem;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 639px) {
+  .market::before { inset-inline: -.25rem; }
+  .header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: .65rem;
+    padding-block: 1rem .75rem;
+  }
+  .kicker,
+  .subtitle { display: none; }
+  .title { font-size: 1.35rem; }
+  .viewTabs { align-self: stretch; }
+  .viewTabs :global(.ui-tab-indicator) { bottom: -1px; }
+  .viewTab { min-height: 2.75rem; flex: 1 1 50%; justify-content: center; border-bottom: 1px solid var(--color-line); border-radius: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .liveDot::after { animation: none; }
+}

--- a/app/src/components/launchpad/LaunchBrowser.tsx
+++ b/app/src/components/launchpad/LaunchBrowser.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Star } from "lucide-react";
+import { Tabs, TabsList, TabsPanel, TabsTab } from "@/components/vendor/tabs";
+import { useWatchlist } from "./useWatchlist";
+import WatchlistPanel from "./WatchlistPanel";
+
+export default function LaunchBrowser({ children }: { children: ReactNode }) {
+  const params = useSearchParams();
+  const router = useRouter();
+  const { entries, ready } = useWatchlist();
+  const view = params.get("view") === "watchlist" ? "watchlist" : "all";
+  function select(value: unknown) {
+    const next = new URLSearchParams(params);
+    if (value === "watchlist") next.set("view", "watchlist");
+    else next.delete("view");
+    router.replace(`/${next.size ? `?${next}` : ""}#launches`, { scroll: false });
+  }
+  return (
+    <Tabs id="launches" value={view} onValueChange={select} className="min-w-0 scroll-mt-24">
+      <TabsList aria-label="Launch browser" className="gap-6 px-0">
+        <TabsTab value="all">All launches</TabsTab>
+        <TabsTab value="watchlist"><Star size={15} aria-hidden="true" /> Watchlist <span className="font-mono text-xs text-muted tnum">{ready ? entries.length : ""}</span></TabsTab>
+      </TabsList>
+      <TabsPanel value="all" keepMounted>{children}</TabsPanel>
+      <TabsPanel value="watchlist"><WatchlistPanel onBrowse={() => select("all")} /></TabsPanel>
+    </Tabs>
+  );
+}

--- a/app/src/components/launchpad/LaunchBrowser.tsx
+++ b/app/src/components/launchpad/LaunchBrowser.tsx
@@ -6,6 +6,7 @@ import { Star } from "lucide-react";
 import { Tabs, TabsList, TabsPanel, TabsTab } from "@/components/vendor/tabs";
 import { useWatchlist } from "./useWatchlist";
 import WatchlistPanel from "./WatchlistPanel";
+import styles from "./LaunchBrowser.module.css";
 
 export default function LaunchBrowser({ children }: { children: ReactNode }) {
   const params = useSearchParams();
@@ -19,11 +20,18 @@ export default function LaunchBrowser({ children }: { children: ReactNode }) {
     router.replace(`/${next.size ? `?${next}` : ""}#launches`, { scroll: false });
   }
   return (
-    <Tabs id="launches" value={view} onValueChange={select} className="min-w-0 scroll-mt-24">
-      <TabsList aria-label="Launch browser" className="gap-6 px-0">
-        <TabsTab value="all">All launches</TabsTab>
-        <TabsTab value="watchlist"><Star size={15} aria-hidden="true" /> Watchlist <span className="font-mono text-xs text-muted tnum">{ready ? entries.length : ""}</span></TabsTab>
-      </TabsList>
+    <Tabs id="launches" value={view} onValueChange={select} className={`${styles.market} min-w-0 scroll-mt-24`}>
+      <header className={styles.header}>
+        <div className="min-w-0">
+          <div className={styles.kicker}><span className={`${styles.liveDot} bb-beacon`} aria-hidden="true" />Open market</div>
+          <h2 className={styles.title}>Markets, live onchain.</h2>
+          <p className={styles.subtitle}>From first block to first buyer, every launch stays visible.</p>
+        </div>
+        <TabsList aria-label="Launch browser" className={`${styles.viewTabs} gap-0 overflow-visible rounded-xl border-0 p-1`}>
+          <TabsTab value="all" className={`${styles.viewTab} min-h-10 border-0 px-3`}>Market</TabsTab>
+          <TabsTab value="watchlist" className={`${styles.viewTab} min-h-10 border-0 px-3`}><Star size={14} aria-hidden="true" /> Saved <span className={styles.savedCount}>{ready ? entries.length : ""}</span></TabsTab>
+        </TabsList>
+      </header>
       <TabsPanel value="all" keepMounted>{children}</TabsPanel>
       <TabsPanel value="watchlist"><WatchlistPanel onBrowse={() => select("all")} /></TabsPanel>
     </Tabs>

--- a/app/src/components/launchpad/LaunchForm.tsx
+++ b/app/src/components/launchpad/LaunchForm.tsx
@@ -10,7 +10,7 @@ import ImageUpload from "./ImageUpload";
 import FeeChip from "./FeeChip";
 import GitlawbBadge from "./GitlawbBadge";
 import { toast } from "./TxToasts";
-import { btn, card, helper, input, label } from "@/components/ui";
+import { btn, helper, input, label } from "@/components/ui";
 import { ERC20_MIN_ABI, ERC20_TRANSFER_EVENT, LAUNCH_FACTORY_ABI, PERMIT2_ABI, UNIVERSAL_ROUTER_ABI, V4_QUOTER_ABI } from "@/lib/launchpad/abi";
 import { BPS, DEFAULT_SUPPLY, FEE_PRESETS, TICK_SPACING, launchpad, quoteUsdOf, type Quote } from "@/lib/launchpad/config";
 import { capChipLabel, capDisplay, capEntry, capPick, capPresets, capToQuote } from "@/lib/launchpad/market-cap";
@@ -372,21 +372,21 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
 
 
   return (
-    <div className="grid lg:grid-cols-[minmax(0,1fr)_22rem] gap-6 lg:gap-8 items-start">
+    <div className="grid items-start gap-12 lg:grid-cols-[minmax(0,1fr)_22rem] xl:gap-16">
       <form
-        className="space-y-6 min-w-0"
+        className="min-w-0 divide-y divide-line"
         onSubmit={(e) => {
           e.preventDefault();
           void launch();
         }}
       >
         {/* chain + quote */}
-        <section className={`${card} p-5 space-y-4`}>
+        <section className="space-y-5 pb-8">
           <div className="flex items-baseline justify-between gap-3 flex-wrap">
-            <h2 className="text-sm font-semibold text-ink">Chain</h2>
+            <h2 className="text-base font-semibold text-ink">Chain</h2>
             <span className="text-xs text-muted">same contracts, same rules, on both</span>
           </div>
-          <div className="grid sm:grid-cols-2 gap-2">
+          <div className="grid gap-3 sm:grid-cols-2">
             {CHAIN_KEYS.map((k) => {
               const active = chain === k;
               const ok = launchpad(k).configured;
@@ -406,11 +406,11 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                     setMcapPick(null);
                     setCustomMcap("");
                   }}
-                  className={`text-left rounded-xl border p-3.5 transition-colors disabled:opacity-40 ${active ? "border-brand bg-brand-soft" : "border-line-strong bg-card hover:border-ink/40"}`}
+                  className={`border-b-2 px-3 py-3 text-left transition-colors disabled:opacity-40 ${active ? "border-brand bg-brand-soft" : "border-line hover:border-line-strong hover:bg-card"}`}
                   aria-pressed={active}
                 >
                   <div className={`font-semibold text-sm ${active ? "text-brand" : "text-ink"}`}>{CHAIN_LABELS[k]}</div>
-                  <div className="text-xs text-body mt-0.5 leading-snug">{k === "base" ? "Priced in ETH, GITLAWB or a Coinbase tokenized stock. Gas ≈ cents." : ok ? "Priced in USDG (dollars), ETH, GITLAWB or a Robinhood Stock Token. Gas ≈ cents." : "Coming soon."}</div>
+                  <div className={`mt-1 text-xs leading-relaxed ${active ? "text-brand" : "text-body"}`}>{k === "base" ? "Priced in ETH, GITLAWB or a Coinbase tokenized stock. Gas ≈ cents." : ok ? "Priced in USDG (dollars), ETH, GITLAWB or a Robinhood Stock Token. Gas ≈ cents." : "Coming soon."}</div>
                 </button>
               );
             })}
@@ -419,7 +419,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
           {cfg.quotes.length > 0 ? (
             <div className="flex items-center gap-2 flex-wrap">
               <span className={label}>Priced in</span>
-              <div className="flex items-center rounded-full border border-line bg-card p-0.5" role="group" aria-label="quote asset">
+              <div className="flex flex-wrap items-center gap-1" role="group" aria-label="quote asset">
                 {[...cfg.quotes.map((q) => ({ key: q.key, label: q.symbol })), { key: "stock" as const, label: "Stock" }].map((q) => (
                   <button
                     key={q.key}
@@ -429,7 +429,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                       setMcapPick(null);
                       setCustomMcap("");
                     }}
-                    className={`h-8 px-3 rounded-full text-xs font-mono font-bold ${quoteKey === q.key ? "bg-ink text-inverse" : "text-body hover:text-ink"}`}
+                    className={`min-h-11 rounded-lg px-3 text-xs font-mono font-bold ${quoteKey === q.key ? "bg-ink text-inverse" : "text-body hover:bg-card hover:text-ink"}`}
                     aria-pressed={quoteKey === q.key}
                   >
                     {q.label}
@@ -448,7 +448,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
           ) : null}
           {quoteKey === "gitlawb" ? (
             <div className="space-y-2">
-              <span className="inline-flex items-center gap-2 h-9 pl-1.5 pr-3 rounded-full border border-brand bg-brand-soft text-brand text-sm font-semibold">
+              <span className="inline-flex flex-wrap items-center gap-2 py-2 text-brand text-sm font-semibold">
                 {quote.logo ? (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img src={quote.logo} alt="" width={22} height={22} className="rounded-md" />
@@ -467,7 +467,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
             <div className="space-y-2">
               <div className="flex items-center gap-2 flex-wrap">
                 {stock ? (
-                  <span className="inline-flex items-center gap-2 h-9 pl-1.5 pr-3 rounded-full border border-brand bg-brand-soft text-brand text-sm font-semibold">
+                  <span className="inline-flex flex-wrap items-center gap-2 py-2 text-brand text-sm font-semibold">
                     {stock.logo ? (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img src={stock.logo} alt="" width={22} height={22} className={`${stock.logo.startsWith("data:") ? "rounded-md" : "rounded-full"} bg-card`} referrerPolicy="no-referrer" />
@@ -518,7 +518,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                           setMcapPick(null);
                           setCustomMcap("");
                         }}
-                        className="inline-flex items-center gap-1.5 h-8 pl-1.5 pr-2.5 rounded-full border border-line bg-card text-xs font-semibold text-ink hover:border-ink/40"
+                        className="inline-flex min-h-11 items-center gap-1.5 rounded-lg bg-card pl-2 pr-3 text-xs font-semibold text-ink hover:bg-line"
                         title={h.name}
                       >
                         {h.logo ? (
@@ -539,8 +539,8 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
         </section>
 
         {/* identity */}
-        <section className={`${card} p-5 space-y-4`}>
-          <h2 className="text-sm font-semibold text-ink">Token</h2>
+        <section className="space-y-5 py-8">
+          <h2 className="text-base font-semibold text-ink">Token</h2>
           <div className="grid sm:grid-cols-[minmax(0,1fr)_9rem] gap-4">
             <div>
               <label className={label} htmlFor="name">
@@ -585,9 +585,9 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
         </section>
 
         {/* price */}
-        <section className={`${card} p-5 space-y-4`}>
+        <section className="space-y-5 py-8">
           <div className="flex items-baseline justify-between gap-3 flex-wrap">
-            <h2 className="text-sm font-semibold text-ink">Starting market cap</h2>
+            <h2 className="text-base font-semibold text-ink">Starting market cap</h2>
             <span className="text-xs text-muted">1,000,000,000 supply · all of it in the pool</span>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -601,7 +601,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                     setMcapPick(v);
                     setCustomMcap("");
                   }}
-                  className={`h-11 px-4 rounded-xl border font-mono text-sm font-bold tnum ${active ? "bg-ink text-inverse border-ink" : "bg-card text-ink border-line-strong hover:border-ink/40"}`}
+                  className={`min-h-11 rounded-lg px-4 font-mono text-sm font-bold tnum ${active ? "bg-ink text-inverse" : "bg-card text-body hover:bg-line hover:text-ink"}`}
                 >
                   {capChipLabel(v, entry, quote)}
                 </button>
@@ -629,9 +629,9 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
         </section>
 
         {/* fees */}
-        <section className={`${card} p-5 space-y-4`}>
+        <section className="space-y-5 py-8">
           <div className="flex items-baseline justify-between gap-3 flex-wrap">
-            <h2 className="text-sm font-semibold text-ink">Trading fee</h2>
+            <h2 className="text-base font-semibold text-ink">Trading fee</h2>
             <span className="text-xs text-up font-medium">Platform fee: 0, always</span>
           </div>
           <div className="grid sm:grid-cols-3 gap-2">
@@ -645,11 +645,11 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                     setFeePips(f.pips);
                     if (f.pips === 0) setBeneficiary("burn");
                   }}
-                  className={`text-left rounded-xl border p-3.5 transition-colors ${active ? "border-brand bg-brand-soft" : "border-line-strong bg-card hover:border-ink/40"}`}
+                  className={`border-b-2 px-3 py-3 text-left transition-colors ${active ? "border-brand bg-brand-soft" : "border-line hover:border-line-strong hover:bg-card"}`}
                   aria-pressed={active}
                 >
                   <div className={`font-mono font-bold text-lg tnum ${active ? "text-brand" : "text-ink"}`}>{f.label}</div>
-                  <div className="text-xs text-body mt-0.5 leading-snug">{f.blurb}</div>
+                  <div className={`mt-1 text-xs leading-relaxed ${active ? "text-brand" : "text-body"}`}>{f.blurb}</div>
                 </button>
               );
             })}
@@ -672,11 +672,11 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                       type="button"
                       key={o.k}
                       onClick={() => setBeneficiary(o.k)}
-                      className={`text-left rounded-xl border p-3.5 transition-colors ${active ? "border-brand bg-brand-soft" : "border-line-strong bg-card hover:border-ink/40"}`}
+                      className={`border-b-2 px-3 py-3 text-left transition-colors ${active ? "border-brand bg-brand-soft" : "border-line hover:border-line-strong hover:bg-card"}`}
                       aria-pressed={active}
                     >
                       <div className={`font-semibold text-sm ${active ? "text-brand" : "text-ink"}`}>{o.t}</div>
-                      <div className="text-xs text-body mt-0.5 leading-snug">{o.d}</div>
+                      <div className={`mt-1 text-xs leading-relaxed ${active ? "text-brand" : "text-body"}`}>{o.d}</div>
                     </button>
                   );
                 })}
@@ -692,9 +692,9 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
         </section>
 
         {/* submit */}
-        <section className={`${card} p-5 space-y-4`}>
+        <section className="space-y-5 py-8">
           <div className="flex items-baseline justify-between gap-3 flex-wrap">
-            <h2 className="text-sm font-semibold text-ink">
+            <h2 className="text-base font-semibold text-ink">
               First buy <span className="font-normal text-muted">· {buySource === "suggested" ? "suggested" : "optional"}</span>
             </h2>
             <span className="text-xs text-muted">a second transaction, right after the launch confirms</span>
@@ -707,7 +707,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
                   type="button"
                   key={v}
                   onClick={() => (active ? declineFirstBuy() : chooseFirstBuy(v))}
-                  className={`h-11 px-4 rounded-xl border font-mono text-sm font-bold tnum ${active ? "bg-ink text-inverse border-ink" : "bg-card text-ink border-line-strong hover:border-ink/40"}`}
+                  className={`min-h-11 rounded-lg px-4 font-mono text-sm font-bold tnum ${active ? "bg-ink text-inverse" : "bg-card text-body hover:bg-line hover:text-ink"}`}
                 >
                   {fmtQuoteUnits(Number(v), quote.decimals)} {quote.symbol}
                 </button>
@@ -748,9 +748,9 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
           <p className={helper}>Other traders can buy before you. First-buy slippage tolerance: {FIRST_BUY_SLIPPAGE_BPS / 100}%. Network gas and pool fees apply.</p>
         </section>
 
-        <section className={`${card} p-5 space-y-3`}>
+        <section className="space-y-4 pt-8">
           {quoteKey === "stock" && !stock ? (
-            <div className="rounded-xl border border-warm/40 bg-warm-soft px-3.5 py-2.5 text-xs text-warm-ink font-semibold" role="status">
+            <div className="rounded-lg bg-warm-soft px-3.5 py-2.5 text-xs text-warm-ink font-semibold" role="status">
               {STOCK_PICK_MESSAGE}
             </div>
           ) : null}
@@ -784,10 +784,10 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
       </form>
 
       {/* preview */}
-      <aside className="lg:sticky lg:top-20 space-y-4 min-w-0 order-first lg:order-none">
-        <div className={`${card} p-4`}>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">Preview</p>
-          <div className="mt-3 flex items-center gap-3">
+      <aside className="min-w-0 space-y-6 border-t border-line pt-6 lg:sticky lg:top-24 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+        <div>
+          <h2 className="text-base font-semibold text-ink">Preview</h2>
+          <div className="mt-5 flex items-center gap-3">
             <TokenAvatar chain={chain} token={`0x${symbolClean || "token"}`} symbol={symbolClean || "?"} image={/^https:\/\//.test(image.trim()) ? image.trim() : null} size={48} />
             <div className="min-w-0">
               <div className="font-semibold text-ink truncate">{name.trim() || "Your token"}</div>
@@ -799,14 +799,14 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
             </div>
           </div>
           {description.trim() ? <p className="mt-3 text-sm text-body line-clamp-3">{description.trim()}</p> : null}
-          <dl className="mt-4 grid grid-cols-2 gap-2">
+          <dl className="mt-5 grid grid-cols-2 gap-x-5 border-b border-line">
             <Mini k="Opens at" v={fdvPreview !== null ? cap(fdvPreview).main : "—"} sub={fdvPreview !== null ? cap(fdvPreview).detail : CHAIN_LABELS[chain]} />
             <Mini k="First buy" v={initialBuyRaw ? `${initialBuy.trim()} ${quote.symbol}` : "none"} sub={buyPreview ? `${buySource === "suggested" ? "suggested · " : ""}~${fmtPct(buyPreview.pctOfSupply)} of supply` : "pool opens untouched"} />
             <Mini k="Trading fee" v={FEE_PRESETS.find((f) => f.pips === feePips)?.label ?? "—"} sub={feePips === 0 ? "free pool" : beneficiary === "burn" ? "burned" : "to beneficiary"} />
             <Mini k="Platform fee" v="0" sub="always" accent />
           </dl>
         </div>
-        <ul className="text-[13px] text-body space-y-2 px-1">
+        <ul className="space-y-4 text-[13px] leading-relaxed text-body">
           {[
             ["Deploys a plain ERC-20", "no mint, no pause, no blacklist, no tax"],
             ["Opens a Uniswap v4 pool", `${quote.symbol} / your token on ${CHAIN_LABELS[chain]}, no hook`],
@@ -829,7 +829,7 @@ export default function LaunchForm({ ethUsd, gitlawbUsd = null, initialChain = "
 
 function Mini({ k, v, sub, accent }: { k: string; v: string; sub?: string | null; accent?: boolean }) {
   return (
-    <div className="rounded-xl bg-paper border border-line px-3 py-2.5 min-w-0">
+    <div className="min-w-0 space-y-1 border-t border-line py-4">
       <dt className="text-[11px] text-muted truncate">{k}</dt>
       <dd className={`font-mono font-bold text-sm tnum truncate ${accent ? "text-up" : "text-ink"}`}>{v}</dd>
       {sub ? <dd className="text-[11px] text-muted truncate">{sub}</dd> : null}
@@ -905,7 +905,7 @@ function SubmitButton({
 function PhaseNote({ phase, chain }: { phase: Phase; chain: ChainKey }) {
   if (phase.k === "error")
     return (
-      <p className="rounded-xl bg-down-soft border border-down/20 text-down-ink text-sm px-3 py-2" role="alert">
+      <p className="rounded-lg bg-down-soft text-down-ink text-sm px-3 py-2" role="alert">
         {phase.message}
       </p>
     );

--- a/app/src/components/launchpad/LaunchList.module.css
+++ b/app/src/components/launchpad/LaunchList.module.css
@@ -1,0 +1,87 @@
+.toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: .5rem;
+  padding-bottom: .75rem;
+}
+
+.searchWrap { position: relative; min-width: 0; }
+.searchIcon { position: absolute; z-index: 1; top: 50%; left: .85rem; color: var(--color-muted); transform: translateY(-50%); pointer-events: none; }
+
+.searchInput {
+  width: 100%;
+  height: 2.75rem;
+  border: 1px solid var(--color-line);
+  border-radius: .8rem;
+  outline: none;
+  background: var(--color-card);
+  background: color-mix(in srgb, var(--color-card) 82%, transparent);
+  padding: 0 2.75rem 0 2.4rem;
+  color: var(--color-ink);
+  font-size: .8rem;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-ink) 3%, transparent);
+  transition: border-color var(--ui-control-duration) ease, background-color var(--ui-control-duration) ease, box-shadow var(--ui-control-duration) ease;
+}
+
+.searchInput::placeholder { color: var(--color-muted); }
+.searchInput:hover { border-color: var(--color-line-strong); }
+.searchInput:focus { border-color: var(--color-brand); box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-brand) 12%, transparent); }
+.clearSearch { position: absolute; top: 0; right: 0; display: grid; width: 2.75rem; height: 2.75rem; place-items: center; border-radius: .8rem; color: var(--color-muted); }
+.clearSearch:hover { color: var(--color-ink); }
+
+.filterButton { display: inline-flex; min-height: 2.75rem; flex: 0 0 auto; align-items: center; gap: .45rem; border-radius: .75rem; padding-inline: .75rem; color: var(--color-body); font-size: .78rem; font-weight: 600; }
+.filterButton:hover { background: var(--color-card); color: var(--color-ink); }
+.filterActive { background: var(--color-brand-soft); color: var(--color-brand); }
+.filterCount { display: grid; min-width: 1.15rem; height: 1.15rem; place-items: center; border-radius: 999px; background: var(--color-brand); color: var(--color-inverse); font-size: .64rem; }
+
+.sortRail { display: flex; min-width: 0; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .45rem 1rem; padding-bottom: .7rem; }
+.sortScroller { min-width: 0; flex: 1 1 24rem; overflow-x: auto; scrollbar-width: none; }
+.sortScroller::-webkit-scrollbar { display: none; }
+.sortGroup { display: flex; width: max-content; min-width: max-content; align-items: center; gap: .25rem; }
+
+.sortButton {
+  display: inline-flex;
+  min-height: 2.35rem;
+  align-items: center;
+  gap: .35rem;
+  border-radius: .65rem;
+  padding-inline: .72rem;
+  color: var(--color-muted);
+  font-size: .77rem;
+  font-weight: 600;
+}
+
+.sortButton:hover { background: color-mix(in srgb, var(--color-card) 75%, transparent); color: var(--color-ink); }
+.sortButton[aria-pressed="true"] { background: var(--color-brand-soft); color: var(--color-brand); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-brand) 16%, transparent); }
+
+.sortMeta { display: flex; min-width: 0; flex: 0 1 auto; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: .5rem .8rem; }
+.status { display: inline-flex; min-height: 2.25rem; min-width: 0; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: .35rem; color: var(--color-muted); font-size: .69rem; white-space: nowrap; }
+.countText { display: inline-flex; min-width: 0; align-items: center; gap: .3rem; }
+.status strong { color: var(--color-body); font-weight: 650; font-variant-numeric: tabular-nums; }
+.updateState { display: inline-flex; align-items: center; gap: .35rem; margin-left: .25rem; color: var(--color-body); }
+.updateDot { width: .35rem; height: .35rem; border-radius: 999px; background: var(--color-up); }
+.activeFilter { display: inline-flex; min-height: 1.75rem; align-items: center; gap: .3rem; border-radius: .5rem; background: var(--color-brand-soft); padding-inline: .5rem; color: var(--color-brand); }
+
+.list { position: relative; }
+.quietDivider { display: flex; min-height: 2.25rem; align-items: center; border-bottom: 1px solid var(--color-line); padding: .45rem .75rem .45rem 3rem; background: color-mix(in srgb, var(--color-card) 38%, transparent); color: var(--color-muted); font-size: .7rem; }
+.quietVisual { display: flex; min-width: 0; align-items: center; gap: .55rem; }
+.quietVisual strong { flex: 0 0 auto; color: var(--color-body); font-weight: 620; }
+.quietVisual > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.quietDot { width: .35rem; height: .35rem; flex: 0 0 auto; border-radius: 999px; background: var(--color-faint); }
+
+@media (max-width: 639px) {
+  .toolbar { grid-template-columns: minmax(0, 1fr) auto; }
+  .searchWrap { grid-column: 1 / -1; }
+  .sortRail { padding-bottom: .55rem; }
+  .sortScroller { flex-basis: 100%; }
+  .sortMeta { width: 100%; justify-content: space-between; }
+  .sortButton { min-height: 2.75rem; }
+  .status { flex: 1 1 auto; justify-content: space-between; }
+  .quietDivider { padding-left: 3rem; }
+  .quietVisual > span:last-child { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .searchInput { transition: none; }
+}

--- a/app/src/components/launchpad/LaunchList.tsx
+++ b/app/src/components/launchpad/LaunchList.tsx
@@ -3,10 +3,12 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Fragment, useEffect, useRef, useState } from "react";
-import { ArrowDownWideNarrow, ArrowRight, Search, SlidersHorizontal, X } from "lucide-react";
+import { ArrowDownWideNarrow, ArrowRight, Check, Search, SlidersHorizontal, X } from "lucide-react";
 import LaunchRow, { LaunchListHeader, type RowHighlight } from "./LaunchRow";
 import { useLive } from "./LiveProvider";
 import { ToggleGroup, ToggleGroupItem } from "@/components/vendor/toggle-group";
+import { Popover, PopoverClose, PopoverContent, PopoverDescription, PopoverTitle, PopoverTrigger } from "@/components/vendor/popover";
+import ChainSelector from "./ChainSelector";
 import { btn } from "@/components/ui";
 import type { LaunchRow as L, LaunchSort, VolumeWindow } from "@/lib/launchpad/queries";
 import { CHAIN_SHORT, type ChainKey } from "@/lib/chainPublic";
@@ -26,11 +28,6 @@ const SORTS: { key: LaunchSort; label: string }[] = [
   { key: "holders", label: "Holders" },
 ];
 const WINDOWS: VolumeWindow[] = ["1h", "24h", "all"];
-const CHAIN_FILTERS: { key: ChainKey | null; label: string }[] = [
-  { key: null, label: "All chains" },
-  { key: "base", label: CHAIN_SHORT.base },
-  { key: "robinhood", label: CHAIN_SHORT.robinhood },
-];
 const HL_NEW_MS = 60_000;
 const HL_TRADE_MS = 2_500;
 const REORDER_QUIET_MS = 3_000;
@@ -63,6 +60,7 @@ export default function LaunchList({ initial, initialHasMore = false, initialSor
   const pendingOrder = useRef<L[] | null>(null);
   const interaction = useRef({ pointer: false, focus: false, at: 0 });
   const listRef = useRef<HTMLUListElement>(null);
+  const filtersTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     setListParams({ ...selection, limit });
@@ -217,49 +215,42 @@ export default function LaunchList({ initial, initialHasMore = false, initialSor
   const firstQuiet = ranked ? shown.findIndex((row) => liveTier(row, now) === "quiet") : -1; // one divider, where the database's order enters the quiet tier
 
   return (
-    <section id="launches" aria-labelledby="launches-heading" className="min-w-0 scroll-mt-24 overflow-hidden rounded-2xl border border-line bg-paper">
-      <div className="space-y-4 px-4 pt-5">
-        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
-          <div>
-            <div className="flex items-center gap-2.5">
-              <h2 id="launches-heading" className="text-base font-semibold tracking-tight text-ink">Launches</h2>
-              <span className="rounded-md border border-line px-1.5 py-0.5 font-mono text-[11px] text-muted tnum" title="Total launches across both chains">{live.totals.launches}</span>
-            </div>
-            <p className="mt-1 text-xs text-muted">{sort === "live" ? "Tokens with buyers first. Every launch stays in New." : "Every token. Open from the start."}</p>
-          </div>
-          <div className="relative w-full sm:w-64">
+    <section aria-labelledby="launches-heading" className="min-w-0 scroll-mt-24">
+      <h2 id="launches-heading" className="sr-only">Launches</h2>
+      <div className="market-toolbar grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5 py-1.5 sm:flex sm:gap-2">
+          <div className="relative col-span-2 min-w-0 sm:min-w-36 sm:flex-1 sm:basis-40">
             <label htmlFor="launch-search" className="sr-only">Search launches</label>
             <Search aria-hidden="true" size={15} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
-            <input id="launch-search" value={q} onChange={(e) => setQ(e.target.value)} onKeyDown={(e) => { if (e.key === "Escape") setQ(""); }} placeholder="Name, symbol or address" className="h-11 w-full rounded-xl border border-line-strong bg-card pl-9 pr-11 text-[13px] text-ink placeholder:text-muted focus:border-brand" autoComplete="off" spellCheck={false} />
-            {q ? <button type="button" onClick={() => { setQ(""); document.getElementById("launch-search")?.focus(); }} aria-label="Clear search" className="absolute right-0 top-0 grid h-11 w-11 place-items-center rounded-xl text-muted hover:text-ink"><X size={15} aria-hidden="true" /></button> : null}
+            <input id="launch-search" value={q} onChange={(e) => setQ(e.target.value)} onKeyDown={(e) => { if (e.key === "Escape") setQ(""); }} placeholder="Name, symbol or address" className="h-11 w-full rounded-lg border border-transparent bg-card pl-9 pr-11 text-[13px] text-ink placeholder:text-muted hover:border-line focus:border-brand" autoComplete="off" spellCheck={false} />
+            {q ? <button type="button" onClick={() => { setQ(""); document.getElementById("launch-search")?.focus(); }} aria-label="Clear search" className="absolute right-0 top-0 grid h-11 w-11 place-items-center rounded-lg text-muted hover:text-ink"><X size={15} aria-hidden="true" /></button> : null}
           </div>
-        </div>
-        <div className="-mx-4 overflow-x-auto px-4 bb-scroll">
+          <ChainSelector value={chain} onChange={(c) => { const keep = !filter || FILTERS.some((f) => f.key === filter && (!f.chain || !c || f.chain === c)); pick(sort, window_, c, keep ? filter : null); }} />
+          <Popover>
+            <PopoverTrigger ref={filtersTriggerRef} className={`inline-flex min-h-11 shrink-0 items-center gap-2 rounded-lg px-3 text-xs font-medium transition-colors hover:bg-card motion-reduce:transition-none ${filter ? "bg-brand-soft text-brand" : "text-body hover:text-ink"}`}><SlidersHorizontal size={14} aria-hidden="true" />Filters{filter ? <span className="font-mono text-[11px]">1</span> : null}</PopoverTrigger>
+            <PopoverContent>
+              <div className="flex items-center justify-between gap-3 px-2"><PopoverTitle className="text-sm font-semibold">Filter launches</PopoverTitle><PopoverClose aria-label="Close filters" className="grid h-11 w-11 place-items-center rounded-lg text-muted hover:bg-line hover:text-ink"><X size={15} aria-hidden="true" /></PopoverClose></div>
+              <PopoverDescription className="px-2 pb-3 text-xs text-muted">Choose a filter. Select it again to clear.</PopoverDescription>
+              <ToggleGroup aria-label="Quick filter" orientation="vertical" value={filter ? [filter] : []} onValueChange={(values) => pick(sort, window_, chain, (values[0] as LaunchFilter | undefined) ?? null)} className="flex w-full flex-col items-stretch gap-1">
+                {FILTERS.filter((f) => !f.chain || !chain || f.chain === chain).map((f) => <ToggleGroupItem key={f.key} value={f.key} title={f.title} className="min-h-11 w-full justify-between px-3 text-sm">{f.label}{filter === f.key ? <Check size={14} aria-hidden="true" /> : null}</ToggleGroupItem>)}
+              </ToggleGroup>
+            </PopoverContent>
+          </Popover>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-x-4 border-b border-line">
+        <div className="min-w-0 overflow-x-auto bb-scroll">
           <div role="group" aria-label="Sort launches" className="flex min-w-max gap-5">
-            {SORTS.map((s) => <button key={s.key} type="button" onClick={() => pick(s.key)} aria-pressed={s.key === sort} className={`relative flex min-h-11 items-center gap-1.5 border-b-2 text-xs font-medium transition-colors motion-reduce:transition-none ${s.key === sort ? "border-ink text-ink" : "border-transparent text-muted hover:text-ink"}`}>{s.key === "new" ? <ArrowDownWideNarrow size={13} aria-hidden="true" /> : null}{s.label}</button>)}
+            {SORTS.map((s) => <button key={s.key} type="button" onClick={() => pick(s.key)} aria-pressed={s.key === sort} className={`relative flex min-h-11 items-center gap-1.5 border-b-2 text-xs font-medium transition-colors motion-reduce:transition-none ${s.key === sort ? "border-brand text-ink" : "border-transparent text-muted hover:text-ink"}`}>{s.key === "new" ? <ArrowDownWideNarrow size={13} aria-hidden="true" /> : null}{s.label}</button>)}
           </div>
         </div>
+        {showWindow ? <ToggleGroup aria-label="Volume window" value={[window_]} onValueChange={(values) => { if (values[0]) pick(sort, values[0] as VolumeWindow); }}>
+          {WINDOWS.map((w) => <ToggleGroupItem key={w} value={w} className="min-h-11 px-2.5 font-mono tnum">{w === "all" ? "All time" : w}</ToggleGroupItem>)}
+        </ToggleGroup> : null}
       </div>
-      <div className="space-y-3 border-t border-line px-4 py-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <ToggleGroup aria-label="Chain" value={[chain ?? "all"]} onValueChange={(values) => { const value = values[0]; if (!value) return; const c = value === "all" ? null : (value as ChainKey); const keep = !filter || FILTERS.some((f) => f.key === filter && (!f.chain || !c || f.chain === c)); pick(sort, window_, c, keep ? filter : null); }}>
-            {CHAIN_FILTERS.map((c) => <ToggleGroupItem key={c.key ?? "all"} value={c.key ?? "all"}>{c.label}</ToggleGroupItem>)}
-          </ToggleGroup>
-          {showWindow ? <ToggleGroup aria-label="Volume window" value={[window_]} onValueChange={(values) => { if (values[0]) pick(sort, values[0] as VolumeWindow); }}>
-            {WINDOWS.map((w) => <ToggleGroupItem key={w} value={w} className="px-2.5 font-mono tnum">{w === "all" ? "All time" : w}</ToggleGroupItem>)}
-          </ToggleGroup> : null}
-        </div>
-        <div className="flex items-start gap-2">
-          <SlidersHorizontal aria-hidden="true" size={13} className="mt-3.5 shrink-0 text-muted" />
-          <ToggleGroup aria-label="Quick filter" value={filter ? [filter] : []} onValueChange={(values) => pick(sort, window_, chain, (values[0] as LaunchFilter | undefined) ?? null)} className="min-w-0 gap-1 overflow-x-auto rounded-none border-0 bg-transparent p-0 bb-scroll">
-            {FILTERS.filter((f) => !f.chain || !chain || f.chain === chain).map((f) => <ToggleGroupItem key={f.key} value={f.key} title={f.title} className="min-h-10 px-2.5 text-[11px] data-pressed:bg-card">{f.label}</ToggleGroupItem>)}
-          </ToggleGroup>
-        </div>
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 py-1.5 text-[11px] text-muted">
+        <div role="status" className="inline-flex flex-wrap items-center gap-2">{updating || searching ? <><Spinner size={11} />{searching ? "Searching all launches…" : "Updating view…"}</> : nq ? <><span className="font-mono tnum">{shown.length}</span> matches</> : <><span className="font-mono tnum">{shown.length} / {live.totals.launches}</span> launches · {chain ? CHAIN_SHORT[chain] : "both chains"}</>}{filter ? <button type="button" onClick={() => { pick(sort, window_, chain, null); filtersTriggerRef.current?.focus(); }} className="inline-flex min-h-8 items-center gap-1.5 rounded-md bg-brand-soft px-2 text-brand" aria-label="Clear active filter">{FILTERS.find((f) => f.key === filter)?.label}<X size={12} aria-hidden="true" /></button> : null}</div>
+        <span>{holding ? "Order held while browsing" : "Updates every 5s"}</span>
       </div>
-      <div role="status" className="flex min-h-9 items-center justify-between gap-2 border-t border-line px-4 text-[11px] text-muted">
-        <span className="inline-flex items-center gap-2">{updating || searching ? <><Spinner size={11} />{searching ? "Searching all launches…" : "Updating view…"}</> : nq ? <><span className="font-mono tnum">{shown.length}</span> matches</> : <><span className="font-mono tnum">{shown.length}</span> shown · {chain ? CHAIN_SHORT[chain] : "both chains"}</>}</span>
-        <span className="shrink-0">{holding ? "Order held while browsing" : "Updates every 5s"}</span>
-      </div>
+      <p className="sr-only">{sort === "live" ? "Tokens with buyers first. Every launch stays in New." : "Every token. Open from the start."}</p>
       <LaunchListHeader window={showWindow ? window_ : "all"} />
       <ul ref={listRef} aria-label="Token launches" aria-busy={updating} onPointerEnter={(e) => { if (e.pointerType === "mouse") interaction.current.pointer = true; }} onPointerLeave={() => { interaction.current.pointer = false; interaction.current.at = Date.now(); }} onPointerDown={() => { interaction.current.at = Date.now(); }} onFocusCapture={() => { interaction.current.focus = true; }} onBlurCapture={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) { interaction.current.focus = false; interaction.current.at = Date.now(); } }}>
         {shown.map((l, i) => {
@@ -267,7 +258,7 @@ export default function LaunchList({ initial, initialHasMore = false, initialSor
           const chip = ranked ? liveChip(l, now) : null;
           const rank = !nq && sort !== "new" && (!chip || chip.tier === "live") ? i + 1 : undefined;
           return <Fragment key={key}>
-            {i === firstQuiet ? <li className="border-b border-line bg-card px-4 py-2 text-[11px] text-muted"><span className="font-medium text-body">Quiet launches</span> · no buyers yet. One row per wallet; every launch stays in New.</li> : null}
+            {i === firstQuiet ? <li className="border-b border-line py-1.5 text-[11px] text-muted"><span className="font-medium text-body">Quiet launches</span> · no buyers yet. One row per wallet; every launch stays in New.</li> : null}
             <li data-token={key}><LaunchRow l={l} rank={rank} window={showWindow ? window_ : "all"} hl={hl.get(key) ?? null} now={now} pop={Boolean(hl.get(key) && hl.get(key)?.kind !== "new")} chip={chip} /></li>
           </Fragment>;
         })}

--- a/app/src/components/launchpad/LaunchList.tsx
+++ b/app/src/components/launchpad/LaunchList.tsx
@@ -18,6 +18,7 @@ import { liveChip, liveTier } from "@/lib/launchpad/ranking";
 import { PAGE_SIZE } from "@/lib/launchpad/paging";
 import { Spinner } from "@/components/Skeleton";
 import { startNav } from "@/components/RouteProgress";
+import styles from "./LaunchList.module.css";
 
 const SORTS: { key: LaunchSort; label: string }[] = [
   { key: "live", label: "Live" },
@@ -217,16 +218,16 @@ export default function LaunchList({ initial, initialHasMore = false, initialSor
   return (
     <section aria-labelledby="launches-heading" className="min-w-0 scroll-mt-24">
       <h2 id="launches-heading" className="sr-only">Launches</h2>
-      <div className="market-toolbar grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5 py-1.5 sm:flex sm:gap-2">
-          <div className="relative col-span-2 min-w-0 sm:min-w-36 sm:flex-1 sm:basis-40">
+      <div className={`${styles.toolbar} market-toolbar`}>
+          <div className={styles.searchWrap}>
             <label htmlFor="launch-search" className="sr-only">Search launches</label>
-            <Search aria-hidden="true" size={15} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
-            <input id="launch-search" value={q} onChange={(e) => setQ(e.target.value)} onKeyDown={(e) => { if (e.key === "Escape") setQ(""); }} placeholder="Name, symbol or address" className="h-11 w-full rounded-lg border border-transparent bg-card pl-9 pr-11 text-[13px] text-ink placeholder:text-muted hover:border-line focus:border-brand" autoComplete="off" spellCheck={false} />
-            {q ? <button type="button" onClick={() => { setQ(""); document.getElementById("launch-search")?.focus(); }} aria-label="Clear search" className="absolute right-0 top-0 grid h-11 w-11 place-items-center rounded-lg text-muted hover:text-ink"><X size={15} aria-hidden="true" /></button> : null}
+            <Search aria-hidden="true" size={16} className={styles.searchIcon} />
+            <input id="launch-search" value={q} onChange={(e) => setQ(e.target.value)} onKeyDown={(e) => { if (e.key === "Escape") setQ(""); }} placeholder="Search token, symbol or address" className={styles.searchInput} autoComplete="off" spellCheck={false} />
+            {q ? <button type="button" onClick={() => { setQ(""); document.getElementById("launch-search")?.focus(); }} aria-label="Clear search" className={styles.clearSearch}><X size={15} aria-hidden="true" /></button> : null}
           </div>
           <ChainSelector value={chain} onChange={(c) => { const keep = !filter || FILTERS.some((f) => f.key === filter && (!f.chain || !c || f.chain === c)); pick(sort, window_, c, keep ? filter : null); }} />
           <Popover>
-            <PopoverTrigger ref={filtersTriggerRef} className={`inline-flex min-h-11 shrink-0 items-center gap-2 rounded-lg px-3 text-xs font-medium transition-colors hover:bg-card motion-reduce:transition-none ${filter ? "bg-brand-soft text-brand" : "text-body hover:text-ink"}`}><SlidersHorizontal size={14} aria-hidden="true" />Filters{filter ? <span className="font-mono text-[11px]">1</span> : null}</PopoverTrigger>
+            <PopoverTrigger ref={filtersTriggerRef} className={`${styles.filterButton} ui-pressable ${filter ? styles.filterActive : ""}`}><SlidersHorizontal size={14} aria-hidden="true" />Filters{filter ? <span className={styles.filterCount}>1</span> : null}</PopoverTrigger>
             <PopoverContent>
               <div className="flex items-center justify-between gap-3 px-2"><PopoverTitle className="text-sm font-semibold">Filter launches</PopoverTitle><PopoverClose aria-label="Close filters" className="grid h-11 w-11 place-items-center rounded-lg text-muted hover:bg-line hover:text-ink"><X size={15} aria-hidden="true" /></PopoverClose></div>
               <PopoverDescription className="px-2 pb-3 text-xs text-muted">Choose a filter. Select it again to clear.</PopoverDescription>
@@ -236,29 +237,28 @@ export default function LaunchList({ initial, initialHasMore = false, initialSor
             </PopoverContent>
           </Popover>
       </div>
-      <div className="flex flex-wrap items-center justify-between gap-x-4 border-b border-line">
-        <div className="min-w-0 overflow-x-auto bb-scroll">
-          <div role="group" aria-label="Sort launches" className="flex min-w-max gap-5">
-            {SORTS.map((s) => <button key={s.key} type="button" onClick={() => pick(s.key)} aria-pressed={s.key === sort} className={`relative flex min-h-11 items-center gap-1.5 border-b-2 text-xs font-medium transition-colors motion-reduce:transition-none ${s.key === sort ? "border-brand text-ink" : "border-transparent text-muted hover:text-ink"}`}>{s.key === "new" ? <ArrowDownWideNarrow size={13} aria-hidden="true" /> : null}{s.label}</button>)}
+      <div className={styles.sortRail}>
+        <div className={`${styles.sortScroller} bb-scroll`}>
+          <div role="group" aria-label="Sort launches" className={styles.sortGroup}>
+            {SORTS.map((s) => <button key={s.key} type="button" onClick={() => pick(s.key)} aria-pressed={s.key === sort} className={`${styles.sortButton} ui-pressable`}>{s.key === "new" ? <ArrowDownWideNarrow size={13} aria-hidden="true" /> : null}{s.label}</button>)}
           </div>
         </div>
-        {showWindow ? <ToggleGroup aria-label="Volume window" value={[window_]} onValueChange={(values) => { if (values[0]) pick(sort, values[0] as VolumeWindow); }}>
-          {WINDOWS.map((w) => <ToggleGroupItem key={w} value={w} className="min-h-11 px-2.5 font-mono tnum">{w === "all" ? "All time" : w}</ToggleGroupItem>)}
-        </ToggleGroup> : null}
-      </div>
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 py-1.5 text-[11px] text-muted">
-        <div role="status" className="inline-flex flex-wrap items-center gap-2">{updating || searching ? <><Spinner size={11} />{searching ? "Searching all launches…" : "Updating view…"}</> : nq ? <><span className="font-mono tnum">{shown.length}</span> matches</> : <><span className="font-mono tnum">{shown.length} / {live.totals.launches}</span> launches · {chain ? CHAIN_SHORT[chain] : "both chains"}</>}{filter ? <button type="button" onClick={() => { pick(sort, window_, chain, null); filtersTriggerRef.current?.focus(); }} className="inline-flex min-h-8 items-center gap-1.5 rounded-md bg-brand-soft px-2 text-brand" aria-label="Clear active filter">{FILTERS.find((f) => f.key === filter)?.label}<X size={12} aria-hidden="true" /></button> : null}</div>
-        <span>{holding ? "Order held while browsing" : "Updates every 5s"}</span>
+        <div className={styles.sortMeta}>
+          {showWindow ? <ToggleGroup aria-label="Volume window" value={[window_]} onValueChange={(values) => { if (values[0]) pick(sort, values[0] as VolumeWindow); }}>
+            {WINDOWS.map((w) => <ToggleGroupItem key={w} value={w} className="min-h-9 px-2.5 font-mono tnum">{w === "all" ? "All time" : w}</ToggleGroupItem>)}
+          </ToggleGroup> : null}
+          <div role="status" className={styles.status}><span className={styles.countText}>{updating || searching ? <><Spinner size={11} />{searching ? "Searching…" : "Updating…"}</> : nq ? <><strong>{shown.length}</strong> matches</> : <><strong>{shown.length}</strong> of <span className="tnum">{live.totals.launches}</span> · {chain ? CHAIN_SHORT[chain] : "both chains"}</>}</span>{filter ? <button type="button" onClick={() => { pick(sort, window_, chain, null); filtersTriggerRef.current?.focus(); }} className={styles.activeFilter} aria-label="Clear active filter">{FILTERS.find((f) => f.key === filter)?.label}<X size={12} aria-hidden="true" /></button> : null}<span className={styles.updateState}><span className={styles.updateDot} aria-hidden="true" />{holding ? "Order paused" : "Live · 5s"}</span></div>
+        </div>
       </div>
       <p className="sr-only">{sort === "live" ? "Tokens with buyers first. Every launch stays in New." : "Every token. Open from the start."}</p>
       <LaunchListHeader window={showWindow ? window_ : "all"} />
-      <ul ref={listRef} aria-label="Token launches" aria-busy={updating} onPointerEnter={(e) => { if (e.pointerType === "mouse") interaction.current.pointer = true; }} onPointerLeave={() => { interaction.current.pointer = false; interaction.current.at = Date.now(); }} onPointerDown={() => { interaction.current.at = Date.now(); }} onFocusCapture={() => { interaction.current.focus = true; }} onBlurCapture={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) { interaction.current.focus = false; interaction.current.at = Date.now(); } }}>
+      <ul className={styles.list} ref={listRef} aria-label="Token launches" aria-busy={updating} onPointerEnter={(e) => { if (e.pointerType === "mouse") interaction.current.pointer = true; }} onPointerLeave={() => { interaction.current.pointer = false; interaction.current.at = Date.now(); }} onPointerDown={() => { interaction.current.at = Date.now(); }} onFocusCapture={() => { interaction.current.focus = true; }} onBlurCapture={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) { interaction.current.focus = false; interaction.current.at = Date.now(); } }}>
         {shown.map((l, i) => {
           const key = launchKey(l);
           const chip = ranked ? liveChip(l, now) : null;
           const rank = !nq && sort !== "new" && (!chip || chip.tier === "live") ? i + 1 : undefined;
           return <Fragment key={key}>
-            {i === firstQuiet ? <li className="border-b border-line py-1.5 text-[11px] text-muted"><span className="font-medium text-body">Quiet launches</span> · no buyers yet. One row per wallet; every launch stays in New.</li> : null}
+            {i === firstQuiet ? <li className={styles.quietDivider} title="No buyer activity yet. One visible launch per wallet; every launch remains discoverable in New."><span aria-hidden="true" className={styles.quietVisual}><span className={styles.quietDot} /><strong>First-trade queue</strong><span>One market per wallet · always visible in New</span></span><span className="sr-only">Quiet launches. No buyer activity yet. One visible launch per wallet; every launch remains discoverable in New.</span></li> : null}
             <li data-token={key}><LaunchRow l={l} rank={rank} window={showWindow ? window_ : "all"} hl={hl.get(key) ?? null} now={now} pop={Boolean(hl.get(key) && hl.get(key)?.kind !== "new")} chip={chip} /></li>
           </Fragment>;
         })}

--- a/app/src/components/launchpad/LaunchMachine.module.css
+++ b/app/src/components/launchpad/LaunchMachine.module.css
@@ -5,14 +5,26 @@
 .crosshair::before, .crosshair::after { content: ""; position: absolute; background: var(--color-muted); }
 .crosshair::before { width: 9px; height: 1px; top: 4px; }
 .crosshair::after { width: 1px; height: 9px; left: 4px; }
-.playback { display: flex; align-items: center; gap: 6px; min-height: 36px; padding: 0 8px; border-radius: 6px; font-size: 11px; color: var(--color-muted); cursor: pointer; }
+.playback { display: flex; align-items: center; gap: 6px; min-height: 36px; padding: 0 8px; border-radius: 6px; font-size: 11px; color: var(--color-muted); cursor: pointer; transition: color 150ms ease, background-color 150ms ease, transform 150ms ease; }
 .playback:hover { color: var(--color-ink); background: var(--color-card); }
+.playback:active:not(:disabled) { transform: scale(.97); }
+.playback:focus-visible, .stageButton:focus-visible { outline: 2px solid var(--color-brand); outline-offset: 3px; }
 .machine[data-playing="true"] { --motion-state: running; }
 .playback { min-width: 68px; justify-content: flex-end; }
 .playback:disabled { cursor: default; }
 .viewport { width: 100%; perspective: 1000px; }
 .scene { width: 100%; transition: transform 280ms ease-out; transform-origin: 50% 60%; }
 .drawing { display: block; width: 100%; aspect-ratio: 560 / 398; overflow: hidden; stroke-linejoin: round; stroke-linecap: round; }
+.sequence { pointer-events: none; }
+.sequenceTrack { stroke: var(--color-line); stroke-width: 1; }
+.sequenceSegment { stroke: var(--color-brand); stroke-width: 1.5; opacity: 0; }
+.sequenceLabel { fill: var(--color-muted); font-family: var(--font-sans); font-size: 15px; font-weight: 600; letter-spacing: .8px; }
+.sequenceStep[data-active="true"] .sequenceLabel { fill: var(--color-brand); }
+.sequenceStep[data-active="true"] .sequenceSegment { opacity: 1; }
+/* One finite reveal per stage, never a separate autoplay clock or moving marquee.
+   The same pause variable freezes the caption and the assembly together. */
+.machine[data-loop="true"] .sequenceStep[data-active="true"] .sequenceLabel { animation: sequence-reveal 240ms cubic-bezier(.2, .7, .2, 1) both; animation-play-state: var(--motion-state); }
+@keyframes sequence-reveal { from { opacity: .55; transform: translateY(3px); } to { opacity: 1; transform: translateY(0); } }
 .grid { stroke: var(--color-line); stroke-width: .7; }
 .plateTop { fill: var(--color-line); stroke: var(--color-faint); stroke-width: 1; }
 .faceLeft { fill: var(--color-card); stroke: var(--color-faint); stroke-width: .8; }
@@ -120,9 +132,10 @@
 @keyframes guide-flow { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -54; } }
 
 .controls { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-bottom: 1px solid var(--color-line); }
-.stageButton { position: relative; display: flex; align-items: center; gap: 8px; min-height: 44px; padding: 0 8px; color: var(--color-muted); font-size: 12px; cursor: pointer; white-space: nowrap; }
+.stageButton { position: relative; display: flex; align-items: center; gap: 8px; min-height: 44px; padding: 0 8px; color: var(--color-muted); font-size: 12px; cursor: pointer; white-space: nowrap; transition: color 150ms ease, background-color 150ms ease; }
 .stageButton::after { position: absolute; content: ""; bottom: -1px; left: 8px; right: 8px; height: 1px; background: transparent; }
-.stageButton:hover { color: var(--color-ink); }
+.stageButton:hover { color: var(--color-ink); background: var(--color-card); }
+.stageButton:active { background: var(--color-line); }
 .stageButton[aria-pressed="true"] { color: var(--color-ink); }
 .stageButton[aria-pressed="true"]::after { background: var(--color-ink); }
 .stageNumber { font-family: var(--font-mono); font-size: 10px; color: var(--color-muted); }
@@ -166,8 +179,10 @@
   .scene { transition: none; transform: none !important; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .scene, .token, .pool, .clampLeft, .clampRight { transition: none; }
+  .scene, .token, .pool, .clampLeft, .clampRight, .playback, .stageButton { transition: none; }
   .scene { transform: none !important; }
+  .playback:active:not(:disabled) { transform: none; }
+  .machine[data-loop="true"] .sequenceStep[data-active="true"] .sequenceLabel { animation: none; }
   .machine[data-loop="true"] :is(.assembly, .token, .pool, .poolCurrent, .ripple, .rippleAfter, .clampLeft, .clampRight, .lockTrace, .guides) { animation: none; }
   .machine[data-loop="true"] :is(.stageProgress[data-phase], .detailContent[aria-hidden]) { animation: none; }
 }

--- a/app/src/components/launchpad/LaunchMachine.tsx
+++ b/app/src/components/launchpad/LaunchMachine.tsx
@@ -5,6 +5,7 @@ import { Pause, Play, ArrowUpRight, LockKeyhole } from "lucide-react";
 import { launchpad } from "@/lib/launchpad/config";
 import { explorerAddress } from "@/lib/chainPublic";
 import { shouldAnimateLaunch } from "@/lib/launchpad/hero-animation";
+import LaunchSequence from "./LaunchSequence";
 import styles from "./LaunchMachine.module.css";
 
 const stages = [
@@ -63,7 +64,7 @@ export default function LaunchMachine() {
   }
 
   function tilt(event: PointerEvent<HTMLDivElement>) {
-    if (paused || event.pointerType !== "mouse" || !window.matchMedia(TILT_QUERY).matches) return;
+    if (!playing || event.pointerType !== "mouse" || !window.matchMedia(TILT_QUERY).matches) return;
     const box = event.currentTarget.getBoundingClientRect();
     const x = (event.clientX - box.left) / box.width - 0.5;
     const y = (event.clientY - box.top) / box.height - 0.5;
@@ -83,6 +84,7 @@ export default function LaunchMachine() {
     <div className={styles.viewport} onPointerMove={tilt} onPointerLeave={() => scene.current?.style.removeProperty("transform")}>
       <div ref={scene} className={styles.scene}>
         <svg viewBox="0 0 560 398" fill="none" className={styles.drawing} aria-hidden="true" focusable="false">
+          <LaunchSequence stage={stage} />
           <g className={styles.grid}>
             {[-100, -50, 0, 50, 100].map((n) => <g key={n}><line x1={280 + n * .86 - 111.8} y1={308 + n * .38 + 49.4} x2={280 + n * .86 + 111.8} y2={308 + n * .38 - 49.4} /><line x1={280 - n * .86 - 111.8} y1={308 + n * .38 - 49.4} x2={280 - n * .86 + 111.8} y2={308 + n * .38 + 49.4} /></g>)}
           </g>

--- a/app/src/components/launchpad/LaunchRow.module.css
+++ b/app/src/components/launchpad/LaunchRow.module.css
@@ -1,0 +1,240 @@
+.shell {
+  position: relative;
+  border-bottom: 1px solid var(--color-line);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 7.6rem;
+}
+
+.watch {
+  position: absolute;
+  z-index: 3;
+  top: .75rem;
+  left: 0;
+}
+
+.row {
+  position: relative;
+  z-index: 1;
+  min-height: 5.25rem;
+  padding-block: .75rem;
+  isolation: isolate;
+}
+
+.row::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  background: var(--color-card);
+  opacity: 0;
+  transition: opacity var(--ui-control-duration) ease;
+  pointer-events: none;
+}
+
+.row::after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  top: .75rem;
+  bottom: .75rem;
+  left: 0;
+  width: 2px;
+  border-radius: 999px;
+  background: var(--color-brand);
+  opacity: 0;
+  transform: scaleY(.35);
+  transition: opacity var(--ui-control-duration) ease, transform var(--ui-panel-duration) var(--ui-ease-out);
+  pointer-events: none;
+}
+
+.row:hover::before,
+.row:focus-visible::before { opacity: .68; }
+
+.row:hover::after,
+.row:focus-visible::after { opacity: 1; transform: scaleY(1); }
+
+.listHeader {
+  min-height: 2.5rem;
+  border-block: 1px solid var(--color-line);
+  background: color-mix(in srgb, var(--color-paper) 94%, transparent);
+  color: var(--color-muted);
+  font-size: .7rem;
+  font-weight: 600;
+  letter-spacing: .01em;
+  backdrop-filter: blur(12px);
+}
+
+.rank {
+  display: none;
+  width: 1.25rem;
+  flex: 0 0 auto;
+  color: var(--color-muted);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: .68rem;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.avatar {
+  flex: 0 0 auto;
+  border: 1px solid var(--color-line-strong);
+  border-radius: .8rem;
+  background: var(--color-card);
+}
+
+.name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-ink);
+  font-size: .96rem;
+  font-weight: 650;
+  line-height: 1.25rem;
+  letter-spacing: -.018em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.newLabel { flex: 0 0 auto; color: var(--color-brand); font-size: .68rem; font-weight: 650; }
+
+.identityMeta {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: .35rem;
+  margin-top: .16rem;
+  overflow: hidden;
+  color: var(--color-muted);
+  font-size: .72rem;
+  line-height: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.symbol { color: var(--color-body); font-family: var(--font-geist-mono), ui-monospace, monospace; font-size: .68rem; }
+
+.context {
+  display: flex;
+  grid-column: 1 / -1;
+  grid-row: 2;
+  min-width: 0;
+  align-items: center;
+  gap: .55rem;
+  overflow: hidden;
+  font-size: .7rem;
+  line-height: 1rem;
+  white-space: nowrap;
+}
+
+.fee { flex: 0 0 auto; color: var(--color-muted); font-weight: 550; }
+.fee[data-mode="burn"] { color: var(--color-warm-ink); }
+
+.status {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: .35rem;
+  overflow: hidden;
+  color: var(--color-muted);
+  text-overflow: ellipsis;
+}
+
+.statusDot { width: .28rem; height: .28rem; flex: 0 0 auto; border-radius: 999px; background: var(--color-faint); }
+.status[data-tier="live"] { color: var(--color-up); }
+.status[data-tier="live"] .statusDot { background: var(--color-up); }
+.status[data-tier="new"] { color: var(--color-brand); }
+.status[data-tier="new"] .statusDot { background: var(--color-brand); }
+
+.marketCell,
+.volumeCell { min-width: 0; text-align: right; }
+
+.mobileMetricLabel { display: block; margin-bottom: .16rem; color: var(--color-muted); font-size: .66rem; line-height: .9rem; }
+.capLine { display: flex; min-width: 0; align-items: baseline; justify-content: flex-end; gap: .45rem; }
+
+.capValue {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-ink);
+  font-size: 1.12rem;
+  font-weight: 670;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -.035em;
+  line-height: 1.25rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.change { flex: 0 0 auto; font-size: .68rem; }
+
+.capDetail,
+.metricHint {
+  display: block;
+  margin-top: .18rem;
+  overflow: hidden;
+  color: var(--color-muted);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: .66rem;
+  font-variant-numeric: tabular-nums;
+  line-height: .9rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.volumeValue {
+  display: block;
+  overflow: hidden;
+  color: var(--color-body);
+  font-size: .84rem;
+  font-weight: 560;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.15rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity { min-width: 0; color: var(--color-body); font-size: .76rem; line-height: 1.05rem; text-align: right; }
+.tradeCounts,
+.noTrades { display: block; color: var(--color-body); }
+.tradeValues { display: inline-flex; max-width: 100%; align-items: baseline; gap: .35rem; white-space: nowrap; }
+.tradeValues strong { font-weight: 650; font-variant-numeric: tabular-nums; }
+.buyValue { color: var(--color-up); }
+.sellValue { color: var(--color-down-ink); }
+.zeroValue { color: var(--color-muted); }
+.tradeDivider { color: var(--color-faint); }
+
+.activityMeta {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: .35rem;
+  margin-top: .18rem;
+  overflow: hidden;
+  color: var(--color-muted);
+  font-size: .67rem;
+  white-space: nowrap;
+}
+
+.mobileMetrics { display: grid; grid-row: 3; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: center; gap: .75rem; }
+.mobileMetrics > div { display: flex; min-width: 0; align-items: baseline; gap: .35rem; }
+.mobileMetrics > div:last-child { justify-content: flex-end; }
+.mobileMetrics dt { color: var(--color-muted); font-size: .66rem; line-height: .9rem; }
+.mobileMetrics dd { overflow: hidden; color: var(--color-body); font-size: .76rem; font-variant-numeric: tabular-nums; line-height: 1rem; text-overflow: ellipsis; white-space: nowrap; }
+.mobileMetrics > div:last-child dd { overflow: visible; white-space: normal; }
+.mobileMetrics .activity { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: flex-end; gap: 0 .35rem; white-space: nowrap; }
+.mobileMetrics .activityMeta { margin-top: 0; }
+.mobileMetrics .activityMeta::before { content: "·"; color: var(--color-faint); }
+
+@media (min-width: 640px) {
+  .shell { contain-intrinsic-size: auto 5.5rem; }
+  .row { min-height: 5.5rem; }
+  .context { grid-column: 1; grid-row: 2; padding-left: 3.5rem; }
+  .mobileMetrics { display: none; }
+  .mobileMetricLabel { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+}
+
+@media (min-width: 1280px) { .rank { display: block; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .row::before,
+  .row::after { transition: none; }
+}

--- a/app/src/components/launchpad/LaunchRow.tsx
+++ b/app/src/components/launchpad/LaunchRow.tsx
@@ -13,24 +13,55 @@ import { marketUsd } from "@/lib/launchpad/market-format";
 import { capDisplay } from "@/lib/launchpad/market-cap";
 import type { LiveTier } from "@/lib/launchpad/ranking";
 import WatchButton from "./WatchButton";
+import styles from "./LaunchRow.module.css";
 
 const columns = "launch-ledger";
+const counts = new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 });
+
+function TradeCounts({ buys, sells }: { buys: number; sells: number }) {
+  const buyWord = buys === 1 ? "buy" : "buys";
+  const sellWord = sells === 1 ? "sell" : "sells";
+  const exact = `${buys} ${buyWord}, ${sells} ${sellWord}`;
+  if (buys === 0 && sells === 0) {
+    return <span className={styles.noTrades} title="0 buys, 0 sells"><span className="sr-only">0 buys, 0 sells. </span><span aria-hidden="true">No trades</span></span>;
+  }
+  return (
+    <span className={styles.tradeCounts} title={exact}>
+      <span className="sr-only">{exact}. </span>
+      <span aria-hidden="true" className={styles.tradeValues}>
+        <span><strong className={buys ? styles.buyValue : styles.zeroValue}>{counts.format(buys)}</strong> {buyWord}</span>
+        <span className={styles.tradeDivider}>·</span>
+        <span><strong className={sells ? styles.sellValue : styles.zeroValue}>{counts.format(sells)}</strong> {sellWord}</span>
+      </span>
+    </span>
+  );
+}
+
+function ActivitySignal({ buys, sells, holders, volumeLabel }: { buys: number; sells: number; holders: number; volumeLabel?: string }) {
+  return (
+    <div className={styles.activity}>
+      <TradeCounts buys={buys} sells={sells} />
+      <div className={styles.activityMeta}>
+        {volumeLabel ? <span className="lg:hidden"><span className="sr-only">Volume </span><span className="tnum">{volumeLabel}</span><span aria-hidden="true"> vol</span></span> : null}
+        {volumeLabel ? <span className="lg:hidden" aria-hidden="true">·</span> : null}
+        <span title={`${holders} ${holders === 1 ? "holder" : "holders"}`}><span className="sr-only">{`${holders} ${holders === 1 ? "holder" : "holders"}. `}</span><span aria-hidden="true"><span className="tnum">{counts.format(holders)}</span> {holders === 1 ? "holder" : "holders"}</span></span>
+      </div>
+    </div>
+  );
+}
 
 export function LaunchListHeader({ window }: { window: VolumeWindow }) {
   return (
-    <div aria-hidden="true" className={`hidden sm:grid ${columns} items-center gap-3 border-b border-line pl-11 pr-2 py-2 text-[11px] font-medium text-muted`}>
-      <span>Token / paired with</span>
-      <span className="text-right">Market cap</span>
-      <span className="hidden text-right lg:block">Since launch</span>
-      <span className="text-right">Volume · {window}</span>
-      <span className="text-right">Buys / sells</span>
-      <span className="hidden text-right lg:block">Age</span>
+    <div aria-hidden="true" className={`${styles.listHeader} hidden sm:grid sticky top-14 z-20 ${columns} items-center gap-3 pl-12 pr-3`}>
+      <span>Token</span>
+      <span className="text-right">Market</span>
+      <span className="hidden text-right lg:block">Volume · {window}</span>
+      <span className="text-right">Order flow</span>
     </div>
   );
 }
 
 export type RowHighlight = { kind: "new" | "buy" | "sell"; at: number } | null;
-
 export type RowChip = { tier: LiveTier; text: string } | null;
 
 export default function LaunchRow({ l, rank, window = "all", hl = null, now, pop = false, chip = null }: { l: L; ethUsd?: number | null; rank?: number; window?: VolumeWindow; hl?: RowHighlight; now: number; pop?: boolean; chip?: RowChip }) {
@@ -39,55 +70,55 @@ export default function LaunchRow({ l, rank, window = "all", hl = null, now, pop
   const volUsd = window === "1h" ? l.volume_1h_usd : window === "24h" ? l.volume_24h_usd : l.volume_usd;
   const volLabel = volUsd !== null ? marketUsd(volUsd) : fmtQuote(volRaw, l.quote_decimals, l.quote_symbol);
   const volumeDetail = volUsd !== null ? fmtUsd(volUsd) : volLabel;
-  const cap = capDisplay(l.fdv_quote, l.quote_usd, { key: l.quote_key, symbol: l.quote_symbol, decimals: l.quote_decimals }); // dollars lead; the quote figure is the detail
+  const cap = capDisplay(l.fdv_quote, l.quote_usd, { key: l.quote_key, symbol: l.quote_symbol, decimals: l.quote_decimals });
   const capLabel = cap.main;
   const capDetail = cap.usd !== null ? `${fmtUsd(cap.usd)} · ${cap.detail}` : `${cap.main} · ${cap.detail}`;
   const feeLabel = mode === "free" ? "0% trading fee" : `${pipsToPct(l.lp_fee)} fee → ${mode === "burn" ? "burned" : mode === "split" ? "split" : "beneficiary"}`;
   const flash = hl ? `bb-row-${hl.kind}` : "";
-  const age = <time dateTime={l.block_time} title={new Date(l.block_time).toUTCString()} suppressHydrationWarning>{ago(l.block_time, now)}</time>;
+  const age = <><span className="sr-only">Launched </span><time dateTime={l.block_time} title={new Date(l.block_time).toUTCString()} suppressHydrationWarning>{ago(l.block_time, now)}</time><span className="sr-only"> ago</span></>;
+  const rowChip = chip?.tier === "quiet" ? l.launcher_collapsed ? { tier: chip.tier, text: `+${l.launcher_collapsed} more from this wallet` } : null : chip;
+  const context = <><span className={styles.fee} data-mode={mode}>{feeLabel}</span>{rowChip ? <span className={styles.status} data-tier={rowChip.tier} title={rowChip.text} suppressHydrationWarning><span className={styles.statusDot} aria-hidden="true" />{rowChip.text}</span> : null}</>;
 
   return (
-    <div className="relative">
-    <div className="absolute -left-1 top-3 z-10"><WatchButton token={l} /></div>
-    <Link href={`/t/${l.chain}/${l.token}`} className={`bb-market-row group block border-b border-line bg-paper pl-11 pr-2 py-3 transition-colors hover:bg-card focus-visible:relative focus-visible:z-10 motion-reduce:transition-none ${flash}`} title={l.description || `${l.name} (${l.symbol})`}>
-      <div className={`grid ${columns} grid-cols-[minmax(0,1fr)_6rem] items-center gap-x-3 gap-y-2.5`}>
-        <div className="flex min-w-0 items-center gap-2.5">
-          {rank !== undefined ? <span className="hidden w-4 shrink-0 text-right font-mono text-[11px] text-muted tnum xl:block">{rank}</span> : null}
-          <TokenAvatar chain={l.chain} token={l.token} symbol={l.symbol} image={l.image_url} size={36} className="shrink-0 rounded-lg" />
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-center gap-2">
-              <span className="truncate text-sm font-semibold text-ink">{l.name}</span>
-              {isGitlawbQuote(l.quote_key) ? <GitlawbBadge /> : null}
-              {hl?.kind === "new" ? <span className="shrink-0 text-[10px] font-medium text-brand">New</span> : null}
+    <div className={styles.shell}>
+      <div className={styles.watch}><WatchButton token={l} /></div>
+      <Link href={`/t/${l.chain}/${l.token}`} className={`bb-market-row ${styles.row} group block pl-12 pr-3 outline-none ${flash}`} title={l.description || `${l.name} (${l.symbol})`}>
+        <div className={`grid ${columns} grid-cols-[minmax(0,1fr)_6.5rem] items-center gap-x-3 gap-y-1`}>
+          <div className="flex min-w-0 items-center gap-2.5">
+            {rank !== undefined ? <><span className="sr-only">Rank {rank}. </span><span aria-hidden="true" className={styles.rank}>{rank}</span></> : null}
+            <TokenAvatar chain={l.chain} token={l.token} symbol={l.symbol} image={l.image_url} size={44} className={styles.avatar} />
+            <div className="min-w-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className={styles.name}>{l.name}</span>
+                {isGitlawbQuote(l.quote_key) ? <GitlawbBadge /> : null}
+                {hl?.kind === "new" ? <span className={styles.newLabel}>New</span> : null}
+              </div>
+              <div className={styles.identityMeta} title={`${l.symbol} · ${CHAIN_SHORT[l.chain]} · paired with ${l.quote_symbol}`}>
+                <span className={styles.symbol}>{l.symbol}</span><span aria-hidden="true">·</span><span>{CHAIN_SHORT[l.chain]} / {l.quote_symbol}</span><span aria-hidden="true">·</span><span>{age}</span>
+              </div>
             </div>
-            <div className="mt-0.5 truncate text-[11px] text-muted" title={`${l.symbol} · ${CHAIN_SHORT[l.chain]} · paired with ${l.quote_symbol}`}>
-              <span className="font-mono text-body">{l.symbol}</span><span aria-hidden="true"> · </span>{CHAIN_SHORT[l.chain]}<span aria-hidden="true"> · </span>{l.quote_symbol}<span className="hidden sm:inline lg:hidden"> · {age}</span>
-            </div>
-            <div className={`mt-0.5 truncate text-[11px] ${mode === "burn" ? "text-warm-ink" : "text-muted"}`}>{feeLabel}</div>
-            {chip ? <div className={`mt-0.5 truncate text-[11px] ${chip.tier === "live" ? "text-up" : chip.tier === "new" ? "text-brand" : "text-muted"}`} suppressHydrationWarning>{chip.text}</div> : null}
           </div>
+
+          <div className={styles.context}>{context}</div>
+
+          <div className={styles.marketCell}>
+            <span className={styles.mobileMetricLabel}>Market cap</span>
+            <div className={styles.capLine}>
+              <span key={hl?.at ?? "rest"} className={`${styles.capValue} ${pop ? "bb-pop" : ""}`} title={capDetail}>{capLabel}</span>
+              <span className="sr-only">Change since launch </span><ChangeChip v={l.change_from_launch} plain className={styles.change} />
+            </div>
+            <span className={styles.capDetail} title={capDetail}>{cap.detail}</span>
+          </div>
+
+          <div className={`${styles.volumeCell} hidden lg:block`} title={volumeDetail}><span className="sr-only">Volume {window} </span><span className={styles.volumeValue}>{volLabel}</span><span className={styles.metricHint}>{window === "all" ? "all time" : window}</span></div>
+          <div className="hidden min-w-0 sm:block"><ActivitySignal buys={l.buys} sells={l.sells} holders={l.holders} volumeLabel={volLabel} /></div>
+
+          <dl className={`${styles.mobileMetrics} col-span-2 sm:hidden`}>
+            <div className="min-w-0"><dt>Volume · {window}</dt><dd title={volumeDetail}>{volLabel}</dd></div>
+            <div className="min-w-0 text-right"><dt className="sr-only">Order flow</dt><dd><ActivitySignal buys={l.buys} sells={l.sells} holders={l.holders} /></dd></div>
+          </dl>
         </div>
-        <div className="min-w-0 text-right">
-          <span className="mb-0.5 block text-[10px] text-muted sm:sr-only">Market cap</span>
-          <span key={hl?.at ?? "rest"} className={`block truncate font-mono text-sm font-bold text-ink tnum ${pop ? "bb-pop" : ""}`} title={capDetail}>{capLabel}</span>
-          <span className="hidden truncate font-mono text-[10px] text-muted tnum lg:block" title={capDetail}>{cap.detail}</span>
-          <span className="mt-0.5 block lg:hidden"><span className="block truncate font-mono text-[10px] text-muted tnum" title={capDetail}>{cap.detail}</span><span className="sr-only">Change since launch </span><ChangeChip v={l.change_from_launch} plain /></span>
-        </div>
-        <div className="hidden min-w-0 text-right lg:block"><span className="sr-only">Change since launch </span><ChangeChip v={l.change_from_launch} plain /></div>
-        <div className="hidden min-w-0 text-right font-mono text-xs text-body tnum sm:block" title={volumeDetail}><span className="sr-only">Volume {window} </span><span className="block truncate">{volLabel}</span></div>
-        <div className="hidden text-right font-mono text-xs tnum sm:block">
-          <span className="sr-only">Buys </span><span className="text-up">{l.buys}</span><span className="text-muted"> / </span><span className="sr-only">Sells </span><span className="text-down-ink">{l.sells}</span>
-          <div className="mt-0.5 text-[10px] text-muted">{l.holders} holders</div>
-        </div>
-        <div className="hidden text-right font-mono text-[11px] text-muted tnum lg:block"><span className="sr-only">Launched </span>{age}<span className="sr-only"> ago</span></div>
-        <dl className="col-span-2 grid grid-cols-[1.3fr_1fr_1fr_auto] gap-2 pt-1 sm:hidden">
-          <div className="min-w-0"><dt className="text-[10px] text-muted">Volume · {window}</dt><dd className="mt-1 truncate font-mono text-[11px] text-body tnum" title={volumeDetail}>{volLabel}</dd></div>
-          <div><dt className="text-[10px] text-muted">Buys / sells</dt><dd className="mt-1 font-mono text-[11px] tnum"><span className="text-up">{l.buys}</span><span className="text-muted"> / </span><span className="text-down-ink">{l.sells}</span></dd></div>
-          <div><dt className="text-[10px] text-muted">Holders</dt><dd className="mt-1 font-mono text-[11px] text-body tnum">{l.holders}</dd></div>
-          <div className="text-right"><dt className="text-[10px] text-muted">Age</dt><dd className="mt-1 font-mono text-[11px] text-body tnum">{age}</dd></div>
-        </dl>
-      </div>
-    </Link>
+      </Link>
     </div>
   );
 }

--- a/app/src/components/launchpad/LaunchRow.tsx
+++ b/app/src/components/launchpad/LaunchRow.tsx
@@ -12,18 +12,19 @@ import GitlawbBadge, { isGitlawbQuote } from "./GitlawbBadge";
 import { marketUsd } from "@/lib/launchpad/market-format";
 import { capDisplay } from "@/lib/launchpad/market-cap";
 import type { LiveTier } from "@/lib/launchpad/ranking";
+import WatchButton from "./WatchButton";
 
-const columns = "md:grid-cols-[minmax(0,1fr)_6.5rem_5.5rem_6rem_5rem_2.5rem]";
+const columns = "launch-ledger";
 
 export function LaunchListHeader({ window }: { window: VolumeWindow }) {
   return (
-    <div aria-hidden="true" className={`hidden md:grid ${columns} items-center gap-3 border-y border-line bg-card px-4 py-3 text-[11px] font-medium text-muted`}>
+    <div aria-hidden="true" className={`hidden sm:grid ${columns} items-center gap-3 border-b border-line pl-11 pr-2 py-2 text-[11px] font-medium text-muted`}>
       <span>Token / paired with</span>
       <span className="text-right">Market cap</span>
-      <span className="text-right">Since launch</span>
+      <span className="hidden text-right lg:block">Since launch</span>
       <span className="text-right">Volume · {window}</span>
       <span className="text-right">Buys / sells</span>
-      <span className="text-right">Age</span>
+      <span className="hidden text-right lg:block">Age</span>
     </div>
   );
 }
@@ -46,8 +47,10 @@ export default function LaunchRow({ l, rank, window = "all", hl = null, now, pop
   const age = <time dateTime={l.block_time} title={new Date(l.block_time).toUTCString()} suppressHydrationWarning>{ago(l.block_time, now)}</time>;
 
   return (
-    <Link href={`/t/${l.chain}/${l.token}`} className={`bb-market-row group block border-b border-line bg-paper px-4 py-3.5 transition-colors hover:bg-card focus-visible:relative focus-visible:z-10 motion-reduce:transition-none ${flash}`} title={l.description || `${l.name} (${l.symbol})`}>
-      <div className={`grid ${columns} grid-cols-[minmax(0,1fr)_7rem] items-center gap-x-3 gap-y-3`}>
+    <div className="relative">
+    <div className="absolute -left-1 top-3 z-10"><WatchButton token={l} /></div>
+    <Link href={`/t/${l.chain}/${l.token}`} className={`bb-market-row group block border-b border-line bg-paper pl-11 pr-2 py-3 transition-colors hover:bg-card focus-visible:relative focus-visible:z-10 motion-reduce:transition-none ${flash}`} title={l.description || `${l.name} (${l.symbol})`}>
+      <div className={`grid ${columns} grid-cols-[minmax(0,1fr)_6rem] items-center gap-x-3 gap-y-2.5`}>
         <div className="flex min-w-0 items-center gap-2.5">
           {rank !== undefined ? <span className="hidden w-4 shrink-0 text-right font-mono text-[11px] text-muted tnum xl:block">{rank}</span> : null}
           <TokenAvatar chain={l.chain} token={l.token} symbol={l.symbol} image={l.image_url} size={36} className="shrink-0 rounded-lg" />
@@ -58,26 +61,26 @@ export default function LaunchRow({ l, rank, window = "all", hl = null, now, pop
               {hl?.kind === "new" ? <span className="shrink-0 text-[10px] font-medium text-brand">New</span> : null}
             </div>
             <div className="mt-0.5 truncate text-[11px] text-muted" title={`${l.symbol} · ${CHAIN_SHORT[l.chain]} · paired with ${l.quote_symbol}`}>
-              <span className="font-mono text-body">{l.symbol}</span><span aria-hidden="true"> · </span>{CHAIN_SHORT[l.chain]}<span aria-hidden="true"> · </span>{l.quote_symbol}
+              <span className="font-mono text-body">{l.symbol}</span><span aria-hidden="true"> · </span>{CHAIN_SHORT[l.chain]}<span aria-hidden="true"> · </span>{l.quote_symbol}<span className="hidden sm:inline lg:hidden"> · {age}</span>
             </div>
             <div className={`mt-0.5 truncate text-[11px] ${mode === "burn" ? "text-warm-ink" : "text-muted"}`}>{feeLabel}</div>
             {chip ? <div className={`mt-0.5 truncate text-[11px] ${chip.tier === "live" ? "text-up" : chip.tier === "new" ? "text-brand" : "text-muted"}`} suppressHydrationWarning>{chip.text}</div> : null}
           </div>
         </div>
         <div className="min-w-0 text-right">
-          <span className="mb-0.5 block text-[10px] text-muted md:sr-only">Market cap</span>
+          <span className="mb-0.5 block text-[10px] text-muted sm:sr-only">Market cap</span>
           <span key={hl?.at ?? "rest"} className={`block truncate font-mono text-sm font-bold text-ink tnum ${pop ? "bb-pop" : ""}`} title={capDetail}>{capLabel}</span>
-          <span className="hidden truncate font-mono text-[10px] text-muted tnum md:block" title={capDetail}>{cap.detail}</span>
-          <span className="mt-0.5 block md:hidden"><span className="block truncate font-mono text-[10px] text-muted tnum" title={capDetail}>{cap.detail}</span><span className="sr-only">Change since launch </span><ChangeChip v={l.change_from_launch} plain /></span>
+          <span className="hidden truncate font-mono text-[10px] text-muted tnum lg:block" title={capDetail}>{cap.detail}</span>
+          <span className="mt-0.5 block lg:hidden"><span className="block truncate font-mono text-[10px] text-muted tnum" title={capDetail}>{cap.detail}</span><span className="sr-only">Change since launch </span><ChangeChip v={l.change_from_launch} plain /></span>
         </div>
-        <div className="hidden min-w-0 text-right md:block"><span className="sr-only">Change since launch </span><ChangeChip v={l.change_from_launch} plain /></div>
-        <div className="hidden min-w-0 text-right font-mono text-xs text-body tnum md:block" title={volumeDetail}><span className="sr-only">Volume {window} </span><span className="block truncate">{volLabel}</span></div>
-        <div className="hidden text-right font-mono text-xs tnum md:block">
+        <div className="hidden min-w-0 text-right lg:block"><span className="sr-only">Change since launch </span><ChangeChip v={l.change_from_launch} plain /></div>
+        <div className="hidden min-w-0 text-right font-mono text-xs text-body tnum sm:block" title={volumeDetail}><span className="sr-only">Volume {window} </span><span className="block truncate">{volLabel}</span></div>
+        <div className="hidden text-right font-mono text-xs tnum sm:block">
           <span className="sr-only">Buys </span><span className="text-up">{l.buys}</span><span className="text-muted"> / </span><span className="sr-only">Sells </span><span className="text-down-ink">{l.sells}</span>
           <div className="mt-0.5 text-[10px] text-muted">{l.holders} holders</div>
         </div>
-        <div className="hidden text-right font-mono text-[11px] text-muted tnum md:block"><span className="sr-only">Launched </span>{age}<span className="sr-only"> ago</span></div>
-        <dl className="col-span-2 grid grid-cols-[1.3fr_1fr_1fr_auto] gap-3 border-t border-line pt-2.5 md:hidden">
+        <div className="hidden text-right font-mono text-[11px] text-muted tnum lg:block"><span className="sr-only">Launched </span>{age}<span className="sr-only"> ago</span></div>
+        <dl className="col-span-2 grid grid-cols-[1.3fr_1fr_1fr_auto] gap-2 pt-1 sm:hidden">
           <div className="min-w-0"><dt className="text-[10px] text-muted">Volume · {window}</dt><dd className="mt-1 truncate font-mono text-[11px] text-body tnum" title={volumeDetail}>{volLabel}</dd></div>
           <div><dt className="text-[10px] text-muted">Buys / sells</dt><dd className="mt-1 font-mono text-[11px] tnum"><span className="text-up">{l.buys}</span><span className="text-muted"> / </span><span className="text-down-ink">{l.sells}</span></dd></div>
           <div><dt className="text-[10px] text-muted">Holders</dt><dd className="mt-1 font-mono text-[11px] text-body tnum">{l.holders}</dd></div>
@@ -85,5 +88,6 @@ export default function LaunchRow({ l, rank, window = "all", hl = null, now, pop
         </dl>
       </div>
     </Link>
+    </div>
   );
 }

--- a/app/src/components/launchpad/LaunchSequence.tsx
+++ b/app/src/components/launchpad/LaunchSequence.tsx
@@ -1,0 +1,36 @@
+import { useId } from "react";
+import styles from "./LaunchMachine.module.css";
+
+const sequence = [
+  { label: "Create", offset: "13%", dashOffset: 0 },
+  { label: "Pool", offset: "49%", dashOffset: -36 },
+  { label: "Lock", offset: "85%", dashOffset: -72 },
+] as const;
+
+/** Original curved type treatment; its only input is the machine's existing stage. */
+export default function LaunchSequence({ stage }: { stage: number }) {
+  const pathId = `launch-sequence-${useId()}`;
+
+  return (
+    <g className={styles.sequence}>
+      <defs>
+        <path id={pathId} d="M191 28 Q321 -15 475 101" />
+      </defs>
+      <path d="M191 40 Q321 -3 469 113" pathLength="100" className={styles.sequenceTrack} />
+      {sequence.map((item, index) => (
+        <g key={item.label} className={styles.sequenceStep} data-active={stage === index}>
+          <path
+            d="M191 40 Q321 -3 469 113"
+            pathLength="100"
+            strokeDasharray="26 100"
+            strokeDashoffset={item.dashOffset}
+            className={styles.sequenceSegment}
+          />
+          <text className={styles.sequenceLabel} textAnchor="middle">
+            <textPath href={`#${pathId}`} startOffset={item.offset}>{item.label}</textPath>
+          </text>
+        </g>
+      ))}
+    </g>
+  );
+}

--- a/app/src/components/launchpad/LaunchTape.tsx
+++ b/app/src/components/launchpad/LaunchTape.tsx
@@ -37,7 +37,7 @@ export default function LaunchTape({ initial }: { initial: FeedItem[] }) {
   }, [subscribe]);
 
   return (
-    <section aria-labelledby="activity-heading" className="overflow-hidden rounded-2xl border border-line bg-paper">
+    <section aria-labelledby="activity-heading" className="min-w-0">
       <div className="flex min-h-14 items-center justify-between border-b border-line px-4">
         <h2 id="activity-heading" className="flex items-center gap-2 text-sm font-semibold text-ink"><Activity size={14} aria-hidden="true" className="text-muted" />Activity</h2>
         <span className="text-[11px] text-muted">Launches & trades</span>

--- a/app/src/components/launchpad/MeDashboard.module.css
+++ b/app/src/components/launchpad/MeDashboard.module.css
@@ -8,7 +8,8 @@
 .welcomeMain h2 { margin-top: 12px; color: var(--color-ink); font-size: 36px; font-weight: 600; line-height: 1.15; letter-spacing: -.04em; }
 .welcomeMain h2 span { color: var(--color-muted); }
 .welcomeCopy { max-width: 340px; margin-top: 20px; font-size: 14px; line-height: 1.75; text-wrap: pretty; }
-.connectButton, .outlineButton, .quietButton, .refresh { display: inline-flex; align-items: center; justify-content: center; gap: 10px; min-height: 44px; padding: 10px 16px; border-radius: 8px; color: var(--color-ink); background: var(--color-line); font-size: 13px; font-weight: 600; cursor: pointer; transition: color 160ms, background-color 160ms; }
+.connectButton, .outlineButton, .quietButton, .refresh { display: inline-flex; align-items: center; justify-content: center; gap: 10px; min-height: 44px; padding: 10px 16px; border-radius: 8px; color: var(--color-ink); background: var(--color-line); font-size: 13px; font-weight: 600; cursor: pointer; transition: color 160ms, background-color 160ms, transform 160ms; }
+.dashboard :is(.connectButton, .outlineButton, .quietButton, .refresh):active:not(:disabled) { transform: scale(.98); }
 .connectButton { margin-top: 28px; background: var(--color-ink); color: var(--color-inverse); padding-inline: 20px; }
 .connectButton:hover:not(:disabled) { background: var(--color-body); }
 .outlineButton:hover:not(:disabled), .refresh:hover:not(:disabled) { background: var(--color-line-strong); }
@@ -31,12 +32,25 @@
 .disclosure p { max-width: 560px; text-align: right; text-wrap: pretty; }
 .walletBar { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding-block: 20px; border-top: 1px solid var(--color-line); }
 .identity { display: flex; align-items: center; gap: 12px; min-width: 0; }
-.walletIcon { display: grid; place-items: center; width: 32px; height: 44px; color: var(--color-muted); }
+.identity > svg { flex-shrink: 0; }
 .identity p { font-size: 11px; color: var(--color-muted); margin-bottom: 2px; }
 .address { font-family: var(--font-mono); font-size: 13px; color: var(--color-ink); }
 .walletUtilities { display: flex; align-items: center; gap: 16px; }
 .updateNote { font-size: 11px; color: var(--color-muted); }
-.refresh { padding-inline: 14px; font-size: 12px; }
+.refresh { min-width: 112px; padding-inline: 14px; font-size: 12px; }
+.refresh[data-refreshed] { color: var(--color-up); }
+.collectionProgress { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 20px; padding-block: 18px; margin-bottom: 12px; border-block: 1px solid var(--color-line); }
+.collectionProgress > div { display: flex; align-items: center; gap: 12px; }
+.progressMarker { display: grid; place-items: center; width: 24px; flex-shrink: 0; color: var(--color-brand); }
+.collectionProgress strong { display: block; color: var(--color-ink); font-size: 13px; font-weight: 500; }
+.collectionProgress p > span { display: block; margin-top: 4px; color: var(--color-muted); font-size: 12px; line-height: 1.65; }
+.collectionProgress ol { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; }
+.collectionProgress li { display: flex; align-items: center; gap: 6px; color: var(--color-muted); font-size: 11px; }
+.collectionProgress li > span { font-variant-numeric: tabular-nums; }
+.collectionProgress li[data-active] { color: var(--color-ink); }
+.collectionProgress li[data-active] > span { color: var(--color-brand); }
+.collectionProgress[data-stage="confirmed"] .progressMarker { color: var(--color-up); }
+.collectionProgress[data-stage="failed"] .progressMarker { color: var(--color-down-ink); }
 .stats { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 32px; padding-bottom: 28px; border-bottom: 1px solid var(--color-line); }
 .stat { min-width: 0; padding-block: 16px; }
 .stat dt { color: var(--color-muted); font-size: 12px; }
@@ -123,7 +137,6 @@
   .tabsList { gap: 20px; }
   .tabCount { display: none; }
   .walletBar { gap: 8px; }
-  .walletIcon { display: none; }
   .refresh { padding-inline: 12px; }
   .stats, .loadingStats { gap: 12px 24px; }
   .stat dd:not(.statHint) { font-size: 19px; }
@@ -132,4 +145,5 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .dashboard *, .dashboard *::before, .dashboard *::after { transition: none !important; }
+  .dashboard :is(.connectButton, .outlineButton, .quietButton, .refresh):active:not(:disabled) { transform: none; }
 }

--- a/app/src/components/launchpad/MeDashboard.module.css
+++ b/app/src/components/launchpad/MeDashboard.module.css
@@ -1,22 +1,23 @@
 .dashboard { min-width: 0; margin-top: 32px; color: var(--color-body); }
 .dashboard :is(a, button, [tabindex]):focus-visible { outline: 2px solid var(--color-brand); outline-offset: 3px; border-radius: 6px; }
-.welcome { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--color-line); border-radius: 20px; overflow: hidden; }
-.welcomeMain { padding: 40px; background: var(--color-card); }
-.walletMark { display: grid; place-items: center; width: 60px; height: 60px; border: 1px solid var(--color-line-strong); border-radius: 16px; color: var(--color-ink); margin-bottom: 28px; }
-.eyebrow { color: var(--color-muted); font-size: 11px; font-weight: 600; letter-spacing: .1em; text-transform: uppercase; }
+.welcome { display: grid; grid-template-columns: 1fr 1fr; align-items: start; gap: 64px; padding-block: 8px 32px; }
+.welcomeMain { min-width: 0; }
+.walletMark { display: inline-flex; color: var(--color-muted); margin-bottom: 24px; }
+.eyebrow { color: var(--color-muted); font-size: 12px; line-height: 1.6; }
+.welcomeMain > .eyebrow { margin-top: 16px; }
 .welcomeMain h2 { margin-top: 12px; color: var(--color-ink); font-size: 36px; font-weight: 600; line-height: 1.15; letter-spacing: -.04em; }
 .welcomeMain h2 span { color: var(--color-muted); }
 .welcomeCopy { max-width: 340px; margin-top: 20px; font-size: 14px; line-height: 1.75; text-wrap: pretty; }
-.connectButton, .outlineButton, .quietButton, .refresh { display: inline-flex; align-items: center; justify-content: center; gap: 10px; min-height: 44px; padding: 10px 16px; border: 1px solid var(--color-line-strong); border-radius: 9999px; color: var(--color-ink); background: var(--color-paper); font-size: 13px; font-weight: 600; cursor: pointer; transition: color 160ms, background-color 160ms, border-color 160ms; }
-.connectButton { margin-top: 28px; background: var(--color-ink); color: var(--color-inverse); border-color: var(--color-ink); padding-inline: 20px; }
-.connectButton:hover:not(:disabled) { background: var(--color-body); border-color: var(--color-body); }
-.outlineButton:hover:not(:disabled), .refresh:hover:not(:disabled) { border-color: var(--color-ink); background: var(--color-card); }
-.quietButton { background: transparent; border-color: transparent; }
-.quietButton:hover:not(:disabled) { background: var(--color-card); border-color: var(--color-line); }
+.connectButton, .outlineButton, .quietButton, .refresh { display: inline-flex; align-items: center; justify-content: center; gap: 10px; min-height: 44px; padding: 10px 16px; border-radius: 8px; color: var(--color-ink); background: var(--color-line); font-size: 13px; font-weight: 600; cursor: pointer; transition: color 160ms, background-color 160ms; }
+.connectButton { margin-top: 28px; background: var(--color-ink); color: var(--color-inverse); padding-inline: 20px; }
+.connectButton:hover:not(:disabled) { background: var(--color-body); }
+.outlineButton:hover:not(:disabled), .refresh:hover:not(:disabled) { background: var(--color-line-strong); }
+.quietButton { background: transparent; }
+.quietButton:hover:not(:disabled) { background: var(--color-card); }
 .dashboard button:disabled { opacity: .5; cursor: not-allowed; }
 .readOnly { display: flex; align-items: flex-start; gap: 8px; margin-top: 20px; max-width: 330px; color: var(--color-muted); font-size: 11px; line-height: 1.75; text-wrap: pretty; }
 .readOnly svg { margin-top: 2px; flex-shrink: 0; }
-.welcomeGuide { padding: 40px; border-left: 1px solid var(--color-line); }
+.welcomeGuide { min-width: 0; padding-left: 32px; border-left: 1px solid var(--color-line); }
 .capabilities { margin-top: 8px; }
 .capabilities li { display: grid; grid-template-columns: 28px minmax(0, 1fr); gap: 12px; padding-block: 26px; border-bottom: 1px solid var(--color-line); }
 .step { color: var(--color-muted); font-family: var(--font-mono); font-size: 11px; padding-top: 3px; }
@@ -30,27 +31,26 @@
 .disclosure p { max-width: 560px; text-align: right; text-wrap: pretty; }
 .walletBar { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding-block: 20px; border-top: 1px solid var(--color-line); }
 .identity { display: flex; align-items: center; gap: 12px; min-width: 0; }
-.walletIcon { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; border: 1px solid var(--color-line); background: var(--color-card); color: var(--color-ink); }
+.walletIcon { display: grid; place-items: center; width: 32px; height: 44px; color: var(--color-muted); }
 .identity p { font-size: 11px; color: var(--color-muted); margin-bottom: 2px; }
 .address { font-family: var(--font-mono); font-size: 13px; color: var(--color-ink); }
 .walletUtilities { display: flex; align-items: center; gap: 16px; }
 .updateNote { font-size: 11px; color: var(--color-muted); }
 .refresh { padding-inline: 14px; font-size: 12px; }
-.stats { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border: 1px solid var(--color-line); border-radius: 16px; overflow: hidden; }
-.stat { min-width: 0; padding: 24px; background: var(--color-card); }
-.stat + .stat { border-left: 1px solid var(--color-line); }
+.stats { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 32px; padding-bottom: 28px; border-bottom: 1px solid var(--color-line); }
+.stat { min-width: 0; padding-block: 16px; }
 .stat dt { color: var(--color-muted); font-size: 12px; }
 .stat dd:not(.statHint) { margin-top: 10px; font-family: var(--font-mono); font-size: 25px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.04em; overflow-wrap: anywhere; }
 .statHint { margin-top: 8px; color: var(--color-muted); font-size: 10px; line-height: 1.5; text-wrap: pretty; }
-.ledger { margin-top: 28px; border: 1px solid var(--color-line); border-radius: 16px; }
-.tabsList { padding-inline: 20px; gap: 28px; }
+.ledger { min-width: 0; margin-top: 28px; }
+.tabsList { gap: 28px; }
 .tabCount { font-family: var(--font-mono); font-size: 10px; font-variant-numeric: tabular-nums; color: var(--color-muted); }
-.panelHeading { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 16px; padding: 24px 20px; }
+.panelHeading { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 16px; padding-block: 24px; }
 .panelHeading h2 { color: var(--color-ink); font-size: 15px; font-weight: 600; }
 .panelHeading p { color: var(--color-muted); font-size: 12px; margin-top: 4px; text-wrap: pretty; }
 .tokenList { min-width: 0; }
 .tokenList > li { border-top: 1px solid var(--color-line); }
-.launchRow { display: grid; grid-template-columns: minmax(0, 1fr) 120px 120px auto; align-items: center; gap: 16px; padding: 20px; }
+.launchRow { display: grid; grid-template-columns: minmax(0, 1fr) 120px 120px auto; align-items: center; gap: 16px; padding-block: 20px; }
 .tokenIdentity { display: flex; align-items: center; gap: 12px; min-width: 0; min-height: 44px; }
 .tokenIdentity:hover .tokenName { text-decoration: underline; text-underline-offset: 4px; }
 .tokenName { display: flex; align-items: center; flex-wrap: wrap; gap: 4px 8px; min-width: 0; }
@@ -58,16 +58,17 @@
 .tokenMeta { display: flex; align-items: center; flex-wrap: wrap; gap: 3px 8px; margin-top: 4px; color: var(--color-muted); font-family: var(--font-mono); font-size: 10px; line-height: 1.75; }
 .figure { min-width: 0; text-align: right; font-family: var(--font-mono); font-size: 13px; font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
 .rowActions { display: flex; align-items: center; gap: 4px; }
-.rowActions button { border-radius: 10px; padding-inline: 12px; font-size: 12px; }
-.panelNote { display: flex; align-items: flex-start; gap: 8px; padding: 16px 20px; border-top: 1px solid var(--color-line); color: var(--color-muted); font-size: 11px; line-height: 1.7; text-wrap: pretty; }
+.rowActions button { padding-inline: 12px; font-size: 12px; }
+.panelNote { display: flex; align-items: flex-start; gap: 8px; padding-block: 20px; border-top: 1px solid var(--color-line); color: var(--color-muted); font-size: 11px; line-height: 1.7; text-wrap: pretty; }
 .panelNote svg { flex-shrink: 0; margin-top: 2px; }
-.holdingRow { display: flex; align-items: center; gap: 12px; min-width: 0; padding: 20px; transition: background-color 160ms; }
+.holdingRow { display: flex; align-items: center; gap: 12px; min-width: 0; padding-block: 20px; transition: background-color 160ms; }
 .holdingRow:hover { background: var(--color-card); }
 .holdingValue { flex-shrink: 0; max-width: 40%; text-align: right; font-family: var(--font-mono); font-size: 13px; font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
 .tradeScroll { max-width: 100%; overflow-x: auto; border-top: 1px solid var(--color-line); }
 .trades { width: 100%; text-align: left; font-size: 12px; }
-.trades th { font-size: 10px; font-weight: 500; color: var(--color-muted); white-space: nowrap; background: var(--color-card); }
-.trades :is(th, td) { padding: 12px 20px; }
+.trades th { font-size: 10px; font-weight: 500; color: var(--color-muted); white-space: nowrap; }
+.trades :is(th, td) { padding: 12px 20px 12px 0; }
+.trades :is(th, td):last-child { padding-right: 0; }
 .trades td { color: var(--color-ink); }
 .trades :is(th, td):nth-child(n + 3) { text-align: right; }
 .trades td:nth-child(3) { white-space: nowrap; }
@@ -76,34 +77,32 @@
 .tradeSide { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-sans); font-weight: 600; }
 .tradeChain { display: block; font-size: 10px; color: var(--color-muted); }
 .trades .txLink { justify-content: flex-end; gap: 5px; color: var(--color-muted); white-space: nowrap; }
-.empty { display: flex; align-items: center; flex-direction: column; text-align: center; border-top: 1px solid var(--color-line); padding: 40px 24px 48px; }
-.emptyIcon { display: grid; place-items: center; width: 56px; height: 56px; margin-bottom: 20px; background: var(--color-card); border: 1px dashed var(--color-line-strong); border-radius: 16px; color: var(--color-muted); }
+.empty { display: flex; align-items: flex-start; flex-direction: column; border-top: 1px solid var(--color-line); padding-block: 40px 48px; }
+.emptyIcon { display: inline-flex; margin-bottom: 20px; color: var(--color-muted); }
 .empty h3 { font-size: 18px; font-weight: 600; letter-spacing: -.02em; color: var(--color-ink); }
 .empty p { max-width: 350px; margin-top: 8px; color: var(--color-muted); font-size: 13px; line-height: 1.75; text-wrap: pretty; }
 .empty .outlineButton { margin-top: 24px; }
-.error { margin-block: 16px; padding: 20px; border: 1px solid var(--color-line-strong); border-radius: 12px; font-size: 13px; line-height: 1.75; }
+.error { margin-block: 16px; padding-block: 20px; border-block: 1px solid var(--color-line); font-size: 13px; line-height: 1.75; }
 .error h2 { color: var(--color-ink); font-size: 16px; font-weight: 600; }
 .error p { margin-block: 8px 16px; color: var(--color-muted); }
 .loading { display: grid; gap: 28px; }
-.loadingStats { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
-.loadingRows { border: 1px solid var(--color-line); border-radius: 16px; overflow: hidden; }
+.loadingStats { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 32px; }
+.loadingRows { min-width: 0; border-top: 1px solid var(--color-line); }
 @media (max-width: 1023px) {
-  .welcomeMain, .welcomeGuide { padding: 28px; }
+  .welcome { gap: 32px; }
+  .welcomeGuide { padding-left: 24px; }
   .welcomeMain h2 { font-size: 32px; }
   .launchRow { grid-template-columns: minmax(0, 1fr) 120px 120px; }
   .rowActions { grid-column: 1 / -1; justify-content: flex-end; }
-  .stat { padding: 20px; }
+  .stats { gap: 24px; }
   .stat dd:not(.statHint) { font-size: 22px; }
 }
 @media (max-width: 767px) {
   .welcome { grid-template-columns: minmax(0, 1fr); }
-  .welcomeGuide { border-left: 0; border-top: 1px solid var(--color-line); }
-  .welcomeMain, .welcomeGuide { padding: 28px 24px; }
+  .welcomeGuide { padding: 28px 0 0; border-left: 0; border-top: 1px solid var(--color-line); }
   .welcomeCopy, .readOnly { max-width: none; }
   .welcomeMain h2 { font-size: 34px; }
   .stats, .loadingStats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .stat:nth-child(3) { border-left: 0; }
-  .stat:nth-child(n + 3) { border-top: 1px solid var(--color-line); }
   .updateNote { display: none; }
   .launchRow { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px 12px; }
   .tokenIdentity { grid-column: 1 / -1; }
@@ -111,25 +110,24 @@
   .rowActions { justify-content: flex-start; }
   .disclosure { flex-direction: column; gap: 6px; }
   .disclosure p { text-align: left; }
-  .trades :is(th, td) { padding: 8px 12px; }
+  .trades :is(th, td) { padding: 8px 12px 8px 0; }
   .usdColumn { display: none; }
-  .holdingRow { flex-wrap: wrap; padding: 16px; }
+  .holdingRow { flex-wrap: wrap; padding-block: 16px; }
   .holdingValue { flex-basis: 100%; max-width: none; padding-left: 48px; text-align: left; }
 }
 @media (max-width: 399px) {
-  .welcomeMain, .welcomeGuide { padding: 24px 20px; }
   .welcomeMain h2 { font-size: 30px; }
   .capabilities li { grid-template-columns: 20px minmax(0, 1fr); gap: 8px; }
   .capabilities h3 { align-items: flex-start; font-size: 14px; gap: 8px; }
   .capabilities h3 svg { margin-top: 2px; width: 16px; }
-  .tabsList { gap: 20px; padding-inline: 16px; }
+  .tabsList { gap: 20px; }
   .tabCount { display: none; }
   .walletBar { gap: 8px; }
   .walletIcon { display: none; }
   .refresh { padding-inline: 12px; }
-  .stat { padding: 16px; }
+  .stats, .loadingStats { gap: 12px 24px; }
   .stat dd:not(.statHint) { font-size: 19px; }
-  .panelHeading, .launchRow { padding: 20px 16px; }
+  .panelHeading, .launchRow { padding-block: 20px; }
   .trades { min-width: 360px; }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/app/src/components/launchpad/MeDashboard.tsx
+++ b/app/src/components/launchpad/MeDashboard.tsx
@@ -23,7 +23,7 @@ import type { EditFields } from "@/lib/launchpad/editAuth";
 import { ago } from "@/lib/launchpad/time";
 import { BUILDER_DATA_SUFFIX, CHAINS, CHAIN_SHORT, explorerTx, shortAddr, type ChainKey } from "@/lib/chainPublic";
 import { friendlyError } from "@/lib/errors";
-import { SkRow, SkStat } from "@/components/Skeleton";
+import { Sk, SkRow } from "@/components/Skeleton";
 import ConnectWallet from "@/components/ConnectWallet";
 import styles from "./MeDashboard.module.css";
 
@@ -157,8 +157,8 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
         <section className={styles.welcome} aria-labelledby="wallet-welcome">
           <div className={styles.welcomeMain}>
             <span className={styles.walletMark} aria-hidden="true"><Wallet size={28} strokeWidth={1.5} /></span>
-            <p className={styles.eyebrow}>Start with your wallet</p>
             <h2 id="wallet-welcome">Your wallet.<br /><span>Your workspace.</span></h2>
+            <p className={styles.eyebrow}>Start with your wallet</p>
             <p className={styles.welcomeCopy}>Bring your launches, fees and trading activity into one view. No new account to create.</p>
             <ConnectWallet className={styles.connectButton}>
               Connect wallet<ArrowRight size={16} aria-hidden="true" />
@@ -197,7 +197,7 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
     return (
       <div className={styles.dashboard}>
         {walletBar}
-        {err ? <div className={styles.error} role="alert"><h2>We couldn’t load your dashboard.</h2><p>{err}. Your wallet and tokens are unchanged.</p><button type="button" className={styles.outlineButton} onClick={() => void load()} disabled={refreshing}>Try again<RefreshCw size={14} aria-hidden="true" /></button></div> : <div className={styles.loading} aria-busy="true" aria-label="Loading your dashboard"><dl className={styles.loadingStats}>{Array.from({ length: 4 }, (_, k) => <SkStat key={k} />)}</dl><ul className={styles.loadingRows}>{Array.from({ length: 3 }, (_, k) => <SkRow key={k} i={k} />)}</ul></div>}
+        {err ? <div className={styles.error} role="alert"><h2>We couldn’t load your dashboard.</h2><p>{err}. Your wallet and tokens are unchanged.</p><button type="button" className={styles.outlineButton} onClick={() => void load()} disabled={refreshing}>Try again<RefreshCw size={14} aria-hidden="true" /></button></div> : <div className={styles.loading} aria-busy="true" aria-label="Loading your dashboard"><div className={styles.loadingStats}>{Array.from({ length: 4 }, (_, k) => <div key={k} className={styles.stat}><Sk className="h-3 w-24 max-w-full" /><Sk className="mt-3 h-7 w-20 max-w-full" /><Sk className="mt-3 h-2 w-28 max-w-full" /></div>)}</div><ul className={styles.loadingRows}>{Array.from({ length: 3 }, (_, k) => <SkRow key={k} i={k} />)}</ul></div>}
       </div>
     );
   }

--- a/app/src/components/launchpad/MeDashboard.tsx
+++ b/app/src/components/launchpad/MeDashboard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
-import { ArrowDownLeft, ArrowRight, ArrowUpRight, Coins, Layers3, LockKeyhole, RefreshCw, Wallet } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowDownLeft, ArrowRight, ArrowUpRight, Check, CircleAlert, Coins, Layers3, LockKeyhole, RefreshCw, Wallet } from "lucide-react";
 import { useAccount, useConfig } from "wagmi";
 import { getPublicClient, getWalletClient } from "wagmi/actions";
 import type { Address } from "viem";
@@ -25,11 +25,15 @@ import { BUILDER_DATA_SUFFIX, CHAINS, CHAIN_SHORT, explorerTx, shortAddr, type C
 import { friendlyError } from "@/lib/errors";
 import { Sk, SkRow } from "@/components/Skeleton";
 import ConnectWallet from "@/components/ConnectWallet";
+import WalletAvatar from "@/components/WalletAvatar";
 import styles from "./MeDashboard.module.css";
 
 type Me = { wallet: string; ethUsd: number | null; launches: LaunchRow[]; tokens: (LaunchRow & { my_buys: number; my_sells: number; my_last_trade: string })[]; trades: WalletTrade[] };
 type Pending = Record<string, bigint | null>; // key chain:token → uncollected quote (raw), null = unknown
 type Balances = Record<string, bigint | null>;
+type CollectStage = "checking" | "signing" | "confirming" | "syncing" | "confirmed" | "failed";
+type Collection = { symbol: string; stage: CollectStage; message?: string };
+const COLLECT_LABELS: Record<CollectStage, string> = { checking: "Checking fees", signing: "Confirm in wallet", confirming: "Awaiting confirmation", syncing: "Refreshing indexed data", confirmed: "Confirmed on-chain", failed: "Collection stopped" };
 
 const key = (l: { chain: ChainKey; token: string }) => `${l.chain}:${l.token}`;
 
@@ -54,21 +58,47 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
   const [editing, setEditing] = useState<LaunchRow | null>(null);
   const [now, setNow] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
+  const [refreshed, setRefreshed] = useState(false);
+  const [collection, setCollection] = useState<Collection | null>(null);
+  const [batch, setBatch] = useState<{ completed: number; total: number } | null>(null);
+  const mounted = useRef(true);
+  const collecting = useRef(false);
+  const collectingBatch = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+
+  useEffect(() => {
+    if (!refreshed) return;
+    const timer = setTimeout(() => setRefreshed(false), 3000);
+    return () => clearTimeout(timer);
+  }, [refreshed]);
+
+  useEffect(() => {
+    if (collection?.stage !== "confirmed" || batch) return;
+    const timer = setTimeout(() => setCollection(null), 6000);
+    return () => clearTimeout(timer);
+  }, [collection, batch]);
 
   const load = useCallback(async () => {
     if (!address) return;
     setRefreshing(true);
+    setRefreshed(false);
     try {
       const res = await fetch(`/api/me?wallet=${address}`, { cache: "no-store" });
       if (!res.ok) throw new Error(`me ${res.status}`);
       const m = (await res.json()) as Me;
+      if (!mounted.current) return;
       setMe(m);
       setErr(null);
       setNow(Date.now());
+      setRefreshed(true);
     } catch (e) {
-      setErr(e instanceof Error ? e.message : "failed to load");
+      if (mounted.current) setErr(e instanceof Error ? e.message : "failed to load");
     } finally {
-      setRefreshing(false);
+      if (mounted.current) setRefreshing(false);
     }
   }, [address]);
 
@@ -124,30 +154,58 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
 
   async function collect(l: LaunchRow) {
     const cfg = launchpad(l.chain);
-    if (!cfg.locker || !address) return;
+    if (!cfg.locker || !address || !mounted.current || collecting.current) return false;
+    collecting.current = true;
     setBusy(key(l));
+    setCollection({ symbol: l.symbol, stage: "checking" });
     try {
       const pub = getPublicClient(config, { chainId: CHAINS[l.chain].id })!;
       const wallet = await getWalletClient(config, { chainId: CHAINS[l.chain].id });
+      if (!mounted.current) return false;
       const { request } = await pub.simulateContract({ address: cfg.locker, abi: LAUNCH_LOCKER_ABI, functionName: "collect", args: [BigInt(l.token_id)], account: address, dataSuffix: BUILDER_DATA_SUFFIX });
+      if (!mounted.current) return false;
+      setCollection({ symbol: l.symbol, stage: "signing" });
       const hash = await wallet.writeContract(request);
+      if (mounted.current) setCollection({ symbol: l.symbol, stage: "confirming" });
       const receipt = await pub.waitForTransactionReceipt({ hash });
       if (receipt.status !== "success") throw new Error("Transaction reverted on-chain.");
+      if (!mounted.current) return false;
+      setCollection({ symbol: l.symbol, stage: "syncing" });
       await fetch(`/api/launch/sync?chain=${l.chain}&tx=${hash}`, { method: "POST" }).catch(() => {});
+      if (!mounted.current) return false;
       toast({ kind: "collect", title: `Fees collected for ${l.symbol}`, sub: isBurnOnly(l.recipients) ? "Burned on the spot" : "Paid to the beneficiaries", chain: l.chain, token: l.token, symbol: l.symbol });
       await load();
+      if (!mounted.current) return false;
+      setCollection({ symbol: l.symbol, stage: "confirmed", message: "The transaction succeeded. Indexed totals may take a moment to update." });
+      return true;
     } catch (e) {
-      toast({ kind: "info", title: `Collect failed for ${l.symbol}`, sub: friendlyError(e) });
+      if (mounted.current) {
+        const message = friendlyError(e);
+        setCollection({ symbol: l.symbol, stage: "failed", message });
+        toast({ kind: "info", title: `Collect failed for ${l.symbol}`, sub: message });
+      }
+      return false;
     } finally {
-      setBusy(null);
+      collecting.current = false;
+      if (mounted.current) setBusy(null);
     }
   }
 
   async function collectAll() {
-    if (!me) return;
-    for (const l of me.launches) {
-      const p = pending[key(l)];
-      if (p && p > 0n) await collect(l);
+    if (!me || collecting.current || collectingBatch.current) return;
+    const targets = me.launches.filter((l) => (pending[key(l)] ?? 0n) > 0n);
+    if (!targets.length) return;
+    collectingBatch.current = true;
+    setBatch({ completed: 0, total: targets.length });
+    try {
+      for (const [index, l] of targets.entries()) {
+        if (!mounted.current || !await collect(l)) break;
+        if (!mounted.current) break;
+        setBatch({ completed: index + 1, total: targets.length });
+      }
+    } finally {
+      collectingBatch.current = false;
+      if (mounted.current) setBatch(null);
     }
   }
 
@@ -189,8 +247,8 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
   const feesUnknown = me?.launches.some((l) => pending[key(l)] === null) ?? false;
 
   const walletBar = <div className={styles.walletBar}>
-    <div className={styles.identity}><span className={styles.walletIcon} aria-hidden="true"><Wallet size={19} /></span><div><p>Connected wallet</p><span className={styles.address} title={address}>{shortAddr(address)}</span></div></div>
-    <div className={styles.walletUtilities}><span className={styles.updateNote}>{refreshing ? "Updating your dashboard" : now ? "Latest loaded snapshot" : "Base + Robinhood Chain"}</span><button type="button" className={styles.refresh} onClick={() => void load()} disabled={refreshing || busy !== null}><RefreshCw size={15} aria-hidden="true" />{refreshing ? "Refreshing…" : "Refresh"}</button></div>
+    <div className={styles.identity}><WalletAvatar address={address} size={40} /><div><p>Connected wallet</p><span className={styles.address} title={address}>{shortAddr(address)}</span></div></div>
+    <div className={styles.walletUtilities}><span className={styles.updateNote} role="status">{refreshing ? "Loading indexed activity" : err ? "Refresh unavailable" : refreshed ? "Snapshot updated" : now ? "Latest loaded snapshot" : "Base + Robinhood Chain"}</span><button type="button" className={styles.refresh} onClick={() => void load()} disabled={refreshing || busy !== null || batch !== null} aria-busy={refreshing} data-refreshed={refreshed || undefined}>{refreshed && !refreshing ? <Check size={15} aria-hidden="true" /> : <RefreshCw size={15} aria-hidden="true" />}{refreshing ? "Refreshing…" : refreshed ? "Updated" : "Refresh"}</button></div>
   </div>;
 
   if (!me) {
@@ -205,6 +263,10 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
     <div className={styles.dashboard}>
       {walletBar}
       {err ? <p className={styles.error} role="alert">Refresh failed: {err}. Showing the last loaded data. Try Refresh again.</p> : null}
+      {collection ? <div className={styles.collectionProgress} data-stage={collection.stage} role="status" aria-live="polite" aria-atomic="true">
+        <div><span className={styles.progressMarker} aria-hidden="true">{collection.stage === "confirmed" ? <Check size={16} /> : collection.stage === "failed" ? <CircleAlert size={16} /> : <Coins size={16} />}</span><p><strong>{collection.symbol}: {COLLECT_LABELS[collection.stage]}</strong><span>{batch ? `${batch.completed} of ${batch.total} confirmed. Each collection needs your approval.` : collection.message ?? "Your wallet stays in control at every step."}</span></p></div>
+        {collection.stage !== "failed" && collection.stage !== "confirmed" ? <ol aria-label="Collection progress">{(["checking", "signing", "confirming"] as const).map((stage, index) => <li key={stage} data-active={stage === collection.stage || (stage === "confirming" && collection.stage === "syncing") || undefined}><span>{index + 1}</span>{stage === "checking" ? "Check" : stage === "signing" ? "Sign" : "Confirm"}</li>)}</ol> : null}
+      </div> : null}
       <dl className={styles.stats}>
         <Stat k="Your launches" v={String(me.launches.length)} hint="Across both chains" />
         <Stat k="Fees earned" v={fmtUsd(earnedUsd, { compact: true })} hint="Your share, USD-priced launches" accent="up" />
@@ -223,8 +285,8 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
         <div className={styles.panelHeading}>
           <div><h2>Your launches</h2><p>Manage details and collect trading fees.</p></div>
           {collectable.length > 1 ? (
-            <button type="button" onClick={() => void collectAll()} disabled={busy !== null} className={styles.outlineButton}>
-              {busy ? "Collecting…" : `Collect all (${collectable.length})`}
+            <button type="button" onClick={() => void collectAll()} disabled={busy !== null || batch !== null} className={styles.outlineButton}>
+              {batch ? `Collecting ${Math.min(batch.completed + 1, batch.total)} of ${batch.total}` : busy ? "Collecting…" : `Collect all (${collectable.length})`}
             </button>
           ) : null}
         </div>
@@ -265,8 +327,8 @@ function WalletDashboard({ address, isConnected }: { address: Address | undefine
                     <div className="text-[11px] text-muted">uncollected</div>
                   </div>
                   <div className={styles.rowActions}>
-                    <button type="button" onClick={() => void collect(l)} disabled={busy !== null || !p || p === 0n} className={styles.outlineButton} aria-label={`Collect fees for ${l.symbol}`}>
-                      {busy === k ? "Collecting…" : "Collect"}
+                    <button type="button" onClick={() => { if (!collectingBatch.current) void collect(l); }} disabled={busy !== null || batch !== null || !p || p === 0n} className={styles.outlineButton} aria-label={`Collect fees for ${l.symbol}`}>
+                      {busy === k && collection ? COLLECT_LABELS[collection.stage] : "Collect"}
                     </button>
                     <button type="button" onClick={() => setEditing(l)} className={styles.quietButton} aria-label={`Edit ${l.symbol} details`}>
                       Edit

--- a/app/src/components/launchpad/Posts.tsx
+++ b/app/src/components/launchpad/Posts.tsx
@@ -149,7 +149,7 @@ export default function TokenComments({ chain, token, symbol, launcher, embedded
   const replies = (id: number) => posts.filter((p) => p.parent_id === id).slice().reverse();
 
   return (
-    <section className={embedded ? "overflow-hidden bg-paper" : "rounded-2xl bg-card border border-line overflow-hidden"} id="comments">
+    <section className={embedded ? "min-w-0" : "min-w-0 border-t border-line"} id="comments">
       <div className="px-4 h-11 flex items-center justify-between border-b border-line">
         <h2 className="text-sm font-semibold text-ink">
           Comments <span className="ml-1 text-xs font-normal text-muted font-mono tnum">{posts.length}</span>
@@ -306,7 +306,7 @@ export function PostsFeed({ initial, compact = false }: { initial: PostRow[]; co
   };
   const shown = compact ? posts.slice(0, COMPACT_LIMIT) : posts;
   return (
-    <section className={`rounded-2xl border border-line overflow-hidden ${compact ? "bg-paper" : "bg-card"}`}>
+    <section className="min-w-0">
       <div className={`px-4 ${compact ? "min-h-14" : "h-11"} flex items-center justify-between gap-2 ${compact && collapsed ? "" : "border-b border-line"}`}>
         <h2 className="text-sm font-semibold text-ink flex items-center gap-2">
           {compact ? <MessageSquare size={14} aria-hidden="true" className="text-muted" /> : null}

--- a/app/src/components/launchpad/TokenAvatar.tsx
+++ b/app/src/components/launchpad/TokenAvatar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { cn } from "@/lib/utils";
 
 /** Deterministic hue from an address — same identity trick as the tape dots. */
 export function hueOf(addr: string): number {
@@ -30,7 +31,7 @@ export default function TokenAvatar({ token, symbol, image, size = 40, className
         height={size}
         referrerPolicy="no-referrer"
         onError={() => setFailedSrc(src)}
-        className={`shrink-0 rounded-xl object-cover bg-paper border border-line ${className}`}
+        className={cn("shrink-0 rounded-xl object-cover bg-paper border border-line", className)}
         style={style}
       />
     );
@@ -38,7 +39,7 @@ export default function TokenAvatar({ token, symbol, image, size = 40, className
   return (
     <div
       aria-hidden
-      className={`shrink-0 rounded-xl grid place-items-center font-display font-bold text-white select-none ${className}`}
+      className={cn("shrink-0 rounded-xl grid place-items-center font-display font-bold text-white select-none", className)}
       style={{ ...style, background: `linear-gradient(135deg, hsl(${h} 70% 55%), hsl(${(h + 40) % 360} 75% 45%))` }}
     >
       {symbol.slice(0, 1).toUpperCase()}

--- a/app/src/components/launchpad/TokenDetails.tsx
+++ b/app/src/components/launchpad/TokenDetails.tsx
@@ -14,8 +14,8 @@ export default function TokenDetails({ trades, holders, conversation, about }: {
     return () => { clearTimeout(timer); cancelAnimationFrame(frame); window.removeEventListener("hashchange", selectHash); };
   }, []);
   return (
-    <Tabs id="token-details" value={tab} onValueChange={(v) => setTab(String(v))} className="scroll-mt-24 overflow-hidden rounded-2xl border border-line bg-paper">
-      <TabsList aria-label="Token details">
+    <Tabs id="token-details" value={tab} onValueChange={(v) => setTab(String(v))} className="min-w-0 scroll-mt-24">
+      <TabsList aria-label="Token details" className="gap-5 px-0">
         <TabsTab value="trades">Trades</TabsTab>
         <TabsTab value="holders">Holders</TabsTab>
         <TabsTab value="conversation">Conversation</TabsTab>

--- a/app/src/components/launchpad/TradePanel.tsx
+++ b/app/src/components/launchpad/TradePanel.tsx
@@ -177,28 +177,28 @@ export default function TradePanel({ chain, token, symbol, poolKey, quote, ethUs
   const inUsd = amountIn !== null && side === "buy" && quoteUsd ? fmtUsd(units(amountIn, quote.decimals) * quoteUsd) : null;
 
   return (
-    <section className="overflow-hidden rounded-2xl border border-line-strong bg-paper scroll-mt-24" id="trade" tabIndex={-1} aria-label={`Trade ${symbol}`}>
+    <section className="overflow-hidden rounded-xl bg-card scroll-mt-24" id="trade" tabIndex={-1} aria-label={`Trade ${symbol}`}>
       <div className="flex min-h-12 items-center justify-between gap-3 border-b border-line px-5"><h2 className="min-w-0 truncate text-sm font-semibold text-ink">Trade {symbol}</h2><span className="shrink-0 text-[11px] text-muted">{CHAIN_LABEL}</span></div>
       <div className="space-y-4 p-4 sm:p-5">
       <ToggleGroup aria-label="Trade side" value={[side]} onValueChange={(v) => { if (!v[0] || busy) return; setSide(v[0] as Side); setAmount(""); setQuote(null); setQuoting(false); setPhase({ k: "idle" }); }} className="grid w-full grid-cols-2">
-        {(["buy", "sell"] as Side[]).map((s) => <ToggleGroupItem key={s} value={s} disabled={busy} className={`min-h-10 text-sm ${s === "buy" ? "data-pressed:text-up" : "data-pressed:text-down-ink"}`}>{s === "buy" ? "Buy" : "Sell"}</ToggleGroupItem>)}
+        {(["buy", "sell"] as Side[]).map((s) => <ToggleGroupItem key={s} value={s} disabled={busy} className={`min-h-11 text-sm data-pressed:bg-paper ${s === "buy" ? "data-pressed:text-up" : "data-pressed:text-down-ink"}`}>{s === "buy" ? "Buy" : "Sell"}</ToggleGroupItem>)}
       </ToggleGroup>
 
       <div className="relative">
-        <div className="rounded-xl border border-line bg-card px-4 pt-3 pb-4">
+        <div className="border-b border-line pb-5">
           <div className="flex items-center justify-between gap-2 text-[11px] text-muted"><label htmlFor={`amount-${chain}-${token}`}>{side === "buy" ? "You pay" : "You sell"}</label>
-            {balance !== undefined ? <button type="button" disabled={busy} className="max-w-[65%] truncate font-mono text-[10px] hover:text-ink" title="Use maximum available balance (reserve gas for ETH)" onClick={() => setAmount(side === "buy" ? (isNative ? formatEther(balance > parseEther("0.0005") ? balance - parseEther("0.0005") : 0n) : formatUnits(balance, quote.decimals)) : formatEther(balance))}>Bal {side === "buy" ? fmtQ(balance) : fmtCompact(Number(balance) / 1e18)}</button> : <Wallet size={12} aria-hidden />}
+            {balance !== undefined ? <button type="button" disabled={busy} className="min-h-11 max-w-[65%] truncate font-mono text-[10px] hover:text-ink" title="Use maximum available balance (reserve gas for ETH)" onClick={() => setAmount(side === "buy" ? (isNative ? formatEther(balance > parseEther("0.0005") ? balance - parseEther("0.0005") : 0n) : formatUnits(balance, quote.decimals)) : formatEther(balance))}>Bal {side === "buy" ? fmtQ(balance) : fmtCompact(Number(balance) / 1e18)}</button> : <Wallet size={12} aria-hidden />}
           </div>
           <div className="mt-2 flex items-center gap-3">
-            <input id={`amount-${chain}-${token}`} disabled={busy} className="min-w-0 w-full bg-transparent py-1 font-mono text-[30px] leading-tight text-ink outline-offset-4 placeholder:text-faint tnum" value={amount} onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))} placeholder="0.0" inputMode="decimal" autoComplete="off" aria-label={side === "buy" ? `${quote.symbol} amount` : `${symbol} amount`} />
-            <span className="max-w-24 shrink-0 truncate rounded-lg border border-line-strong bg-paper px-2.5 py-1.5 text-xs font-medium text-ink">{side === "buy" ? quote.symbol : symbol}</span>
+            <input id={`amount-${chain}-${token}`} disabled={busy} className="min-w-0 w-full bg-transparent py-1 font-mono text-[30px] leading-tight text-ink outline-offset-4 placeholder:text-muted tnum" value={amount} onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))} placeholder="0.0" inputMode="decimal" autoComplete="off" aria-label={side === "buy" ? `${quote.symbol} amount` : `${symbol} amount`} />
+            <span className="max-w-24 shrink-0 truncate py-1.5 text-xs font-medium text-ink">{side === "buy" ? quote.symbol : symbol}</span>
           </div>
           <div className="mt-3 grid grid-cols-4 gap-1.5">
-            {side === "buy" ? BUY_PRESETS[quote.key].map((p) => <button key={p} type="button" disabled={busy} onClick={() => setAmount(p)} aria-label={`Pay ${p} ${quote.symbol}`} className={`min-h-8 rounded-md border font-mono text-[11px] tnum hover:border-line-strong disabled:opacity-40 ${amount === p ? "border-line-strong bg-paper text-ink" : "border-line text-muted"}`}>{fmtQuoteUnits(Number(p), quote.decimals)}</button>) : [25, 50, 100].map((pct) => <button key={pct} type="button" disabled={busy || !balance} onClick={() => balance !== undefined && setAmount(formatEther((balance * BigInt(pct)) / 100n))} className="min-h-8 rounded-md border border-line font-mono text-[11px] text-muted tnum hover:border-line-strong disabled:opacity-40">{pct === 100 ? "Max" : `${pct}%`}</button>)}
+            {side === "buy" ? BUY_PRESETS[quote.key].map((p) => <button key={p} type="button" disabled={busy} onClick={() => setAmount(p)} aria-label={`Pay ${p} ${quote.symbol}`} className={`min-h-11 rounded-lg font-mono text-[11px] tnum hover:bg-paper disabled:opacity-40 ${amount === p ? "bg-paper text-ink" : "text-muted"}`}>{fmtQuoteUnits(Number(p), quote.decimals)}</button>) : [25, 50, 100].map((pct) => <button key={pct} type="button" disabled={busy || !balance} onClick={() => balance !== undefined && setAmount(formatEther((balance * BigInt(pct)) / 100n))} className="min-h-11 rounded-lg font-mono text-[11px] text-muted tnum hover:bg-paper disabled:opacity-40">{pct === 100 ? "Max" : `${pct}%`}</button>)}
           </div>
         </div>
-        <div className="relative z-10 mx-auto -my-3 flex size-7 items-center justify-center rounded-lg border border-line bg-paper text-muted" aria-hidden><ArrowDown size={13} /></div>
-        <div className="rounded-xl border border-line bg-card px-4 pt-4 pb-3">
+        <div className="relative z-10 mx-auto -my-3 flex size-6 items-center justify-center bg-card text-muted" aria-hidden><ArrowDown size={13} /></div>
+        <div className="pt-5 pb-1">
           <div className="text-[11px] text-muted">You receive <span className="text-[10px]">· estimated</span></div>
           <div className="mt-2 flex min-h-7 items-center justify-between gap-3">
             <span className="min-w-0 break-words font-mono text-base font-bold text-ink tnum">{outLabel ?? "—"}</span>{quoting && amountIn !== null ? <Spinner size={13} className="shrink-0 text-muted" /> : null}
@@ -255,7 +255,7 @@ export default function TradePanel({ chain, token, symbol, poolKey, quote, ethUs
       )}
 
       {phase.k === "error" ? (
-        <p className="rounded-xl bg-down-soft border border-down/20 text-down-ink text-sm px-3 py-2" role="alert">
+        <p className="rounded-lg bg-down-soft text-down-ink text-sm px-3 py-2" role="alert">
           {phase.message}
         </p>
       ) : null}

--- a/app/src/components/launchpad/TradingChart.module.css
+++ b/app/src/components/launchpad/TradingChart.module.css
@@ -1,5 +1,5 @@
-.terminal { min-width: 0; overflow: hidden; border: 1px solid var(--color-line); border-radius: 16px; background: var(--color-paper); color: var(--color-ink); }
-.header { display: flex; justify-content: space-between; align-items: center; gap: 16px; padding: 20px; }
+.terminal { min-width: 0; background: var(--color-paper); color: var(--color-ink); }
+.header { display: flex; justify-content: space-between; align-items: center; gap: 16px; padding: 4px 0 20px; }
 .marketIdentity { min-width: 0; }
 .kicker { display: flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 500; }
 .kicker > svg { flex-shrink: 0; color: var(--color-muted); }
@@ -8,7 +8,7 @@
 .chain { border-left: 1px solid var(--color-line-strong); padding-left: 8px; margin-left: 2px; color: var(--color-muted); font-size: 10px; }
 .metric { margin-top: 18px; color: var(--color-muted); font-size: 11px; font-weight: 400; }
 .priceLine { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin-top: 3px; }
-.priceLine strong { font: 700 36px/1.2 var(--font-mono); letter-spacing: -.06em; overflow-wrap: anywhere; }
+.priceLine strong { font: 700 36px/1.2 var(--font-mono); letter-spacing: -.04em; overflow-wrap: anywhere; }
 .denom { color: var(--color-muted); font-size: 11px; }
 .change { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; margin-top: 7px; color: var(--color-muted); font-size: 10px; }
 .headerControls { display: flex; flex-direction: column; align-items: flex-end; flex-shrink: 0; gap: 10px; }
@@ -16,7 +16,7 @@
 .currencySelect { position: relative; display: flex; align-items: center; }
 .currencySelect select { height: 32px; max-width: 125px; appearance: none; padding: 0 28px 0 10px; border: 1px solid var(--color-line); border-radius: 8px; background: var(--color-paper); color: var(--color-ink); font-size: 11px; cursor: pointer; }
 .currencySelect svg { position: absolute; right: 9px; pointer-events: none; color: var(--color-muted); }
-.toolbar { display: flex; align-items: stretch; gap: 4px; border-block: 1px solid var(--color-line); background: var(--color-card); padding: 0 8px; }
+.toolbar { display: flex; align-items: stretch; gap: 4px; border-block: 1px solid var(--color-line); padding: 0; }
 .scrollTools { display: flex; align-items: center; min-width: 0; flex: 1; overflow-x: auto; scrollbar-width: thin; }
 .intervals, .ranges { flex-shrink: 0; border: 0; border-radius: 0; background: transparent; padding: 0; gap: 0; }
 .intervals .interval { height: 44px; padding-inline: 10px; border: 0; border-bottom: 2px solid transparent; border-radius: 0; background: transparent; color: var(--color-muted); font: 11px var(--font-mono); box-shadow: none; }
@@ -28,7 +28,7 @@
 .iconButton { display: grid; place-items: center; flex-shrink: 0; width: 40px; height: 44px; color: var(--color-muted); cursor: pointer; }
 .iconButton:hover, .tool:hover, .scaleButton:hover { background: var(--color-line); color: var(--color-ink); }
 .terminal button:disabled { opacity: .4; cursor: not-allowed; }
-.legend { padding: 13px 16px 10px; min-height: 74px; }
+.legend { padding: 13px 0 10px; min-height: 74px; }
 .legendContext { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; font-size: 11px; }
 .legendContext > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .legendContext > span > span { color: var(--color-muted); }
@@ -49,15 +49,15 @@
 .baselineNote { position: absolute; z-index: 3; top: 18%; left: 16px; right: 112px; display: flex; flex-direction: column; gap: 8px; text-align: center; pointer-events: none; }
 .baselineNote span { font-size: 13px; }
 .baselineNote small { color: var(--color-muted); font-size: 11px; line-height: 1.6; }
-.bottomToolbar { display: flex; justify-content: space-between; flex-wrap: wrap; align-items: center; border-top: 1px solid var(--color-line); padding: 4px 8px; }
+.bottomToolbar { display: flex; justify-content: space-between; flex-wrap: wrap; align-items: center; border-top: 1px solid var(--color-line); padding: 4px 0; }
 .ranges .range { height: 44px; padding-inline: 10px; border: 0; border-bottom: 2px solid transparent; border-radius: 0; background: transparent; color: var(--color-muted); font: 11px var(--font-mono); box-shadow: none; }
 .ranges .range[data-pressed] { border-bottom-color: var(--color-ink); background: transparent; color: var(--color-ink); }
 .scaleTools { display: flex; align-items: center; gap: 2px; }
 .scaleButton { min-width: 34px; min-height: 44px; padding-inline: 5px; border-bottom: 2px solid transparent; color: var(--color-muted); font: 11px var(--font-mono); cursor: pointer; }
 .scaleButton[aria-pressed="true"] { border-bottom-color: var(--color-ink); color: var(--color-ink); }
-.footer { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px; padding: 11px 16px; border-top: 1px solid var(--color-line); color: var(--color-muted); font-size: 10px; }
+.footer { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px; padding: 8px 0; color: var(--color-muted); font-size: 10px; }
 .footer a:hover { color: var(--color-ink); }
-.dataNote { display: flex; flex-direction: column; gap: 4px; padding: 0 16px 12px; color: var(--color-muted); font-size: 10px; line-height: 1.6; }
+.dataNote { display: flex; flex-direction: column; gap: 4px; padding: 0 0 12px; color: var(--color-muted); font-size: 10px; line-height: 1.6; }
 .terminal :is(button, select, a, [tabindex]):focus-visible { outline: 2px solid var(--color-brand); outline-offset: -2px; }
 .terminal:fullscreen { display: flex; flex-direction: column; border: 0; border-radius: 0; padding-inline: max(12px, env(safe-area-inset-left)); overflow-y: auto; }
 .terminal:fullscreen .header { padding: 12px; }
@@ -65,27 +65,27 @@
 .terminal:fullscreen .priceLine strong { font-size: 28px; }
 .terminal:fullscreen .plotWrap { flex: 1; min-height: 200px; }
 .terminal:fullscreen .plot { position: absolute; inset: 0; height: 100%; }
-@media (min-width: 1280px) { .plot { height: 430px; } }
+@media (min-width: 1280px) { .plot { height: clamp(430px, 50dvh, 620px); } }
 @media (max-width: 639px) {
-  .header { padding: 16px 12px; gap: 8px; }
+  .header { padding: 4px 0 16px; gap: 8px; }
   .priceLine strong { font-size: 28px; }
   .headerControls button { padding-inline: 9px; }
   .kicker { font-size: 11px; }
   .chain { display: none; }
-  .legend { padding: 12px; min-height: 95px; }
+  .legend { padding: 12px 0; min-height: 95px; }
   .legendContext { flex-wrap: wrap; gap: 6px; }
   .ohlc { font-size: 10px; gap: 5px 9px; }
   .plot { height: 340px; }
   .fixedTools .iconButton { width: 34px; }
-  .bottomToolbar { padding-inline: 4px; }
+  .bottomToolbar { padding-inline: 0; }
   .ranges .range { padding-inline: 9px; }
   .scaleTools { margin-left: auto; }
-  .footer, .dataNote { padding-inline: 12px; }
+  .footer, .dataNote { padding-inline: 0; }
 }
 @media (prefers-reduced-motion: reduce) { .terminal * { scroll-behavior: auto; transition: none; } }
 @media (max-width: 399px) {
   .header { flex-wrap: wrap; gap: 14px; }
   .marketIdentity { flex: 1 0 100%; }
   .headerControls { width: 100%; flex-direction: row; align-items: center; justify-content: space-between; }
-  .priceLine strong { letter-spacing: -.045em; }
+  .priceLine strong { letter-spacing: -.04em; }
 }

--- a/app/src/components/launchpad/TrendingStrip.tsx
+++ b/app/src/components/launchpad/TrendingStrip.tsx
@@ -56,7 +56,7 @@ export default function TrendingStrip({ initial }: { initial: Snap }) {
 
   return (
     <section aria-labelledby="trending-heading" className="min-w-0">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <ChartNoAxesCombined size={15} aria-hidden="true" className="text-muted" />
           <h2 id="trending-heading" className="text-sm font-semibold text-ink">Trending</h2>
@@ -65,36 +65,39 @@ export default function TrendingStrip({ initial }: { initial: Snap }) {
         <span className="text-[11px] text-muted" title="Ranked by distinct wallets other than the launcher, then trades, volume and holders (log-scaled), with a boost for young tokens. The hourly window needs two such wallets; the daily window needs one.">Ranked by on-chain activity</span>
       </div>
       {items.length === 0 ? (
-        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 rounded-xl border border-dashed border-line-strong px-4 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-b border-line pb-3">
           <p className="text-xs text-muted">A quiet window. Trending appears when tokens have enough trading activity.</p>
           <a href="#launches" className="inline-flex min-h-8 items-center gap-1.5 text-xs font-medium text-body hover:text-ink">Explore launches <ArrowUpRight size={13} aria-hidden="true" /></a>
         </div>
       ) : (
-        <ol aria-label="Trending tokens" className="grid auto-cols-[minmax(13rem,1fr)] grid-flow-col gap-2 overflow-x-auto pb-1 bb-scroll snap-x snap-mandatory lg:auto-cols-fr" onPointerEnter={(e) => { if (e.pointerType === "mouse") active.current.pointer = true; }} onPointerLeave={() => { active.current.pointer = false; }} onFocusCapture={() => { active.current.focus = true; }} onBlurCapture={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) active.current.focus = false; }}>
+        <ol aria-label="Trending tokens" className="grid auto-cols-[minmax(15rem,1fr)] grid-flow-col divide-x divide-line overflow-x-auto border-y border-line bb-scroll snap-x snap-mandatory lg:auto-cols-fr" onPointerEnter={(e) => { if (e.pointerType === "mouse") active.current.pointer = true; }} onPointerLeave={() => { active.current.pointer = false; }} onFocusCapture={() => { active.current.focus = true; }} onBlurCapture={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) active.current.focus = false; }}>
           {items.map((row, index) => {
             const trades = snap.window === "1h" ? row.trades_1h : row.trades_24h;
             const volume = snap.window === "1h" ? row.volume_1h_usd : row.volume_24h_usd;
             const quoteVolume = snap.window === "1h" ? row.volume_1h : row.volume_24h;
             const volumeLabel = volume !== null ? marketUsd(volume) : fmtQuote(quoteVolume, row.quote_decimals, row.quote_symbol);
-            // `relative`: the cards hold sr-only (absolutely positioned) labels; without a positioned ancestor inside
+            // `relative`: entries hold sr-only (absolutely positioned) labels; without a positioned ancestor inside
             // the scroller they resolve against <main> and stretch the whole page sideways on phones
             return (
               <li key={launchKey(row)} className="relative min-w-0 snap-start">
-                <Link href={`/t/${row.chain}/${row.token}`} className={`group block h-full rounded-xl border bg-card p-3.5 transition-colors hover:border-muted motion-reduce:transition-none ${index === 0 ? "border-line-strong" : "border-line"}`}>
-                  <div className="mb-3 flex items-center justify-between text-[11px] text-muted">
-                    <span className="font-mono tnum">0{index + 1}<span className="sr-only"> ranked</span></span>
-                    {isGitlawbQuote(row.quote_key) ? <span className="flex items-center gap-1">{CHAIN_SHORT[row.chain]} · <GitlawbBadge /></span> : <span>{CHAIN_SHORT[row.chain]} · {row.quote_symbol}</span>}
-                    <ArrowUpRight size={13} aria-hidden="true" className="text-muted group-hover:text-ink" />
-                  </div>
+                <Link href={`/t/${row.chain}/${row.token}`} className="group block h-full px-4 py-3 transition-colors hover:bg-card focus-visible:outline-offset-[-2px] motion-reduce:transition-none">
                   <div className="flex min-w-0 items-center gap-2">
+                    <span className="shrink-0 font-mono text-[11px] text-muted tnum">{index + 1}<span className="sr-only"> ranked</span></span>
                     <TokenAvatar chain={row.chain} token={row.token} symbol={row.symbol} image={row.image_url} size={30} className="shrink-0 rounded-lg" />
-                    <div className="min-w-0"><p className="truncate text-[13px] font-semibold text-ink">{row.name}</p><p className="truncate font-mono text-[10px] text-muted">{row.symbol}</p></div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[13px] font-semibold text-ink">{row.name}</p>
+                      <div className="flex min-w-0 items-center gap-1 text-[10px] text-muted">
+                        <span className="truncate"><span className="font-mono">{row.symbol}</span> · {CHAIN_SHORT[row.chain]} · {isGitlawbQuote(row.quote_key) ? null : row.quote_symbol}</span>
+                        {isGitlawbQuote(row.quote_key) ? <GitlawbBadge /> : null}
+                      </div>
+                    </div>
+                    <ArrowUpRight size={13} aria-hidden="true" className="shrink-0 text-muted group-hover:text-ink" />
                   </div>
-                  <div className="mt-3 flex min-w-0 items-baseline justify-between gap-2">
+                  <div className="mt-2 flex min-w-0 items-baseline justify-between gap-2">
                     <span className="truncate font-mono text-sm font-bold text-ink tnum"><span className="sr-only">Market cap </span>{capDisplay(row.fdv_quote, row.quote_usd, { key: row.quote_key, symbol: row.quote_symbol, decimals: row.quote_decimals }).compact}</span>
                     <ChangeChip v={row.change_from_launch} plain />
                   </div>
-                  <div className="mt-2 flex items-center justify-between gap-2 border-t border-line pt-2 text-[10px] text-muted">
+                  <div className="mt-1.5 flex items-center justify-between gap-2 text-[10px] text-muted">
                     <span><span className="font-mono tnum text-body">{trades}</span> trades</span><span className="truncate font-mono tnum" title={`Volume ${volumeLabel}`}>{volumeLabel}</span>
                   </div>
                 </Link>

--- a/app/src/components/launchpad/WatchButton.tsx
+++ b/app/src/components/launchpad/WatchButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { Star } from "lucide-react";
+import { watchlistKey, type WatchlistIdentity } from "@/lib/launchpad/watchlist";
+import { useWatchlist } from "./useWatchlist";
+
+/** Kept outside token links: saving must never navigate or request a signature. */
+export default function WatchButton({ token, labelled = false, onRemoved }: { token: WatchlistIdentity; labelled?: boolean; onRemoved?: (button: HTMLButtonElement) => void }) {
+  const { savedKeys, ready, toggle, storageError } = useWatchlist();
+  const reduced = useReducedMotion();
+  const [message, setMessage] = useState("");
+  const saved = savedKeys.includes(watchlistKey(token));
+  const label = `${saved ? "Remove" : "Save"} ${token.name} ${saved ? "from" : "to"} watchlist`;
+  return (
+    <span className="relative inline-flex shrink-0">
+      <button type="button" disabled={!ready} aria-label={label} aria-pressed={saved} title={label}
+        onClick={(event) => {
+          const result = toggle(token);
+          setMessage(result === "limit" ? "Your watchlist is full. Remove a token to save another (50 maximum)." : result === "invalid" ? "This token could not be saved." : "");
+          if (result === "removed") onRemoved?.(event.currentTarget);
+        }}
+        className={`inline-flex min-h-11 items-center justify-center gap-2 rounded-xl transition-colors disabled:opacity-40 motion-reduce:transition-none ${labelled ? "border border-line px-3 text-xs hover:border-line-strong" : "w-11"} ${saved ? "text-brand" : "text-muted hover:text-ink"}`}>
+        <motion.span initial={false} whileTap={reduced ? undefined : { scale: 0.88 }} animate={{ scale: saved && !reduced ? [1, 1.3, 1] : 1, rotate: saved && !reduced ? [0, -12, 0] : 0 }} transition={{ duration: reduced ? 0 : 0.24 }} className="inline-flex">
+          <Star size={17} aria-hidden="true" fill={saved ? "currentColor" : "none"} strokeWidth={1.7} />
+        </motion.span>
+        {labelled ? saved ? "Watching" : "Watch" : null}
+      </button>
+      {message ? <span role="alert" className="absolute left-0 top-full z-20 w-52 rounded-xl border border-line-strong bg-paper p-3 text-xs text-warm-ink">{message}</span> : null}
+      {storageError && labelled ? <span role="status" className="sr-only">Browser storage unavailable. Saved for this session only.</span> : null}
+    </span>
+  );
+}

--- a/app/src/components/launchpad/WatchlistPanel.tsx
+++ b/app/src/components/launchpad/WatchlistPanel.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, Check, CheckCheck, Database, RefreshCw, Star } from "lucide-react";
+import ChainSelector from "./ChainSelector";
+import { btn } from "@/components/ui";
+import { CHAIN_SHORT, type ChainKey } from "@/lib/chainPublic";
+import { watchlistKey, type WatchlistEntry } from "@/lib/launchpad/watchlist";
+import { capDisplay } from "@/lib/launchpad/market-cap";
+import { ago } from "@/lib/launchpad/time";
+import type { WatchlistData as WatchlistResponse } from "@/lib/launchpad/watchlistData";
+import TokenAvatar from "./TokenAvatar";
+import WatchButton from "./WatchButton";
+import { useWatchlist } from "./useWatchlist";
+
+type Item = WatchlistResponse["items"][number];
+const number = (value: number) => value.toLocaleString("en-US");
+
+export default function WatchlistPanel({ onBrowse }: { onBrowse: () => void }) {
+  const { entries, ready, storageError, markSeen } = useWatchlist();
+  const [chain, setChain] = useState<ChainKey | null>(null);
+  const [notice, setNotice] = useState("");
+  const [reviewCount, setReviewCount] = useState(0);
+  const [reviewedScope, setReviewedScope] = useState("");
+  const heading = useRef<HTMLHeadingElement>(null);
+  const reduced = useReducedMotion();
+  const request = JSON.stringify({ items: entries.map((entry) => ({ chain: entry.chain, token: entry.token, since: entry.seenAt ?? entry.addedAt })) });
+  const query = useQuery({
+    queryKey: ["watchlist", request],
+    enabled: ready && entries.length > 0,
+    queryFn: async ({ signal }): Promise<WatchlistResponse> => {
+      const response = await fetch("/api/launch/watchlist", { method: "POST", headers: { "Content-Type": "application/json" }, body: request, signal, cache: "no-store" });
+      if (!response.ok) throw new Error("Watchlist unavailable");
+      const data = await response.json() as WatchlistResponse;
+      if (!data.indexed || !Array.isArray(data.items)) throw new Error("Index unavailable");
+      return data;
+    },
+    staleTime: 10_000,
+    refetchInterval: 15_000,
+    refetchIntervalInBackground: false,
+    placeholderData: (previous) => previous,
+    retry: 1,
+  });
+  const data = query.data;
+  const byKey = new Map(data?.items.map((item) => [watchlistKey(item), item]));
+  const shown = entries.filter((entry) => !chain || entry.chain === chain);
+  const changed = shown.filter((entry) => hasChanges(entry, byKey.get(watchlistKey(entry))));
+  const incomplete = shown.some((entry) => { const item = byKey.get(watchlistKey(entry)); return !item?.launch || item.holders === null; });
+  const reviewable = shown.flatMap((entry) => { const item = byKey.get(watchlistKey(entry)); return item?.launch ? [item] : []; });
+  const loading = !ready || (entries.length > 0 && query.isPending);
+  const rowLayout = shown.map(watchlistKey).join("|");
+  const reviewed = Boolean(notice && reviewedScope === rowLayout && !changed.length && !query.isError && !query.isPlaceholderData);
+  function review(items: Item[]) {
+    if (!data || query.isError || query.isPlaceholderData) return;
+    markSeen(items.filter((item) => item.launch).map((item) => ({ chain: item.chain, token: item.token, seenAt: data.at, holders: item.holders })));
+    setNotice("Reviewed. New indexed activity will appear here.");
+    setReviewCount((count) => count + 1);
+    setReviewedScope(items.map(watchlistKey).join("|"));
+  }
+  function focusAfterRemoval(button: HTMLButtonElement) {
+    const row = button.closest("li");
+    const next = row?.nextElementSibling?.querySelector("button") ?? row?.previousElementSibling?.querySelector("button");
+    requestAnimationFrame(() => (next?.isConnected ? next : heading.current)?.focus({ preventScroll: true }));
+  }
+
+  return (
+    <section aria-labelledby="watchlist-heading" className="@container min-w-0">
+      <header className="pb-4 pt-5">
+        <div className="flex items-baseline justify-between gap-4">
+          <h2 ref={heading} tabIndex={-1} id="watchlist-heading" className="text-2xl font-semibold tracking-tight text-ink">Your watchlist.</h2>
+          <span aria-label={ready ? `${entries.length} of 50 tokens saved` : "Loading saved tokens"} className="shrink-0 font-mono text-xs text-muted tnum">{ready ? <><span className="text-ink">{entries.length}</span><span aria-hidden="true"> / 50</span></> : "…"}</span>
+        </div>
+        <p className="mt-2 text-[13px] leading-relaxed text-muted">Your picks. Both chains. No wallet needed.</p>
+      </header>
+      {storageError ? <p role="alert" className="border-t border-line px-5 py-3 text-xs text-warm-ink">Some changes could not be saved. If another tab filled your watchlist, remove a token to make room. Unsaved changes last for this session.</p> : null}
+      {loading ? <div role="status" className="space-y-4 border-t border-line p-6"><span className="sr-only">Loading your watchlist</span>{[0, 1, 2].map((key) => <div key={key} className="flex h-20 items-center gap-4 border-b border-line"><span className="h-10 w-10 rounded-xl bg-skeleton" /><span className="h-4 w-36 rounded bg-skeleton" /><span className="ml-auto h-4 w-20 rounded bg-skeleton" /></div>)}</div> : entries.length === 0 ? (
+        <div className="border-t border-line py-10 sm:py-12">
+          <Star size={20} strokeWidth={1.4} className="mb-4 text-brand" aria-hidden="true" />
+          <h3 className="max-w-sm text-2xl font-semibold leading-tight tracking-tight text-ink">A little less searching.<br />A lot more keeping up.</h3>
+          <p className="mt-4 max-w-sm text-pretty text-sm leading-relaxed text-body">Star a token from the launch list or its page. Come back to its trades, creator posts and holder changes in one place.</p>
+          <button type="button" onClick={onBrowse} className={`${btn.secondary} mt-7`}>Find your first token <ArrowRight size={15} aria-hidden="true" /></button>
+          <p className="mt-8 text-[11px] text-muted">Saved in this browser. No account, signatures or notifications.</p>
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between gap-2 pb-3">
+            <ChainSelector label="Watchlist chain" value={chain} onChange={setChain} />
+            <button type="button" aria-label={query.isFetching ? "Refreshing activity" : "Refresh activity"} title="Refresh activity" onClick={() => { if (!query.isFetching) void query.refetch(); }} aria-disabled={query.isFetching} className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-muted transition-colors hover:bg-card hover:text-ink aria-disabled:opacity-50 motion-reduce:transition-none"><RefreshCw size={15} aria-hidden="true" className={query.isFetching ? "animate-spin motion-reduce:animate-none" : ""} /></button>
+          </div>
+          {query.isError ? <div role="alert" className="border-t border-line px-5 py-4 text-sm text-warm-ink">Could not refresh indexed activity. {data ? "Showing the last successful snapshot." : "Your saved tokens are still here."} Use Refresh to try again.</div> : null}
+          {data ? <div className="flex flex-wrap items-center justify-between gap-x-5 gap-y-3 border-y border-line py-4">
+            <div className="min-w-0 flex-1 basis-44"><h3 className="flex items-center gap-2 text-sm font-semibold text-ink">{query.isPlaceholderData ? "Updating your activity…" : changed.length && !query.isError ? <><span className="h-1.5 w-1.5 rounded-full bg-brand" aria-hidden="true" />Since you checked in</> : <>{incomplete && !reviewed ? <Database size={16} className="text-muted" aria-hidden="true" /> : <CheckCheck size={16} className="text-muted" aria-hidden="true" />}{query.isError ? "Last saved snapshot" : reviewed ? "Checkpoint updated" : incomplete ? "Some data is still indexing" : "No new indexed activity"}</>}</h3><p className="mt-1.5 max-w-sm text-pretty text-xs leading-relaxed text-muted">{query.isPlaceholderData ? "Loading your new activity window." : changed.length && !query.isError ? `${changed.length} ${changed.length === 1 ? "token has" : "tokens have"} updates. Mark them reviewed when you're done.` : reviewed ? incomplete ? "New activity will appear here. Holder history is still indexing." : "New indexed activity will appear here." : "Mark reviewed to set a checkpoint for the tokens shown."}</p></div>
+            {reviewable.length ? <button type="button" aria-disabled={query.isError || query.isPlaceholderData} onClick={() => review(reviewable)} className={`${btn.secondarySm} min-h-11 whitespace-nowrap aria-disabled:opacity-50`}><motion.span key={reviewCount} initial={reviewCount && !reduced ? { scale: 0.7 } : false} animate={{ scale: 1 }} transition={{ duration: reduced ? 0 : 0.2 }} className="inline-flex"><Check size={13} aria-hidden="true" /></motion.span>{query.isPlaceholderData ? "Updating…" : "Mark reviewed"}</button> : null}
+          </div> : null}
+          <p role="status" className="sr-only"><span key={reviewCount}>{notice}</span></p>
+          <ul aria-label="Watched tokens" className="divide-y divide-line">
+            {shown.map((entry) => <WatchRow key={watchlistKey(entry)} entry={entry} item={byKey.get(watchlistKey(entry))} now={data?.at} pending={query.isPlaceholderData} layoutKey={rowLayout} reduced={Boolean(reduced)} onRemoved={focusAfterRemoval} />)}
+          </ul>
+          {!shown.length ? <p className="px-6 py-10 text-center text-sm text-muted">No saved tokens on {chain ? CHAIN_SHORT[chain] : "this chain"}. Choose All chains to see your list.</p> : null}
+          <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-line py-4 text-[11px] leading-relaxed text-muted">
+            <p className="max-w-md text-pretty">Stored in this browser. Activity refreshes every 15s while open and may lag the chain. Trade and post catch-up covers up to 30 days.</p>
+            <button type="button" onClick={onBrowse} className="inline-flex min-h-11 items-center gap-1.5 text-xs text-body hover:text-ink">Explore launches <ArrowRight size={13} aria-hidden="true" /></button>
+          </footer>
+        </>
+      )}
+    </section>
+  );
+}
+
+function holderChange(entry: WatchlistEntry, item?: Item) {
+  return entry.holders !== null && item?.holders != null ? item.holders - entry.holders : null;
+}
+function hasChanges(entry: WatchlistEntry, item?: Item) {
+  return Boolean(item?.launch && ((item.trades ?? 0) > 0 || (item.creatorPosts ?? 0) > 0 || holderChange(entry, item)));
+}
+function WatchRow({ entry, item, now = entry.seenAt ?? entry.addedAt, pending = false, layoutKey, reduced, onRemoved }: { entry: WatchlistEntry; item?: Item; now?: number; pending?: boolean; layoutKey: string; reduced: boolean; onRemoved: (button: HTMLButtonElement) => void }) {
+  const l = item?.launch;
+  const delta = holderChange(entry, item);
+  const href = `/t/${entry.chain}/${entry.token}`;
+  const cap = l ? capDisplay(l.fdv_quote, l.quote_usd, { key: l.quote_key, symbol: l.quote_symbol, decimals: l.quote_decimals }) : null;
+  const established = !pending && item?.since != null;
+  return (
+    <motion.li initial={false} layout={reduced ? false : "position"} layoutDependency={layoutKey} transition={{ layout: { duration: 0.24, ease: [0.16, 1, 0.3, 1] } }} className="grid gap-x-5 gap-y-2 py-4 @min-[38rem]:grid-cols-[minmax(0,1.1fr)_minmax(17rem,0.9fr)]">
+      <div className="flex min-w-0 items-center gap-2">
+        <WatchButton token={entry} onRemoved={onRemoved} />
+        <Link href={href} className="flex min-w-0 flex-1 items-center gap-3 rounded-lg">
+          <TokenAvatar chain={entry.chain} token={entry.token} symbol={l?.symbol ?? entry.symbol} image={l?.image_url} size={40} className="shrink-0 rounded-xl" />
+          <div className="min-w-0"><span className="block truncate text-[15px] font-semibold text-ink">{l?.name ?? entry.name}</span><span className="mt-1 block truncate text-[11px] text-muted"><span className="font-mono">{l?.symbol ?? entry.symbol}</span> · {CHAIN_SHORT[entry.chain]}</span></div>
+        </Link>
+        {cap ? <div className="shrink-0 text-right"><span className="text-[11px] text-muted">Market cap</span><span className="mt-0.5 block font-mono text-base font-semibold text-ink tnum" title={`${cap.main} · ${cap.detail}`}>{cap.main}</span></div> : null}
+      </div>
+      {l ? <>
+        <dl className="grid grid-cols-3 pt-2 @min-[38rem]:pt-0">
+          <Activity tokenName={l.name} label="Trades" value={established ? item?.trades : null} href={`${href}#trades`} />
+          <Activity tokenName={l.name} label="Creator posts" value={established ? item?.creatorPosts : null} href={`${href}#comments`} />
+          <Activity tokenName={l.name} label="Holder change" value={established ? delta : null} href={`${href}#holders`} signed />
+        </dl>
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-2 text-[11px] leading-relaxed text-muted @min-[38rem]:col-span-2 @min-[38rem]:pl-13"><span>{item?.windowClamped ? "Trades & posts: last 30 days" : `Since ${entry.seenAt === null ? "saved" : "reviewed"} ${ago(new Date(entry.seenAt ?? entry.addedAt).toISOString(), now)} ago`}{l.quote_symbol ? ` · ${l.quote_symbol} pair` : ""}</span>{item?.holders === null ? <span>Holder history is indexing</span> : entry.holders === null ? <span>Review to track holder changes</span> : null}</div>
+        {item?.windowClamped && delta !== null ? <p className="text-right text-[11px] text-muted @min-[38rem]:col-span-2">Holder change is since your last review.</p> : null}
+      </> : <p className="mt-3 pl-2 text-xs text-muted sm:pl-14">{item ? "Token isn’t available in the index right now. It stays saved." : "Activity unavailable. Try refreshing."}</p>}
+    </motion.li>
+  );
+}
+function Activity({ tokenName, label, value, href, signed = false }: { tokenName: string; label: string; value: number | null | undefined; href: string; signed?: boolean }) {
+  const formatted = value == null ? "Pending" : `${signed && value > 0 ? "+" : ""}${number(value)}`;
+  return <div className="min-w-0 px-2"><dt className="min-h-8 text-[11px] leading-4 text-muted @min-[21rem]:min-h-4">{label}</dt><dd><Link href={href} aria-label={`${tokenName}: ${label}, ${formatted}`} title={`${label}: ${formatted}`} className="group flex min-h-11 items-center justify-between gap-1 rounded-md text-ink transition-colors hover:text-brand motion-reduce:transition-none"><span className={`min-w-0 truncate font-mono tnum ${value == null ? "text-xs text-muted" : "text-lg"}`}>{formatted}</span>{value != null ? <ArrowRight size={12} aria-hidden="true" className="shrink-0 text-muted transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" /> : null}</Link></dd></div>;
+}

--- a/app/src/components/launchpad/launch-machine.test.ts
+++ b/app/src/components/launchpad/launch-machine.test.ts
@@ -13,6 +13,7 @@ const machine = read("./LaunchMachine.tsx");
 const css = read("./LaunchMachine.module.css");
 const metrics = read("./LaunchMechanism.tsx");
 const hero = read("./LaunchHero.tsx");
+const sequence = read("./LaunchSequence.tsx");
 
 test("hero separates the permanent position lock from circulating token supply", () => {
   assert.match(hero, /liquidity position locked forever/i);
@@ -69,6 +70,7 @@ test("hero autoplay loops on CSS clocks with a user pause and cleaned-up observe
 test("autoplay includes mobile while reduced motion and manual inspection remain still", () => {
   assert.match(machine, /const MOTION_QUERY = "\(prefers-reduced-motion: no-preference\)"/);
   assert.match(machine, /event\.pointerType !== "mouse"/);
+  assert.match(machine, /if \(!playing \|\| event\.pointerType/);
   assert.match(machine, /setInspecting\(true\)/);
   assert.match(machine, /disabled=\{!motionAllowed\}/);
   const fallback = css.slice(css.indexOf("@media (prefers-reduced-motion: reduce)"));
@@ -76,6 +78,19 @@ test("autoplay includes mobile while reduced motion and manual inspection remain
   assert.match(fallback, /transform:\s*none\s*!important/);
   assert.match(fallback, /animation:\s*none/);
   assert.doesNotMatch(fallback, /\.playback\s*\{\s*display:\s*none/);
+});
+
+test("curved hero caption shares the existing stage and pausable motion contract", () => {
+  assert.match(machine, /<LaunchSequence stage=\{stage\} \/>/);
+  assert.match(sequence, /useId\(\)/);
+  assert.match(sequence, /data-active=\{stage === index\}/);
+  assert.match(sequence, /<textPath href=\{`#\$\{pathId\}`\}/);
+  for (const label of ["Create", "Pool", "Lock"]) assert.ok(sequence.includes(`label: "${label}"`));
+  assert.doesNotMatch(sequence, /\buseEffect\b|\buseState\b|\bsetInterval\b|\bsetTimeout\b|\brequestAnimationFrame\b|gsap|motion\/react/);
+  assert.match(css, /\.sequenceLabel \{ animation: sequence-reveal[^}]+animation-play-state: var\(--motion-state\)/);
+  assert.match(css.slice(css.indexOf("@media (prefers-reduced-motion: reduce)")), /\.sequenceLabel \{ animation: none; \}/);
+  assert.match(css, /aspect-ratio: 560 \/ 398/, "the new caption stays inside the reserved illustration footprint");
+  assert.doesNotMatch(hero, /["']use client["']/, "the promise and CTA stay server rendered");
 });
 
 test("step selection and copy follow CSS phase events, including the loop seam", () => {

--- a/app/src/components/launchpad/market-cap-sites.test.ts
+++ b/app/src/components/launchpad/market-cap-sites.test.ts
@@ -8,8 +8,8 @@ const read = (p: string) => readFileSync(new URL(p, import.meta.url), "utf8");
 test("the home row shows the quote detail on every width", () => {
   const row = read("./LaunchRow.tsx");
   assert.match(row, /const cap = capDisplay\(l\.fdv_quote, l\.quote_usd/);
-  assert.equal((row.match(/>\{cap\.detail\}</g) ?? []).length, 2, "one rendered detail line for desktop, one for mobile");
-  assert.match(row, /lg:hidden"><span className="block truncate[^"]*" title=\{capDetail\}>\{cap\.detail\}<\/span>/, "the phone and tablet block carries the quote detail");
+  assert.equal((row.match(/>\{cap\.detail\}</g) ?? []).length, 1, "one responsive detail line serves every width");
+  assert.match(row, /className=\{styles\.capDetail\} title=\{capDetail\}>\{cap\.detail\}<\/span>/, "the shared market cell carries the quote detail");
 });
 
 test("one-string sites use the compact form, which carries the mark for an unpriced quote", () => {

--- a/app/src/components/launchpad/market-cap-sites.test.ts
+++ b/app/src/components/launchpad/market-cap-sites.test.ts
@@ -9,7 +9,7 @@ test("the home row shows the quote detail on every width", () => {
   const row = read("./LaunchRow.tsx");
   assert.match(row, /const cap = capDisplay\(l\.fdv_quote, l\.quote_usd/);
   assert.equal((row.match(/>\{cap\.detail\}</g) ?? []).length, 2, "one rendered detail line for desktop, one for mobile");
-  assert.match(row, /md:hidden"><span className="block truncate[^"]*" title=\{capDetail\}>\{cap\.detail\}<\/span>/, "the mobile block carries the detail");
+  assert.match(row, /lg:hidden"><span className="block truncate[^"]*" title=\{capDetail\}>\{cap\.detail\}<\/span>/, "the phone and tablet block carries the quote detail");
 });
 
 test("one-string sites use the compact form, which carries the mark for an unpriced quote", () => {

--- a/app/src/components/launchpad/me-dashboard.test.ts
+++ b/app/src/components/launchpad/me-dashboard.test.ts
@@ -54,7 +54,8 @@ test("fee collection and full signed metadata editing keep their existing transa
   assert.match(source, /wallet\.writeContract\(request\)/);
   assert.match(source, /waitForTransactionReceipt\(\{ hash \}\)/);
   assert.match(source, /\/api\/launch\/sync\?chain=\$\{l\.chain\}&tx=\$\{hash\}/);
-  assert.match(source, /if \(p && p > 0n\) await collect\(l\)/);
+  assert.match(source, /me\.launches\.filter\(\(l\) => \(pending\[key\(l\)\] \?\? 0n\) > 0n\)/);
+  assert.match(source, /if \(!mounted\.current \|\| !await collect\(l\)\) break/);
   assert.match(source, /<EditTokenSheet/);
   for (const field of ["description", "image_url", "website", "x_handle"]) {
     assert.ok(source.includes(`${field}: editing.${field}`));
@@ -63,6 +64,22 @@ test("fee collection and full signed metadata editing keep their existing transa
   assert.match(edit, /buildEditMessage/);
   assert.match(edit, /wallet\.signMessage\(\{ message \}\)/);
   assert.match(source, /Name, symbol, fee and beneficiaries cannot change/);
+});
+
+test("wallet identity and finite feedback do not replace receipt-based collection success", () => {
+  assert.match(source, /<WalletAvatar address=\{address\} size=\{40\}/);
+  assert.match(source, /collecting\.current \|\| collectingBatch\.current/);
+  assert.match(source, /if \(!mounted\.current\) return false/);
+  assert.ok(source.indexOf('if (receipt.status !== "success")') < source.indexOf('stage: "confirmed", message:'));
+  assert.match(source, /setCollection\(\{ symbol: l\.symbol, stage: "signing" \}\)/);
+  assert.match(source, /setCollection\(\{ symbol: l\.symbol, stage: "confirming" \}\)/);
+  assert.match(source, /Indexed totals may take a moment to update/);
+  assert.match(source, /Each collection needs your approval/);
+  assert.match(source, /setTimeout\(\(\) => setRefreshed\(false\), 3000\)/);
+  assert.match(source, /setTimeout\(\(\) => setCollection\(null\), 6000\)/);
+  assert.match(source, /role="status" aria-live="polite" aria-atomic="true"/);
+  assert.match(source, /collection\.stage === "failed" \? <CircleAlert size=\{16\}/);
+  assert.doesNotMatch(source, /setInterval|setTimeout\([^\n]*stage: "confirmed"/);
 });
 
 test("dashboard controls, tables and responsive styling remain accessible and theme-native", () => {

--- a/app/src/components/launchpad/me-dashboard.test.ts
+++ b/app/src/components/launchpad/me-dashboard.test.ts
@@ -70,7 +70,11 @@ test("wallet identity and finite feedback do not replace receipt-based collectio
   assert.match(source, /<WalletAvatar address=\{address\} size=\{40\}/);
   assert.match(source, /collecting\.current \|\| collectingBatch\.current/);
   assert.match(source, /if \(!mounted\.current\) return false/);
-  assert.ok(source.indexOf('if (receipt.status !== "success")') < source.indexOf('stage: "confirmed", message:'));
+  const receiptGuard = source.indexOf('if (receipt.status !== "success")');
+  const confirmedFeedback = source.indexOf('stage: "confirmed", message:');
+  assert.ok(receiptGuard >= 0, "collection must check the receipt status");
+  assert.ok(confirmedFeedback >= 0, "collection must provide confirmed feedback");
+  assert.ok(receiptGuard < confirmedFeedback, "the receipt check must precede confirmed feedback");
   assert.match(source, /setCollection\(\{ symbol: l\.symbol, stage: "signing" \}\)/);
   assert.match(source, /setCollection\(\{ symbol: l\.symbol, stage: "confirming" \}\)/);
   assert.match(source, /Indexed totals may take a moment to update/);

--- a/app/src/components/launchpad/transaction-safety.test.ts
+++ b/app/src/components/launchpad/transaction-safety.test.ts
@@ -9,7 +9,7 @@ import ts from "typescript";
  * real wallet, RPC, or transaction while checking async control flow rather
  * than testing a duplicate implementation of the transaction logic.
  */
-function handler(file: string, name: string, bindings: Record<string, unknown>): (...args: unknown[]) => Promise<void> {
+function handler(file: string, name: string, bindings: Record<string, unknown>): (...args: unknown[]) => Promise<unknown> {
   const source = readFileSync(new URL(file, import.meta.url), "utf8");
   const ast = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
   let declaration = "";
@@ -96,22 +96,117 @@ for (const status of ["reverted", "success"]) {
   test(`dashboard collection handles a ${status} receipt honestly and clears busy state`, async () => {
     const effects: string[] = [];
     const busyStates: (string | null)[] = [];
+    const stages: string[] = [];
+    const mounted = { current: true };
+    const collecting = { current: false };
     const collect = handler("./MeDashboard.tsx", "collect", {
+      mounted, collecting,
       address: "wallet", config: {}, CHAINS: { base: { id: 8453 } },
       launchpad: () => ({ locker: "locker" }), key: () => "base:token",
       LAUNCH_LOCKER_ABI: [], BUILDER_DATA_SUFFIX: "0x",
       setBusy: (value: string | null) => busyStates.push(value),
+      setCollection: (value: { stage: string }) => stages.push(value.stage),
       getPublicClient: () => ({ simulateContract: async () => ({ request: {} }), waitForTransactionReceipt: async () => ({ status }) }),
       getWalletClient: async () => ({ writeContract: async () => "0xhash" }),
       fetch: async () => { effects.push("sync"); }, load: async () => { effects.push("reload"); },
       isBurnOnly: () => false, friendlyError: (error: Error) => error.message,
       toast: (message: { kind: string }) => effects.push(message.kind === "collect" ? "success toast" : "failure toast"),
     });
-    await collect({ chain: "base", token: "token", token_id: 1, symbol: "TEST", recipients: [] });
+    assert.equal(await collect({ chain: "base", token: "token", token_id: 1, symbol: "TEST", recipients: [] }), status === "success");
     assert.deepEqual(effects, status === "success" ? ["sync", "success toast", "reload"] : ["failure toast"]);
     assert.deepEqual(busyStates, ["base:token", null]);
+    assert.equal(collecting.current, false);
+    assert.deepEqual(stages, status === "success" ? ["checking", "signing", "confirming", "syncing", "confirmed"] : ["checking", "signing", "confirming", "failed"]);
   });
 }
+
+for (const unmountAt of ["wallet", "simulation", "receipt", "reload"] as const) {
+  test(`dashboard account change during ${unmountAt} stops later account-scoped actions`, async () => {
+    const mounted = { current: true };
+    const collecting = { current: false };
+    const effects: string[] = [];
+    const stateAfterUnmount: string[] = [];
+    const update = (name: string) => { if (!mounted.current) stateAfterUnmount.push(name); };
+    const collect = handler("./MeDashboard.tsx", "collect", {
+      mounted, collecting, address: "old-wallet", config: {}, CHAINS: { base: { id: 8453 } },
+      launchpad: () => ({ locker: "locker" }), key: () => "base:token",
+      LAUNCH_LOCKER_ABI: [], BUILDER_DATA_SUFFIX: "0x",
+      setBusy: () => update("busy"), setCollection: () => update("collection"),
+      getWalletClient: async () => {
+        if (unmountAt === "wallet") mounted.current = false;
+        return { writeContract: async () => { effects.push("sign"); return "0xhash"; } };
+      },
+      getPublicClient: () => ({
+        simulateContract: async () => { effects.push("simulate"); if (unmountAt === "simulation") mounted.current = false; return { request: {} }; },
+        waitForTransactionReceipt: async () => { effects.push("receipt"); if (unmountAt === "receipt") mounted.current = false; return { status: "success" }; },
+      }),
+      fetch: async () => effects.push("sync"), load: async () => { effects.push("reload"); if (unmountAt === "reload") mounted.current = false; },
+      toast: () => effects.push("toast"), isBurnOnly: () => false, friendlyError: (error: Error) => error.message,
+    });
+    assert.equal(await collect({ chain: "base", token: "token", token_id: 1, symbol: "TEST", recipients: [] }), false);
+    assert.deepEqual(effects, unmountAt === "wallet" ? [] : unmountAt === "simulation" ? ["simulate"] : unmountAt === "receipt" ? ["simulate", "sign", "receipt"] : ["simulate", "sign", "receipt", "sync", "toast", "reload"]);
+    assert.deepEqual(stateAfterUnmount, []);
+    assert.equal(collecting.current, false);
+  });
+}
+
+test("dashboard collection locks before wallet lookup and permits retry after rejection", async () => {
+  const collecting = { current: false };
+  let walletLookups = 0;
+  let rejectWallet!: (error: Error) => void;
+  const pendingWallet = new Promise<never>((_, reject) => { rejectWallet = reject; });
+  const collect = handler("./MeDashboard.tsx", "collect", {
+    mounted: { current: true }, collecting, address: "wallet", config: {}, CHAINS: { base: { id: 8453 } },
+    launchpad: () => ({ locker: "locker" }), key: () => "base:token",
+    setBusy: () => {}, setCollection: () => {}, getPublicClient: () => ({}),
+    getWalletClient: () => { walletLookups++; return pendingWallet; },
+    toast: () => {}, friendlyError: (error: Error) => error.message,
+  });
+  const launch = { chain: "base", token: "token", token_id: 1, symbol: "TEST" };
+  const first = collect(launch);
+  assert.equal(await collect(launch), false);
+  assert.equal(walletLookups, 1);
+  rejectWallet(new Error("Wallet request rejected"));
+  assert.equal(await first, false);
+  assert.equal(collecting.current, false);
+  await collect(launch);
+  assert.equal(walletLookups, 2);
+});
+
+test("collect-all stops at a rejected item, skips unknown fees and releases its batch lock", async () => {
+  const collectingBatch = { current: false };
+  const items: string[] = [];
+  const batches: ({ completed: number; total: number } | null)[] = [];
+  const collectAll = handler("./MeDashboard.tsx", "collectAll", {
+    me: { launches: [{ token: "one" }, { token: "unknown" }, { token: "two" }, { token: "three" }] },
+    pending: { one: 1n, unknown: null, two: 2n, three: 3n },
+    key: (launch: { token: string }) => launch.token,
+    mounted: { current: true }, collecting: { current: false }, collectingBatch,
+    setBatch: (batch: { completed: number; total: number } | null) => batches.push(batch ? { ...batch } : null),
+    collect: async (launch: { token: string }) => { items.push(launch.token); return launch.token !== "two"; },
+  });
+  await collectAll();
+  assert.deepEqual(items, ["one", "two"]);
+  assert.deepEqual(batches, [{ completed: 0, total: 3 }, { completed: 1, total: 3 }, null]);
+  assert.equal(collectingBatch.current, false);
+});
+
+test("collect-all does not request the next signature after its wallet boundary unmounts", async () => {
+  const mounted = { current: true };
+  const collectingBatch = { current: false };
+  let calls = 0;
+  let staleUpdates = 0;
+  const collectAll = handler("./MeDashboard.tsx", "collectAll", {
+    me: { launches: [{ token: "one" }, { token: "two" }] }, pending: { one: 1n, two: 1n },
+    key: (launch: { token: string }) => launch.token, mounted, collecting: { current: false }, collectingBatch,
+    setBatch: () => { if (!mounted.current) staleUpdates++; },
+    collect: async () => { calls++; mounted.current = false; return true; },
+  });
+  await collectAll();
+  assert.equal(calls, 1);
+  assert.equal(staleUpdates, 0);
+  assert.equal(collectingBatch.current, false);
+});
 
 test("preparing a trade disables the same controls as signing and confirming", () => {
   const source = readFileSync(new URL("./TradePanel.tsx", import.meta.url), "utf8");

--- a/app/src/components/launchpad/useWatchlist.ts
+++ b/app/src/components/launchpad/useWatchlist.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { createWatchlistStore, WATCHLIST_SERVER_SNAPSHOT, WATCHLIST_STORAGE_KEY } from "@/lib/launchpad/watchlist";
+
+const store = createWatchlistStore({
+  read: () => window.localStorage.getItem(WATCHLIST_STORAGE_KEY),
+  write: (value) => window.localStorage.setItem(WATCHLIST_STORAGE_KEY, value),
+});
+let subscribers = 0;
+
+function onStorage(event: StorageEvent) {
+  if (event.key === WATCHLIST_STORAGE_KEY || event.key === null) store.refresh();
+}
+
+function subscribe(listener: () => void) {
+  const unsubscribe = store.subscribe(listener);
+  if (subscribers++ === 0) {
+    window.addEventListener("storage", onStorage);
+    window.addEventListener("focus", store.refresh);
+    store.refresh();
+  }
+  return () => {
+    unsubscribe();
+    if (--subscribers === 0) {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener("focus", store.refresh);
+    }
+  };
+}
+
+const getServerSnapshot = () => WATCHLIST_SERVER_SNAPSHOT;
+
+/** One shared store synchronizes every star and view, with a stable server/hydration snapshot. */
+export function useWatchlist() {
+  const snapshot = useSyncExternalStore(subscribe, store.getSnapshot, getServerSnapshot);
+  return { ...snapshot, toggle: store.toggle, markSeen: store.markSeen };
+}

--- a/app/src/components/market-refinement.test.ts
+++ b/app/src/components/market-refinement.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+test("market tape uses consumer-grade hierarchy and descriptive activity without nested actions", () => {
+  const row = source("./launchpad/LaunchRow.tsx");
+  assert.match(row, /className=\{styles\.shell\}/);
+  assert.match(row, /<ActivitySignal buys=\{l\.buys\} sells=\{l\.sells\} holders=\{l\.holders\}/);
+  assert.match(row, /buys === 1 \? "buy" : "buys"/);
+  assert.match(row, /const exact = `\$\{buys\} \$\{buyWord\}, \$\{sells\} \$\{sellWord\}`/);
+  assert.match(row, /title="0 buys, 0 sells"[^>]*>[\s\S]*No trades/);
+  assert.match(row, /styles\.capValue/);
+  assert.doesNotMatch(row, /ArrowUpRight|avatarFrame|activityTrack|buyWidth|sellWidth/);
+  assert.equal((row.match(/className=\{styles\.context\}/g) ?? []).length, 1, "ranking context is rendered once at every width");
+  assert.match(row, /<span className="sr-only">Launched <\/span>/);
+  assert.match(row, /<span className="sr-only">Rank \{rank\}\. <\/span><span aria-hidden="true" className=\{styles\.rank\}>/);
+  assert.match(row, /className="sr-only">\{`\$\{holders\} \$\{holders === 1 \? "holder" : "holders"\}\. `\}/);
+  assert.match(source(".\/launchpad\/LaunchList.tsx"), /className="sr-only">Quiet launches\. No buyer activity yet\. One visible launch per wallet/);
+  const rowCss = source("./launchpad/LaunchRow.module.css");
+  assert.match(rowCss, /\.shell\s*\{[^}]*border-bottom:/);
+  assert.match(rowCss, /\.row:hover::before,[\s\S]*\.row:focus-visible::before/);
+  assert.match(rowCss, /\.row:hover::after,[\s\S]*\.row:focus-visible::after/);
+  assert.match(rowCss, /width: 2px/);
+  assert.match(rowCss, /content-visibility:\s*auto/);
+  assert.match(rowCss, /\.mobileMetrics \.activity \{[^}]*flex-wrap: wrap/);
+  assert.match(rowCss, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(row, /<div className=\{styles\.watch\}><WatchButton[^>]* \/><\/div>\s*<Link/);
+});
+
+test("market loading mirrors the live ledger anatomy", () => {
+  const skeleton = source("./Skeleton.tsx");
+  assert.match(skeleton, /relative min-h-\[5\.25rem\] border-b border-line py-3 pl-12 pr-3/);
+  assert.match(skeleton, /h-11 w-11 shrink-0 rounded-xl/);
+  assert.match(skeleton, /col-span-2 grid grid-cols-2 items-end gap-3 sm:hidden/);
+  assert.match(source("../app\/\(home\)\/loading.tsx"), /market-toolbar grid grid-cols-\[minmax\(0,1fr\)_auto\]/);
+});
+
+test("the launch browser has one calm market header and a measured view switch", () => {
+  const browser = source("./launchpad/LaunchBrowser.tsx");
+  const css = source("./launchpad/LaunchBrowser.module.css");
+  assert.match(browser, /Markets, live onchain\./);
+  assert.match(browser, /From first block to first buyer, every launch stays visible\./);
+  assert.match(browser, /<TabsList aria-label="Launch browser"/);
+  assert.match(css, /\.viewTabs :global\(\.ui-tab-indicator\)/);
+  assert.match(css, /@media \(max-width: 639px\)/);
+});
+
+test("financial font is shared with the error document and self-hosted by Next", () => {
+  assert.match(source("../app/fonts.ts"), /Geist_Mono\(\{ subsets: \["latin"\], variable: "--font-geist-mono"/);
+  for (const path of ["../app/layout.tsx", "../app/global-error.tsx"]) {
+    assert.match(source(path), /geistMono\.variable/);
+  }
+});
+
+test("shared motion is finite, optional on press, and tabs retain native primitive semantics", () => {
+  const css = source("../app/globals.css");
+  assert.match(css, /--ui-control-duration: 160ms/);
+  assert.match(css, /--ui-panel-duration: 220ms/);
+  assert.match(css, /\.ui-pressable:active:not\(:disabled\):not\(\[aria-disabled="true"\]\) \{ transform: none; \}/);
+  const tabs = source("./vendor/tabs.tsx");
+  assert.match(tabs, /TabsPrimitive\.Indicator className="ui-tab-indicator motion-reduce:transition-none"/);
+  assert.match(tabs, /TabsPrimitive\.Tab/);
+  assert.match(source("./launchpad/LaunchBrowser.tsx"), /keepMounted/);
+});

--- a/app/src/components/navigation-shell.tsx
+++ b/app/src/components/navigation-shell.tsx
@@ -8,7 +8,7 @@ import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type SlotProps = { children: ReactNode; className?: string };
-type SurfaceProps = SlotProps & { visible?: boolean };
+type SurfaceProps = SlotProps & { visible?: boolean; docked?: boolean };
 
 // React only re-renders when the threshold changes, not on every scroll pixel.
 function subscribeToScroll(notify: () => void) {
@@ -18,8 +18,9 @@ function subscribeToScroll(notify: () => void) {
 const isFloating = () => window.scrollY > 100;
 const serverIsFloating = () => false;
 
-export function Navbar({ children, className }: SlotProps) {
-  const visible = useSyncExternalStore(subscribeToScroll, isFloating, serverIsFloating);
+export function Navbar({ children, className, docked = false }: SlotProps & { docked?: boolean }) {
+  const scrolled = useSyncExternalStore(subscribeToScroll, isFloating, serverIsFloating);
+  const visible = scrolled && !docked;
   return (
     <header className={cn("sticky top-0 z-40 w-full", className)}>
       {Children.map(children, (child) => isValidElement(child)
@@ -29,7 +30,7 @@ export function Navbar({ children, className }: SlotProps) {
   );
 }
 
-function NavigationSurface({ children, className, visible = false, mobile = false }: SurfaceProps & { mobile?: boolean }) {
+function NavigationSurface({ children, className, visible = false, mobile = false, docked = false }: SurfaceProps & { mobile?: boolean }) {
   const reduced = useReducedMotion();
   const width = visible ? (mobile ? "90%" : "40%") : "100%";
   return (
@@ -40,7 +41,7 @@ function NavigationSurface({ children, className, visible = false, mobile = fals
         y: visible ? 20 : 0,
         borderRadius: visible ? 28 : 0,
         backdropFilter: visible ? "blur(10px)" : "blur(0px)",
-        ...(mobile ? { paddingLeft: visible ? 12 : 16, paddingRight: visible ? 12 : 16 } : {}),
+        ...(mobile && !docked ? { paddingLeft: visible ? 12 : 16, paddingRight: visible ? 12 : 16 } : {}),
       }}
       transition={{ duration: reduced ? 0 : 0.28, ease: [0.22, 1, 0.36, 1] }}
       style={mobile ? undefined : { minWidth: 800 }}

--- a/app/src/components/open-ui.test.ts
+++ b/app/src/components/open-ui.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+test("market and watchlist live on the workspace rather than in enclosing cards", () => {
+  for (const path of ["./launchpad/LaunchList.tsx", "./launchpad/WatchlistPanel.tsx"]) {
+    const opening = source(path).match(/<section aria-labelledby=[^>]+>/)?.[0];
+    assert.ok(opening);
+    assert.doesNotMatch(opening, /rounded|border|overflow-hidden/);
+  }
+});
+
+test("the compact chain selector retains keyboard selection and automatic close", () => {
+  const selector = source("./launchpad/ChainSelector.tsx");
+  assert.match(selector, /Popover open=\{open\} onOpenChange=\{setOpen\}/);
+  assert.match(selector, /aria-label=\{`\$\{label\}:/);
+  assert.match(selector, /orientation="vertical"/);
+  assert.match(selector, /onChange\(values\[0\] === "all" \? null/);
+  assert.match(selector, /setOpen\(false\)/);
+  assert.match(selector, /\[null, "base", "robinhood"\]/);
+  assert.match(source("./vendor/popover.tsx"), /@base-ui\/react\/popover/);
+  assert.match(source("./vendor/popover.tsx"), /collisionPadding=\{12\}/);
+  assert.match(source("./vendor/popover.tsx"), /motion-reduce:transition-none/);
+});
+
+test("secondary filters remain accessible and active filtering is visible outside the popup", () => {
+  const list = source("./launchpad/LaunchList.tsx");
+  assert.match(list, /<PopoverTrigger[^>]+>[\s\S]+?Filters/);
+  assert.match(list, /<PopoverTitle[^>]+>Filter launches/);
+  assert.match(list, /aria-label="Quick filter" orientation="vertical"/);
+  assert.match(list, /aria-label="Clear active filter"/);
+  assert.match(list, /<PopoverTrigger ref=\{filtersTriggerRef\}/);
+  assert.match(list, /pick\(sort, window_, chain, null\); filtersTriggerRef\.current\?\.focus\(\)/);
+  assert.match(list, /aria-label="Volume window"/);
+  assert.match(list, /s\.key === "new"/);
+});
+
+test("tablet rows use four aligned tracks before the full six-column desktop ledger", () => {
+  const css = source("../app/globals.css");
+  assert.match(css, /@media \(min-width: 640px\) \{\s*\.launch-ledger/);
+  assert.match(css, /@media \(min-width: 1024px\) \{\s*\.launch-ledger/);
+  const row = source("./launchpad/LaunchRow.tsx");
+  assert.match(row, /hidden sm:grid/);
+  assert.match(row, /col-span-2 grid[^"\n]+sm:hidden/);
+  assert.doesNotMatch(row.match(/<dl className=[^>]+>/)?.[0] ?? "", /border/);
+});
+
+test("shared toggles have individually selected states without an enclosing tray", () => {
+  const toggle = source("./vendor/toggle-group.tsx");
+  const group = toggle.match(/data-slot="toggle-group"[^\n]+/)?.[0] ?? "";
+  assert.doesNotMatch(group, /border|rounded|bg-card/);
+  assert.match(toggle, /data-pressed:bg-line data-pressed:text-ink/);
+  assert.match(toggle, /@base-ui\/react\/toggle-group/);
+});

--- a/app/src/components/open-ui.test.ts
+++ b/app/src/components/open-ui.test.ts
@@ -37,14 +37,15 @@ test("secondary filters remain accessible and active filtering is visible outsid
   assert.match(list, /s\.key === "new"/);
 });
 
-test("tablet rows use four aligned tracks before the full six-column desktop ledger", () => {
+test("tablet rows use three decision tracks before the four-column desktop market tape", () => {
   const css = source("../app/globals.css");
   assert.match(css, /@media \(min-width: 640px\) \{\s*\.launch-ledger/);
   assert.match(css, /@media \(min-width: 1024px\) \{\s*\.launch-ledger/);
   const row = source("./launchpad/LaunchRow.tsx");
   assert.match(row, /hidden sm:grid/);
-  assert.match(row, /col-span-2 grid[^"\n]+sm:hidden/);
-  assert.doesNotMatch(row.match(/<dl className=[^>]+>/)?.[0] ?? "", /border/);
+  assert.match(row, /styles\.mobileMetrics/);
+  assert.match(row, /hidden lg:block/);
+  assert.doesNotMatch(row.match(/<dl className=[^>]+>/)?.[0] ?? "", /border-/);
 });
 
 test("shared toggles have individually selected states without an enclosing tray", () => {

--- a/app/src/components/sections/Agents.module.css
+++ b/app/src/components/sections/Agents.module.css
@@ -1,6 +1,6 @@
 .page { color: var(--color-body); }
 .page a:focus-visible, .page button:focus-visible, .code:focus-visible { outline: 2px solid var(--color-brand); outline-offset: 4px; border-radius: 6px; }
-.entry { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin: 32px 0 40px; padding: 22px 24px; border: 1px solid var(--color-line); border-radius: 16px; background: var(--color-card); }
+.entry { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin: 0 0 40px; padding-block: 22px; border-block: 1px solid var(--color-line); }
 .entryHeading { display: flex; align-items: center; gap: 16px; min-width: 0; }
 .entryHeading > svg { flex-shrink: 0; color: var(--color-brand); }
 .entryHeading p { margin: 0; color: var(--color-ink); font-size: 15px; font-weight: 600; line-height: 1.5; }
@@ -23,14 +23,14 @@
 .sectionNumber { padding-top: 4px; color: var(--color-brand); font-family: var(--font-mono); font-size: 12px; }
 .sectionHeading h2 { margin: 0; color: var(--color-ink); font-size: 24px; font-weight: 600; line-height: 1.2; letter-spacing: -.035em; }
 .sectionHeading p { margin: 6px 0 0; color: var(--color-muted); font-size: 13px; text-wrap: pretty; }
-.networks { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border: 1px solid var(--color-line); border-radius: 12px; }
-.network { min-width: 0; padding: 16px; }
-.network + .network { border-left: 1px solid var(--color-line); }
-.networkHeading { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 4px 12px; }
+.networks { display: grid; border-block: 1px solid var(--color-line); }
+.network { display: grid; grid-template-columns: 136px minmax(0, 1fr); gap: 20px; min-width: 0; padding-block: 20px; }
+.network + .network { border-top: 1px solid var(--color-line); }
+.networkHeading { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; }
 .networkHeading h3 { margin: 0; color: var(--color-ink); font-size: 13px; font-weight: 600; }
 .networkHeading > span { font-size: 10px; color: var(--color-muted); }
 .networkHeading b { font-family: var(--font-mono); font-weight: 400; }
-.network dl { display: grid; gap: 8px; margin-top: 16px; }
+.network dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }
 .network dt { font-size: 10px; color: var(--color-muted); text-transform: capitalize; }
 .network dd { min-width: 0; margin: 0; font-size: 11px; }
 .network dd a { display: flex; align-items: center; gap: 8px; min-height: 44px; color: var(--color-body); }
@@ -39,56 +39,53 @@
 .network dd svg { flex-shrink: 0; color: var(--color-muted); }
 .prose { margin: 0; font-size: 13px; line-height: 1.9; text-wrap: pretty; }
 .prose code, .parameters code { color: var(--color-ink); font-family: var(--font-mono); font-size: .92em; overflow-wrap: anywhere; }
-.codePanel { min-width: 0; border: 1px solid var(--color-line); border-radius: 12px; background: var(--color-card); }
+.codePanel { min-width: 0; border-radius: 12px; background: var(--color-card); }
 .codeHeader { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 60px; padding: 8px 10px 8px 16px; border-bottom: 1px solid var(--color-line); }
 .codeHeader > div { min-width: 0; }
 .codeTitle { display: block; color: var(--color-ink); font-size: 12px; font-weight: 500; }
 .language { display: block; margin-top: 2px; font-size: 10px; color: var(--color-muted); }
 .copyButton { display: inline-flex; align-items: center; justify-content: center; gap: 6px; min-width: 76px; min-height: 44px; padding: 0 12px; border: 1px solid transparent; border-radius: 8px; color: var(--color-body); font-size: 11px; cursor: pointer; flex-shrink: 0; }
 .copyButton:hover { border-color: var(--color-line-strong); color: var(--color-ink); }
-.code { max-width: 100%; min-width: 0; margin: 0; padding: 20px 16px; overflow-x: auto; border-radius: 0 0 12px 12px; background: var(--color-paper); color: var(--color-body); font-family: var(--font-mono); font-size: 13px; line-height: 1.9; scrollbar-width: thin; scrollbar-color: var(--color-line-strong) transparent; }
+.code { max-width: 100%; min-width: 0; margin: 0; padding: 20px 16px; overflow-x: auto; color: var(--color-body); font-family: var(--font-mono); font-size: 13px; line-height: 1.9; scrollbar-width: thin; scrollbar-color: var(--color-line-strong) transparent; }
 .code code { font-family: inherit; }
 .copyError { margin: 0; padding: 12px 16px; border-top: 1px solid var(--color-line); color: var(--color-body); font-size: 12px; line-height: 1.6; }
 .exampleNote { margin: -8px 0 0; color: var(--color-muted); font-size: 11px; line-height: 1.8; text-wrap: pretty; }
-.reference { border: 1px solid var(--color-line); border-radius: 12px; }
-.referenceHeading { display: flex; align-items: center; gap: 10px; padding: 16px; border-bottom: 1px solid var(--color-line); }
+.reference { min-width: 0; margin-block: 8px; }
+.referenceHeading { display: flex; align-items: center; gap: 10px; padding-bottom: 16px; border-bottom: 1px solid var(--color-line); }
 .referenceHeading svg { color: var(--color-muted); flex-shrink: 0; }
 .referenceHeading h3 { margin: 0; color: var(--color-ink); font-size: 13px; font-weight: 500; }
 .parameters { margin: 0; }
-.parameters > div { display: grid; grid-template-columns: 112px minmax(0, 1fr); gap: 16px; padding: 14px 16px; }
+.parameters > div { display: grid; grid-template-columns: 112px minmax(0, 1fr); gap: 16px; padding-block: 18px; }
 .parameters > div + div { border-top: 1px solid var(--color-line); }
 .parameters dt { font-size: 12px; }
 .parameters dd { margin: 0; font-size: 12px; line-height: 1.8; text-wrap: pretty; }
 .metadata { display: grid; min-width: 0; gap: 14px; padding-top: 8px; }
 .subheading { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
 .subheading h3 { margin: 0; color: var(--color-ink); font-size: 14px; font-weight: 600; }
-.method { display: inline-flex; align-items: center; justify-content: center; min-width: 42px; height: 24px; border: 1px solid var(--color-line-strong); border-radius: 6px; color: var(--color-ink); font-family: var(--font-mono); font-size: 10px; }
+.method { display: inline-flex; align-items: center; min-width: 42px; height: 24px; color: var(--color-muted); font-family: var(--font-mono); font-size: 10px; }
 .optional { margin-left: auto; color: var(--color-muted); font-size: 11px; }
-.endpoints { border: 1px solid var(--color-line); border-radius: 12px; }
-.endpointHeader { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 8px; padding: 14px 16px; color: var(--color-muted); font-size: 11px; background: var(--color-card); border-radius: 12px 12px 0 0; }
-.endpoint { display: grid; grid-template-columns: 42px minmax(0, 1fr); align-items: start; gap: 14px; padding: 18px 16px; border-top: 1px solid var(--color-line); }
+.endpoints { min-width: 0; }
+.endpointHeader { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 8px; padding-bottom: 14px; color: var(--color-muted); font-size: 11px; }
+.endpoint { display: grid; grid-template-columns: 42px minmax(0, 1fr); align-items: start; gap: 14px; padding-block: 20px; border-top: 1px solid var(--color-line); }
 .endpointPath { font-family: var(--font-mono); font-size: 12px; color: var(--color-ink); overflow-wrap: anywhere; }
 .endpoint p { margin: 4px 0 0; color: var(--color-muted); font-size: 12px; }
 .query { display: block; margin-top: 12px; color: var(--color-muted); font-family: var(--font-mono); font-size: 10px; line-height: 1.8; overflow-wrap: anywhere; }
-.dataNote { margin: 0; padding-left: 14px; border-left: 2px solid var(--color-line-strong); color: var(--color-muted); font-size: 12px; line-height: 1.8; text-wrap: pretty; }
+.dataNote { margin: 0; color: var(--color-muted); font-size: 12px; line-height: 1.8; text-wrap: pretty; }
 .dataNote p { margin: 0; }
 .dataNote p + p { margin-top: 12px; }
 .dataNote code { color: var(--color-body); font-family: var(--font-mono); font-size: .92em; overflow-wrap: anywhere; }
-.tradeReference { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--color-line); border-radius: 12px; }
-.tradeReference > div { min-width: 0; padding: 20px; }
-.tradeReference > div + div { border-left: 1px solid var(--color-line); }
+.tradeReference { display: grid; }
+.tradeReference > div { min-width: 0; padding-block: 24px; border-top: 1px solid var(--color-line); }
 .tradeLabel { color: var(--color-muted); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
 .tradeReference h3 { margin: 10px 0; color: var(--color-ink); font-size: 15px; font-weight: 600; }
 @media (max-width: 1023px) {
   .layout { grid-template-columns: 148px minmax(0, 1fr); gap: 28px; }
   .networks { grid-template-columns: minmax(0, 1fr); }
-  .network + .network { border-left: 0; border-top: 1px solid var(--color-line); }
-  .network dl { grid-template-columns: 1fr 1fr; gap: 20px; }
-  .tradeReference { grid-template-columns: minmax(0, 1fr); }
-  .tradeReference > div + div { border-left: 0; border-top: 1px solid var(--color-line); }
+  .network { grid-template-columns: minmax(0, 1fr); gap: 12px; }
+  .networkHeading { flex-direction: row; flex-wrap: wrap; gap: 8px 16px; }
 }
 @media (max-width: 767px) {
-  .entry { flex-wrap: wrap; gap: 12px; padding: 18px; margin: 24px 0; }
+  .entry { flex-wrap: wrap; gap: 12px; padding-block: 18px; margin: 24px 0; }
   .entry > a { margin-left: 35px; }
   .layout { grid-template-columns: minmax(0, 1fr); gap: 32px; }
   .sidebar { position: static; }
@@ -107,6 +104,6 @@
   .entry > a { margin-left: 31px; }
   .codeHeader { padding-left: 12px; gap: 8px; }
   .code { padding: 16px 12px; font-size: 12px; }
-  .endpoint { gap: 10px; padding: 16px 12px; }
+  .endpoint { gap: 10px; padding-block: 16px; }
   .endpointPath { font-size: 11px; }
 }

--- a/app/src/components/sections/Agents.module.css
+++ b/app/src/components/sections/Agents.module.css
@@ -9,12 +9,6 @@
 .entry > a:hover { text-decoration-color: var(--color-ink); }
 .layout { display: grid; grid-template-columns: 176px minmax(0, 1fr); align-items: start; gap: 48px; }
 .sidebar { position: sticky; top: 100px; min-width: 0; }
-.indexLabel { margin: 0 0 12px; color: var(--color-muted); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; }
-.sidebar nav > a { display: flex; align-items: center; gap: 12px; min-height: 44px; font-size: 12px; color: var(--color-body); }
-.sidebar nav > a span { color: var(--color-muted); font-family: var(--font-mono); font-size: 10px; }
-.sidebar nav > a svg { margin-left: auto; color: var(--color-muted); }
-.sidebar nav > a:hover, .sidebar nav > a:focus-visible { color: var(--color-ink); }
-.sidebar nav > a:hover svg, .sidebar nav > a:focus-visible svg { color: var(--color-brand); }
 .sidebarNote { margin-top: 24px; padding-top: 20px; border-top: 1px solid var(--color-line); color: var(--color-muted); font-size: 11px; line-height: 1.8; text-wrap: pretty; }
 .content { display: grid; gap: 48px; min-width: 0; }
 .section { display: grid; gap: 20px; min-width: 0; }
@@ -44,8 +38,17 @@
 .codeHeader > div { min-width: 0; }
 .codeTitle { display: block; color: var(--color-ink); font-size: 12px; font-weight: 500; }
 .language { display: block; margin-top: 2px; font-size: 10px; color: var(--color-muted); }
-.copyButton { display: inline-flex; align-items: center; justify-content: center; gap: 6px; min-width: 76px; min-height: 44px; padding: 0 12px; border: 1px solid transparent; border-radius: 8px; color: var(--color-body); font-size: 11px; cursor: pointer; flex-shrink: 0; }
+.copyButton { display: inline-flex; align-items: center; justify-content: center; gap: 6px; min-width: 88px; min-height: 44px; padding: 0 12px; border: 1px solid transparent; border-radius: 8px; color: var(--color-body); font-size: 12px; cursor: pointer; flex-shrink: 0; transition: color 160ms, border-color 160ms, background-color 160ms, transform 160ms; }
 .copyButton:hover { border-color: var(--color-line-strong); color: var(--color-ink); }
+.copyButton:active:not(:disabled) { transform: scale(.97); }
+.copyButton:disabled { cursor: wait; opacity: .65; }
+.copyButton[data-copied] { color: var(--color-up); }
+.example { display: grid; gap: 12px; min-width: 0; }
+.exampleChain { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; color: var(--color-muted); font-size: 12px; }
+.exampleChain select { min-height: 44px; max-width: 100%; padding: 0 30px 0 12px; border: 1px solid var(--color-line); border-radius: 8px; background: var(--color-paper); color: var(--color-ink); font: inherit; cursor: pointer; transition: border-color 160ms; }
+.exampleChain select:hover { border-color: var(--color-line-strong); }
+.exampleChain select:focus-visible { outline: 2px solid var(--color-brand); outline-offset: 3px; }
+.exampleChain > span { margin-left: auto; font-size: 11px; }
 .code { max-width: 100%; min-width: 0; margin: 0; padding: 20px 16px; overflow-x: auto; color: var(--color-body); font-family: var(--font-mono); font-size: 13px; line-height: 1.9; scrollbar-width: thin; scrollbar-color: var(--color-line-strong) transparent; }
 .code code { font-family: inherit; }
 .copyError { margin: 0; padding: 12px 16px; border-top: 1px solid var(--color-line); color: var(--color-body); font-size: 12px; line-height: 1.6; }
@@ -89,15 +92,13 @@
   .entry > a { margin-left: 35px; }
   .layout { grid-template-columns: minmax(0, 1fr); gap: 32px; }
   .sidebar { position: static; }
-  .sidebar nav { display: flex; flex-wrap: wrap; column-gap: 18px; border-bottom: 1px solid var(--color-line); }
-  .indexLabel { width: 100%; margin-bottom: 4px; }
-  .sidebar nav > a { gap: 8px; }
-  .sidebar nav > a svg, .sidebarNote { display: none; }
+  .sidebarNote { display: none; }
   .sectionHeading h2 { font-size: 22px; }
   .content { gap: 36px; }
   .section + .section { padding-top: 28px; }
   .parameters > div { grid-template-columns: minmax(0, 1fr); gap: 8px; }
 }
+@media (prefers-reduced-motion: reduce) { .copyButton, .exampleChain select { transition: none; } .copyButton:active:not(:disabled) { transform: none; } }
 @media (max-width: 479px) {
   .network dl { grid-template-columns: minmax(0, 1fr); gap: 8px; }
   .entryHeading { gap: 12px; }

--- a/app/src/components/sections/AgentsCodeBlock.tsx
+++ b/app/src/components/sections/AgentsCodeBlock.tsx
@@ -1,28 +1,52 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
+import type { AgentExample } from "./agent-examples";
 import styles from "./Agents.module.css";
 
 /** A copy-only reference. Examples are never sent, evaluated or executed. */
-export default function AgentsCodeBlock({ title, language, code }: { title: string; language: string; code: string }) {
+export default function AgentsCodeBlock({ title, language, code = "", examples }: { title: string; language: string; code?: string; examples?: readonly AgentExample[] }) {
+  const [chain, setChain] = useState(examples?.[0]?.chain);
+  const selected = examples?.find((example) => example.chain === chain) ?? examples?.[0];
+  return <div className={styles.example}>
+    {examples && examples.length > 1 ? <label className={styles.exampleChain}>Example network<select value={chain} onChange={(event) => setChain(event.target.value)} aria-label={`${title} example network`}>{examples.map((example) => <option key={example.chain} value={example.chain}>{example.label}</option>)}</select><span>Reference only</span></label> : null}
+    <CopyReference key={selected?.code ?? code} title={selected?.title ?? title} language={language} code={selected?.code ?? code} />
+  </div>;
+}
+
+function CopyReference({ title, language, code }: { title: string; language: string; code: string }) {
   const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+  const [copying, setCopying] = useState(false);
+  const alive = useRef(true);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    alive.current = true;
+    return () => { alive.current = false; if (timer.current) clearTimeout(timer.current); };
+  }, []);
 
   async function copy() {
+    if (copying) return;
+    setCopying(true);
+    if (timer.current) clearTimeout(timer.current);
     try {
       await navigator.clipboard.writeText(code);
+      if (!alive.current) return;
       setStatus("copied");
+      timer.current = setTimeout(() => setStatus("idle"), 2400);
     } catch {
-      setStatus("error");
+      if (alive.current) setStatus("error");
+    } finally {
+      if (alive.current) setCopying(false);
     }
   }
 
   return <div className={styles.codePanel}>
     <div className={styles.codeHeader}>
       <div><span className={styles.codeTitle}>{title}</span><span className={styles.language}>{language}</span></div>
-      <button type="button" onClick={copy} className={styles.copyButton} aria-label={`Copy ${title.toLowerCase()}`}>
+      <button type="button" onClick={copy} disabled={copying} data-copied={status === "copied" || undefined} className={styles.copyButton} aria-label={`Copy ${title.toLowerCase()}`}>
         {status === "copied" ? <Check size={14} aria-hidden="true" /> : <Copy size={14} aria-hidden="true" />}
-        <span>{status === "copied" ? "Copied" : "Copy"}</span>
+        <span>{copying ? "Copying…" : status === "copied" ? "Copied" : "Copy"}</span>
       </button>
     </div>
     <pre tabIndex={0} role="region" aria-label={`${title}, scrollable code`} className={styles.code}><code>{code}</code></pre>

--- a/app/src/components/sections/CommunityFeed.module.css
+++ b/app/src/components/sections/CommunityFeed.module.css
@@ -4,8 +4,9 @@
 .feedTitle { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; color: var(--color-muted); }
 .feedTitle h2 { color: var(--color-ink); font-size: 14px; font-weight: 600; }
 .feedTitle > span { margin-left: 8px; font-size: 11px; }
-.refresh { display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; flex-shrink: 0; color: var(--color-muted); border-radius: 10px; }
+.refresh { display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; flex-shrink: 0; color: var(--color-muted); border-radius: 10px; transition: color 160ms, background-color 160ms, transform 160ms; }
 .refresh:hover { color: var(--color-ink); background: var(--color-card); }
+.refresh:active:not(:disabled) { transform: scale(.96); }
 .refresh:disabled { opacity: .5; cursor: wait; }
 .filters { grid-column: 1 / -1; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 12px; }
 .search { display: flex; align-items: center; gap: 9px; min-width: 0; min-height: 44px; border-bottom: 1px solid var(--color-line-strong); color: var(--color-muted); }
@@ -21,7 +22,14 @@
 .empty h3 { max-width: 340px; color: var(--color-ink); font-size: 23px; font-weight: 600; line-height: 1.28; letter-spacing: -.035em; text-wrap: balance; }
 .empty > p { max-width: 370px; margin-top: 12px; color: var(--color-muted); font-size: 13px; line-height: 1.75; text-wrap: pretty; }
 .empty > :is(a, button) { margin-top: 24px; }
-.posts { list-style: none; margin: 0; padding: 0; }
+.feedStart { height: 0; }
+.newPostsSlot { position: sticky; top: 88px; z-index: 10; height: 0; display: flex; justify-content: center; pointer-events: none; }
+.newPosts { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 44px; padding: 0 14px; transform: translateY(8px); color: var(--color-ink); background: var(--color-card); border: 1px solid var(--color-line-strong); border-radius: 999px; box-shadow: 0 4px 16px rgb(0 0 0 / .12); pointer-events: auto; font-size: 12px; font-weight: 500; transition: border-color 160ms, background-color 160ms; }
+.newPosts:hover { border-color: var(--color-brand); background: var(--color-card); }
+.newPostsAction { padding-left: 8px; border-left: 1px solid var(--color-line); color: var(--color-brand); }
+.posts { list-style: none; margin: 0; padding: 0; overflow-anchor: none; }
+.postEntering { animation: postEnter 220ms ease-out both; }
+@keyframes postEnter { from { opacity: .4; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
 .posts > li + li { border-top: 1px solid var(--color-line); }
 .post { min-width: 0; }
 .postLink { display: block; padding: 28px 0; transition: background-color 160ms; }
@@ -56,4 +64,4 @@
 .note .caution { margin-top: 20px; }
 @media (max-width: 1023px) { .layout { grid-template-columns: minmax(0, 1fr); gap: 40px; } .aside { display: grid; grid-template-columns: 1fr 1fr; align-items: start; gap: 32px; padding: 32px 0 0; border-left: 0; border-top: 1px solid var(--color-line); } .note { padding-top: 4px; border-top: 0; } }
 @media (max-width: 639px) { .controls { gap: 12px; } .feedTitle > span, .resultLine > span { display: none; } .resultLine { font-size: 10px; } .filters { grid-template-columns: minmax(0, 1fr) auto; gap: 8px; } .search { grid-column: 1 / -1; grid-row: 2; } .empty { padding-block: 36px; } .empty h3 { font-size: 22px; } .aside { grid-template-columns: 1fr; gap: 16px; } .postLink { padding-block: 24px; } .postBody { font-size: 14px; } }
-@media (prefers-reduced-motion: reduce) { .postLink { transition: none; } }
+@media (prefers-reduced-motion: reduce) { .postLink, .refresh, .newPosts { transition: none; } .refresh:active:not(:disabled) { transform: none; } .postEntering { animation: none; } }

--- a/app/src/components/sections/CommunityFeed.module.css
+++ b/app/src/components/sections/CommunityFeed.module.css
@@ -1,33 +1,30 @@
-.layout { display: grid; grid-template-columns: minmax(0, 1fr) 288px; align-items: start; gap: 32px; }
-.toolbar { min-height: 68px; display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 10px 20px; border-bottom: 1px solid var(--color-line); }
+.layout { display: grid; grid-template-columns: minmax(0, 1fr) 256px; align-items: start; gap: 48px; }
+.controls { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px 20px; padding-bottom: 20px; border-bottom: 1px solid var(--color-line); }
+.toolbar { min-height: 32px; display: flex; align-items: center; gap: 12px; }
 .feedTitle { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; color: var(--color-muted); }
 .feedTitle h2 { color: var(--color-ink); font-size: 14px; font-weight: 600; }
 .feedTitle > span { margin-left: 8px; font-size: 11px; }
-.refresh { display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; flex-shrink: 0; color: var(--color-muted); border: 1px solid var(--color-line); border-radius: 50%; }
-.refresh:hover { color: var(--color-ink); border-color: var(--color-line-strong); }
+.refresh { display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; flex-shrink: 0; color: var(--color-muted); border-radius: 10px; }
+.refresh:hover { color: var(--color-ink); background: var(--color-card); }
 .refresh:disabled { opacity: .5; cursor: wait; }
-.filters { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 12px; padding: 16px 20px; }
-.search { display: flex; align-items: center; gap: 9px; min-width: 180px; flex: 1; min-height: 44px; border-bottom: 1px solid var(--color-line-strong); color: var(--color-muted); }
+.filters { grid-column: 1 / -1; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 12px; }
+.search { display: flex; align-items: center; gap: 9px; min-width: 0; min-height: 44px; border-bottom: 1px solid var(--color-line-strong); color: var(--color-muted); }
 .search input { width: 100%; min-width: 0; min-height: 44px; background: transparent; font-size: 12px; color: var(--color-ink); outline-offset: 0; }
 .search input::placeholder { color: var(--color-muted); }
 .search button { display: flex; align-items: center; justify-content: center; height: 44px; width: 44px; flex-shrink: 0; }
-.resultLine { display: flex; justify-content: space-between; gap: 8px; flex-wrap: wrap; padding: 11px 20px; border-block: 1px solid var(--color-line); color: var(--color-muted); font-size: 11px; }
+.resultLine { grid-column: 2; grid-row: 1; display: flex; align-items: center; justify-content: flex-end; gap: 8px; flex-wrap: wrap; color: var(--color-muted); font-size: 11px; }
+.resultLine > span { flex-basis: 100%; text-align: right; }
 .resultLine p span { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
-.empty { padding: 44px 24px 48px; display: flex; flex-direction: column; align-items: center; text-align: center; }
-.conversationMark { position: relative; display: flex; align-items: center; justify-content: center; width: 116px; height: 88px; margin-bottom: 28px; color: var(--color-body); }
-.conversationMark > svg { z-index: 1; width: 68px; height: 60px; padding: 14px; background: var(--color-card); border: 1px solid var(--color-line-strong); border-radius: 12px; }
-.conversationMark > span { position: absolute; width: 64px; height: 48px; border: 1px solid var(--color-line); border-radius: 12px; }
-.conversationMark > span:first-of-type { left: 0; top: 0; }
-.conversationMark > span:last-of-type { right: 0; bottom: 0; border-bottom-color: var(--color-brand); }
+.empty { padding: 48px 0; display: flex; flex-direction: column; align-items: flex-start; text-align: left; }
 .emptyIcon { margin-bottom: 20px; color: var(--color-muted); }
-.empty .emptyEyebrow { margin: 0 0 12px; color: var(--color-muted); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
+.empty .emptyEyebrow { margin-top: 12px; color: var(--color-muted); font-size: 11px; }
 .empty h3 { max-width: 340px; color: var(--color-ink); font-size: 23px; font-weight: 600; line-height: 1.28; letter-spacing: -.035em; text-wrap: balance; }
 .empty > p { max-width: 370px; margin-top: 12px; color: var(--color-muted); font-size: 13px; line-height: 1.75; text-wrap: pretty; }
 .empty > :is(a, button) { margin-top: 24px; }
 .posts { list-style: none; margin: 0; padding: 0; }
 .posts > li + li { border-top: 1px solid var(--color-line); }
 .post { min-width: 0; }
-.postLink { display: block; padding: 24px; transition: background-color 160ms; }
+.postLink { display: block; padding: 28px 0; transition: background-color 160ms; }
 .postLink:hover { background: var(--color-card); }
 .postHeading { display: flex; align-items: center; gap: 12px; }
 .postAuthor { flex: 1; min-width: 0; }
@@ -39,24 +36,24 @@
 .postMeta { display: flex; align-items: center; gap: 8px; margin-top: 18px; color: var(--color-muted); font-size: 11px; }
 .postToken { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 8px; min-width: 0; overflow-wrap: anywhere; }
 .postToken strong { color: var(--color-body); font-weight: 500; }
-.role { border: 1px solid var(--color-line-strong); border-radius: 4px; padding: 2px 5px; }
+.role { color: var(--color-body); font-weight: 500; }
 .discussion { display: inline-flex; align-items: center; gap: 6px; min-height: 32px; margin-top: 8px; color: var(--color-muted); font-size: 11px; }
 .postLink:is(:hover, :focus-visible) .discussion, .postLink:is(:hover, :focus-visible) .postArrow { color: var(--color-brand); }
-.feedFoot { padding: 16px 20px; border-top: 1px solid var(--color-line); color: var(--color-muted); font-size: 11px; line-height: 1.6; text-wrap: pretty; }
-.aside { min-width: 0; }
-.guide { padding: 4px 0 20px; }
-.asideEyebrow { color: var(--color-muted); font-size: 10px; letter-spacing: .05em; text-transform: uppercase; }
-.guide h2 { margin-top: 14px; color: var(--color-ink); font-size: 24px; font-weight: 600; line-height: 1.25; letter-spacing: -.035em; }
+.feedFoot { padding-block: 20px; border-top: 1px solid var(--color-line); color: var(--color-muted); font-size: 11px; line-height: 1.6; text-wrap: pretty; }
+.aside { min-width: 0; padding-left: 24px; border-left: 1px solid var(--color-line); }
+.guide { padding: 4px 0 28px; }
+.asideEyebrow { margin-top: 12px; color: var(--color-muted); font-size: 11px; line-height: 1.6; }
+.guide h2 { color: var(--color-ink); font-size: 22px; font-weight: 600; line-height: 1.25; letter-spacing: -.035em; }
 .guide > p:not(.asideEyebrow) { margin-top: 12px; color: var(--color-body); font-size: 13px; line-height: 1.75; text-wrap: pretty; }
 .steps { margin: 28px 0 8px; list-style: none; padding: 0; }
 .steps > li { display: flex; align-items: baseline; gap: 16px; padding: 14px 0; border-top: 1px solid var(--color-line); }
 .steps > li > span { font-family: var(--font-mono); color: var(--color-muted); font-size: 10px; }
 .steps h3 { font-size: 13px; font-weight: 500; color: var(--color-ink); }
 .steps p { margin-top: 4px; color: var(--color-muted); font-size: 12px; line-height: 1.65; }
-.note { padding: 24px; border: 1px solid var(--color-line); border-radius: 16px; background: var(--color-card); color: var(--color-muted); }
+.note { padding-top: 28px; border-top: 1px solid var(--color-line); color: var(--color-muted); }
 .note h2 { margin-top: 16px; color: var(--color-ink); font-size: 14px; font-weight: 600; line-height: 1.5; }
 .note p { margin-top: 10px; font-size: 12px; line-height: 1.75; text-wrap: pretty; }
-.note .caution { padding-top: 16px; margin-top: 16px; border-top: 1px solid var(--color-line); }
-@media (max-width: 1023px) { .layout { grid-template-columns: minmax(0, 1fr); } .aside { display: grid; grid-template-columns: 1fr 1fr; align-items: start; gap: 32px; } }
-@media (max-width: 639px) { .toolbar, .filters { padding-inline: 16px; } .feedTitle > span { display: none; } .resultLine { padding-inline: 16px; } .resultLine > span { display: none; } .empty { padding: 32px 18px; } .empty h3 { font-size: 22px; } .aside { grid-template-columns: 1fr; gap: 16px; } .postLink { padding: 20px 16px; } .postBody { font-size: 14px; } }
+.note .caution { margin-top: 20px; }
+@media (max-width: 1023px) { .layout { grid-template-columns: minmax(0, 1fr); gap: 40px; } .aside { display: grid; grid-template-columns: 1fr 1fr; align-items: start; gap: 32px; padding: 32px 0 0; border-left: 0; border-top: 1px solid var(--color-line); } .note { padding-top: 4px; border-top: 0; } }
+@media (max-width: 639px) { .controls { gap: 12px; } .feedTitle > span, .resultLine > span { display: none; } .resultLine { font-size: 10px; } .filters { grid-template-columns: minmax(0, 1fr) auto; gap: 8px; } .search { grid-column: 1 / -1; grid-row: 2; } .empty { padding-block: 36px; } .empty h3 { font-size: 22px; } .aside { grid-template-columns: 1fr; gap: 16px; } .postLink { padding-block: 24px; } .postBody { font-size: 14px; } }
 @media (prefers-reduced-motion: reduce) { .postLink { transition: none; } }

--- a/app/src/components/sections/CommunityFeed.tsx
+++ b/app/src/components/sections/CommunityFeed.tsx
@@ -11,7 +11,7 @@ import { useLive } from "@/components/launchpad/LiveProvider";
 import { CHAIN_SHORT, shortAddr, type ChainKey } from "@/lib/chainPublic";
 import { ago, nowMs } from "@/lib/launchpad/time";
 import type { PostRow } from "@/lib/launchpad/postsServer";
-import { communityFingerprint, filterCommunityPosts, reconcileCommunityWindow } from "@/lib/launchpad/community-feed";
+import { communityFingerprint, filterCommunityPosts, reconcileCommunityWindow, revealCommunityPosts } from "@/lib/launchpad/community-feed";
 import shell from "./SectionShell.module.css";
 import styles from "./CommunityFeed.module.css";
 
@@ -108,12 +108,13 @@ export default function CommunityFeed({ initial, loadError = false }: { initial:
   const filtered = Boolean(chain || query.trim());
   function reset() { setChain(null); setQuery(""); }
   function showNewPosts() {
-    setEntering(pending.map((post) => post.id));
+    const revealIds = pending.map((post) => post.id);
+    setEntering(revealIds);
     if (entryTimer.current) clearTimeout(entryTimer.current);
     // Clear even when reduced motion disables animationend, so changing a filter
     // later cannot replay an old batch's entrance.
     entryTimer.current = setTimeout(() => setEntering([]), 250);
-    setFeed({ source: feed.source, ...reconcileCommunityWindow(feed, feed.source, false) });
+    setFeed((current) => ({ source: current.source, ...revealCommunityPosts(current, current.source, revealIds) }));
   }
 
   return <div className={styles.layout}>

--- a/app/src/components/sections/CommunityFeed.tsx
+++ b/app/src/components/sections/CommunityFeed.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState, useTransition } from "react";
+import { Component, createRef, useEffect, useRef, useState, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowRight, ArrowUpRight, MessageSquare, RefreshCw, Search, Signature, X } from "lucide-react";
+import { ArrowRight, ArrowUp, ArrowUpRight, MessageSquare, RefreshCw, Search, Signature, X } from "lucide-react";
 import ChainSelector from "@/components/launchpad/ChainSelector";
 import TokenAvatar from "@/components/launchpad/TokenAvatar";
 import WalletAvatar from "@/components/WalletAvatar";
@@ -11,9 +11,45 @@ import { useLive } from "@/components/launchpad/LiveProvider";
 import { CHAIN_SHORT, shortAddr, type ChainKey } from "@/lib/chainPublic";
 import { ago, nowMs } from "@/lib/launchpad/time";
 import type { PostRow } from "@/lib/launchpad/postsServer";
-import { communityFingerprint, filterCommunityPosts } from "@/lib/launchpad/community-feed";
+import { communityFingerprint, filterCommunityPosts, reconcileCommunityWindow } from "@/lib/launchpad/community-feed";
 import shell from "./SectionShell.module.css";
 import styles from "./CommunityFeed.module.css";
+
+type ScrollAnchorProps = { children: ReactNode; revision: object; filterKey: string; rowIds: number[]; preservePosition: boolean };
+type ScrollAnchor = { id: string; top: number } | null;
+
+// getSnapshotBeforeUpdate reads the old DOM immediately before React changes it.
+// A layout-effect read is too late to preserve the reader after an edited or
+// moderated row changes height. Keep this lifecycle boundary local to the feed.
+class FeedScrollAnchor extends Component<ScrollAnchorProps> {
+  private list = createRef<HTMLDivElement>();
+
+  getSnapshotBeforeUpdate(previous: ScrollAnchorProps): ScrollAnchor {
+    if (!this.props.preservePosition || previous.revision === this.props.revision || previous.filterKey !== this.props.filterKey) return null;
+    const surviving = new Set(this.props.rowIds.map(String));
+    const rows = this.list.current?.querySelectorAll<HTMLElement>("[data-post-id]");
+    if (!rows) return null;
+    for (const row of rows) {
+      const rect = row.getBoundingClientRect();
+      // The header occupies the top 80px; choose the first surviving reading row.
+      if (surviving.has(row.dataset.postId!) && rect.bottom > 80 && rect.top < window.innerHeight) {
+        return { id: row.dataset.postId!, top: rect.top };
+      }
+    }
+    return null;
+  }
+
+  componentDidUpdate(_previous: ScrollAnchorProps, _state: unknown, anchor: ScrollAnchor) {
+    if (!anchor) return;
+    const row = this.list.current?.querySelector<HTMLElement>(`[data-post-id="${anchor.id}"]`);
+    if (row) {
+      const delta = row.getBoundingClientRect().top - anchor.top;
+      if (Math.abs(delta) > .5) window.scrollBy({ top: delta, behavior: "instant" });
+    }
+  }
+
+  render() { return <div id="community-posts" ref={this.list}>{this.props.children}</div>; }
+}
 
 export default function CommunityFeed({ initial, loadError = false }: { initial: PostRow[]; loadError?: boolean }) {
   const router = useRouter();
@@ -22,8 +58,31 @@ export default function CommunityFeed({ initial, loadError = false }: { initial:
   const [query, setQuery] = useState("");
   const [now, setNow] = useState(0);
   const [refreshing, startTransition] = useTransition();
+  const [readingDown, setReadingDown] = useState(false);
+  const [feed, setFeed] = useState(() => ({ source: initial, ...reconcileCommunityWindow<PostRow>({ visible: [], pending: [] }, initial, false) }));
+  const [entering, setEntering] = useState<number[]>([]);
+  const entryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const feedStart = useRef<HTMLDivElement>(null);
   const observed = useRef(communityFingerprint(initial));
   const fullWindowRefresh = useRef(0);
+  // Reconcile before committing the new server payload. A failed load is not an
+  // authoritative empty window. Filters remain local and are never reset here.
+  if (!loadError && initial !== feed.source) {
+    setFeed({ source: initial, ...reconcileCommunityWindow(feed, initial, readingDown || feed.pending.length > 0) });
+  }
+
+  useEffect(() => {
+    const updateReadingPosition = () => setReadingDown((feedStart.current?.getBoundingClientRect().top ?? 0) < 80);
+    updateReadingPosition();
+    window.addEventListener("scroll", updateReadingPosition, { passive: true });
+    window.addEventListener("resize", updateReadingPosition);
+    return () => {
+      window.removeEventListener("scroll", updateReadingPosition);
+      window.removeEventListener("resize", updateReadingPosition);
+    };
+  }, []);
+
+  useEffect(() => () => { if (entryTimer.current) clearTimeout(entryTimer.current); }, []);
   // Keep the server's 100-row window. A changed shared snapshot is a refresh
   // signal, not a replacement with the poller's shorter 30-row window.
   useEffect(() => {
@@ -44,9 +103,18 @@ export default function CommunityFeed({ initial, loadError = false }: { initial:
     return () => { clearTimeout(timer); unsubscribe(); };
   }, [initial, router, subscribe]);
 
-  const shown = filterCommunityPosts(initial, chain, query);
+  const shown = filterCommunityPosts(feed.visible, chain, query);
+  const pending = filterCommunityPosts(feed.pending, chain, query);
   const filtered = Boolean(chain || query.trim());
   function reset() { setChain(null); setQuery(""); }
+  function showNewPosts() {
+    setEntering(pending.map((post) => post.id));
+    if (entryTimer.current) clearTimeout(entryTimer.current);
+    // Clear even when reduced motion disables animationend, so changing a filter
+    // later cannot replay an old batch's entrance.
+    entryTimer.current = setTimeout(() => setEntering([]), 250);
+    setFeed({ source: feed.source, ...reconcileCommunityWindow(feed, feed.source, false) });
+  }
 
   return <div className={styles.layout}>
     <section className={shell.panel} aria-label="Recent community posts" aria-busy={refreshing}>
@@ -65,16 +133,22 @@ export default function CommunityFeed({ initial, loadError = false }: { initial:
       </div>
       <div className={styles.resultLine}><p role="status">{refreshing ? "Refreshing posts…" : loadError ? "Feed unavailable" : <><span>{shown.length}</span> {filtered ? "matching" : "recent"} {shown.length === 1 ? "post" : "posts"}</>}</p><span>Token-page conversations</span></div>
       </header>
+      <div ref={feedStart} className={styles.feedStart} />
+      {!loadError && pending.length > 0 && shown.length > 0 ? <div className={styles.newPostsSlot}>
+        <button type="button" className={styles.newPosts} onClick={showNewPosts} aria-controls="community-posts"><ArrowUp size={14} aria-hidden="true" />{pending.length} new {pending.length === 1 ? "post" : "posts"}<span className={styles.newPostsAction}>Show</span></button>
+        <span className="sr-only" role="status">{pending.length} new {pending.length === 1 ? "post is" : "posts are"} available in this view.</span>
+      </div> : null}
+      <FeedScrollAnchor revision={feed} filterKey={`${chain ?? ""}:${query}`} rowIds={loadError ? [] : shown.map((post) => post.id)} preservePosition={readingDown}>
       {loadError ? <div className={styles.empty}>
         <MessageSquare size={30} aria-hidden="true" className={styles.emptyIcon} /><h3>The feed couldn’t load.</h3><p>Your connection or the indexer may be unavailable. You can retry without connecting a wallet.</p><button type="button" className={shell.action} disabled={refreshing} onClick={() => startTransition(() => router.refresh())}>Try again <RefreshCw size={14} aria-hidden="true" /></button>
       </div> : shown.length === 0 ? <div className={styles.empty}>
         <MessageSquare size={30} aria-hidden="true" className={styles.emptyIcon} />
-        <h3>{filtered ? "No matching conversations." : "The next conversation starts with you."}</h3>
-        <p className={styles.emptyEyebrow}>{filtered ? "Nothing in this view" : "Room for a first word"}</p>
-        <p>{filtered ? "Try another chain or search term. Search covers only the recent posts loaded here." : "Open a token, head to Conversation, and add your perspective. Holders, traders and creators can post with a free wallet signature."}</p>
-        {filtered ? <button type="button" onClick={reset} className={shell.action}>Clear filters <X size={14} aria-hidden="true" /></button> : <Link href="/#launches" className={shell.action}>Find a token <ArrowRight size={15} aria-hidden="true" /></Link>}
+        <h3>{pending.length ? "New conversations are ready." : filtered ? "No matching conversations." : "The next conversation starts with you."}</h3>
+        <p className={styles.emptyEyebrow}>{pending.length ? "Ready when you are" : filtered ? "Nothing in this view" : "Room for a first word"}</p>
+        <p>{pending.length ? `${pending.length} new ${pending.length === 1 ? "post is" : "posts are"} waiting in this view. Your filters will stay the same.` : filtered ? "Try another chain or search term. Search covers only the recent posts loaded here." : "Open a token, head to Conversation, and add your perspective. Holders, traders and creators can post with a free wallet signature."}</p>
+        {pending.length ? <button type="button" onClick={showNewPosts} className={shell.action}>Show new posts <ArrowUp size={14} aria-hidden="true" /></button> : filtered ? <button type="button" onClick={reset} className={shell.action}>Clear filters <X size={14} aria-hidden="true" /></button> : <Link href="/#launches" className={shell.action}>Find a token <ArrowRight size={15} aria-hidden="true" /></Link>}
       </div> : <ol className={styles.posts} aria-label="Posts, newest first">
-        {shown.map((post) => <li key={post.id}>
+        {shown.map((post) => <li key={post.id} data-post-id={post.id} className={entering.includes(post.id) ? styles.postEntering : undefined}>
           <article className={styles.post}>
             <Link href={`/t/${post.chain}/${post.token}#comments`} className={styles.postLink}>
               <div className={styles.postHeading}>
@@ -101,6 +175,7 @@ export default function CommunityFeed({ initial, loadError = false }: { initial:
           </article>
         </li>)}
       </ol>}
+      </FeedScrollAnchor>
       <div className={styles.feedFoot}>Showing up to 100 recent posts. Read the full thread on its token page.</div>
     </section>
 

--- a/app/src/components/sections/CommunityFeed.tsx
+++ b/app/src/components/sections/CommunityFeed.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowRight, ArrowUpRight, MessageSquare, RefreshCw, Search, Signature, X } from "lucide-react";
-import { ToggleGroup, ToggleGroupItem } from "@/components/vendor/toggle-group";
+import ChainSelector from "@/components/launchpad/ChainSelector";
 import TokenAvatar from "@/components/launchpad/TokenAvatar";
 import WalletAvatar from "@/components/WalletAvatar";
 import { useLive } from "@/components/launchpad/LiveProvider";
@@ -50,29 +50,27 @@ export default function CommunityFeed({ initial, loadError = false }: { initial:
 
   return <div className={styles.layout}>
     <section className={shell.panel} aria-label="Recent community posts" aria-busy={refreshing}>
+      <header className={styles.controls}>
       <div className={styles.toolbar}>
         <div className={styles.feedTitle}><MessageSquare size={17} aria-hidden="true" /><h2>Community feed</h2><span>Newest first</span></div>
-        <button type="button" className={styles.refresh} onClick={() => startTransition(() => router.refresh())} disabled={refreshing} aria-label="Refresh posts" title="Refresh posts"><RefreshCw size={15} aria-hidden="true" /></button>
       </div>
       <div className={styles.filters}>
-        <ToggleGroup multiple={false} value={[chain ?? "all"]} onValueChange={(values) => { if (values[0]) setChain(values[0] === "all" ? null : values[0] as ChainKey); }} aria-label="Filter posts by chain">
-          <ToggleGroupItem value="all" className="min-h-11">All chains</ToggleGroupItem>
-          <ToggleGroupItem value="base" className="min-h-11">Base</ToggleGroupItem>
-          <ToggleGroupItem value="robinhood" className="min-h-11">Robinhood</ToggleGroupItem>
-        </ToggleGroup>
+        <ChainSelector value={chain} onChange={setChain} label="Filter posts by chain" />
         <div className={styles.search}>
           <Search size={15} aria-hidden="true" />
           <input type="search" aria-label="Search recent posts" placeholder="Search recent posts" value={query} onChange={(e) => setQuery(e.target.value)} />
           {query ? <button type="button" aria-label="Clear post search" onClick={() => setQuery("")}><X size={14} aria-hidden="true" /></button> : null}
         </div>
+        <button type="button" className={styles.refresh} onClick={() => startTransition(() => router.refresh())} disabled={refreshing} aria-label="Refresh posts" title="Refresh posts"><RefreshCw size={15} aria-hidden="true" /></button>
       </div>
       <div className={styles.resultLine}><p role="status">{refreshing ? "Refreshing posts…" : loadError ? "Feed unavailable" : <><span>{shown.length}</span> {filtered ? "matching" : "recent"} {shown.length === 1 ? "post" : "posts"}</>}</p><span>Token-page conversations</span></div>
+      </header>
       {loadError ? <div className={styles.empty}>
         <MessageSquare size={30} aria-hidden="true" className={styles.emptyIcon} /><h3>The feed couldn’t load.</h3><p>Your connection or the indexer may be unavailable. You can retry without connecting a wallet.</p><button type="button" className={shell.action} disabled={refreshing} onClick={() => startTransition(() => router.refresh())}>Try again <RefreshCw size={14} aria-hidden="true" /></button>
       </div> : shown.length === 0 ? <div className={styles.empty}>
-        <div className={styles.conversationMark} aria-hidden="true"><MessageSquare size={30} /><span /><span /></div>
-        <p className={styles.emptyEyebrow}>{filtered ? "Nothing in this view" : "Room for a first word"}</p>
+        <MessageSquare size={30} aria-hidden="true" className={styles.emptyIcon} />
         <h3>{filtered ? "No matching conversations." : "The next conversation starts with you."}</h3>
+        <p className={styles.emptyEyebrow}>{filtered ? "Nothing in this view" : "Room for a first word"}</p>
         <p>{filtered ? "Try another chain or search term. Search covers only the recent posts loaded here." : "Open a token, head to Conversation, and add your perspective. Holders, traders and creators can post with a free wallet signature."}</p>
         {filtered ? <button type="button" onClick={reset} className={shell.action}>Clear filters <X size={14} aria-hidden="true" /></button> : <Link href="/#launches" className={shell.action}>Find a token <ArrowRight size={15} aria-hidden="true" /></Link>}
       </div> : <ol className={styles.posts} aria-label="Posts, newest first">
@@ -108,8 +106,8 @@ export default function CommunityFeed({ initial, loadError = false }: { initial:
 
     <aside className={styles.aside} aria-label="About the community">
       <section className={styles.guide}>
-        <p className={styles.asideEyebrow}>A little context goes a long way</p>
         <h2>Join from the token.</h2>
+        <p className={styles.asideEyebrow}>A little context goes a long way</p>
         <p>Every post belongs to a token. The full thread, the market and the contracts stay together.</p>
         <ol className={styles.steps}>
           <li><span>01</span><div><h3>Find your token</h3><p>Browse launches on either chain.</p></div></li>

--- a/app/src/components/sections/DocumentationContents.module.css
+++ b/app/src/components/sections/DocumentationContents.module.css
@@ -1,0 +1,15 @@
+.contents { min-width: 0; }
+.title { margin-bottom: 12px; color: var(--color-muted); font-size: 10px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
+.contents ol { margin: 0; padding: 0; list-style: none; }
+.contents li a { position: relative; display: flex; align-items: center; gap: 12px; min-height: 44px; padding-left: 12px; border-left: 1px solid var(--color-line); color: var(--color-muted); font-size: 12px; transition: color 160ms, border-color 160ms; }
+.contents li a span { color: var(--color-muted); font: 10px var(--font-mono); font-variant-numeric: tabular-nums; }
+.contents li a:hover, .contents li a[aria-current="location"] { color: var(--color-ink); }
+.contents li a[aria-current="location"] { border-left-color: var(--color-brand); }
+.contents li a[aria-current="location"] span { color: var(--color-brand); }
+.contents a:focus-visible { outline: 2px solid var(--color-brand); outline-offset: 3px; }
+@media (max-width: 767px) {
+  .contents ol { display: flex; flex-wrap: wrap; gap: 0 20px; }
+  .contents li a { gap: 8px; padding-left: 0; border-left: 0; border-bottom: 2px solid transparent; }
+  .contents li a[aria-current="location"] { border-bottom-color: var(--color-brand); }
+}
+@media (prefers-reduced-motion: reduce) { .contents li a { transition: none; } }

--- a/app/src/components/sections/DocumentationContents.tsx
+++ b/app/src/components/sections/DocumentationContents.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "./DocumentationContents.module.css";
+
+type Section = { id: string; number: string; label: string };
+
+/** Native anchors still work before hydration. Only the reading marker is enhanced. */
+export default function DocumentationContents({ sections, title = "On this page", "aria-label": label }: { sections: readonly Section[]; title?: string; "aria-label": string }) {
+  const [active, setActive] = useState<string | null>(null);
+
+  useEffect(() => {
+    let frame = 0;
+    const update = () => {
+      frame = 0;
+      const elements = sections.map(({ id }) => document.getElementById(id)).filter((element): element is HTMLElement => element !== null);
+      const current = elements.findLast((element) => element.getBoundingClientRect().top <= 160) ?? elements[0];
+      setActive(current?.id ?? null);
+    };
+    const queue = () => { if (!frame) frame = requestAnimationFrame(update); };
+    queue();
+    window.addEventListener("scroll", queue, { passive: true });
+    window.addEventListener("resize", queue);
+    window.addEventListener("hashchange", queue);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("scroll", queue);
+      window.removeEventListener("resize", queue);
+      window.removeEventListener("hashchange", queue);
+    };
+  }, [sections]);
+
+  return <nav className={styles.contents} aria-label={label}>
+    <p className={styles.title}>{title}</p>
+    <ol>{sections.map(({ id, number, label: text }) => <li key={id}>
+      <a href={`#${id}`} aria-current={active === id ? "location" : undefined}><span>{number}</span>{text}</a>
+    </li>)}</ol>
+  </nav>;
+}

--- a/app/src/components/sections/RulesGuide.module.css
+++ b/app/src/components/sections/RulesGuide.module.css
@@ -4,11 +4,6 @@
 .layout { display: grid; grid-template-columns: 176px minmax(0, 1fr); gap: 56px; margin-top: 48px; }
 .contents { position: sticky; top: 112px; align-self: start; }
 .eyebrow { color: var(--color-muted); font-size: 10px; font-weight: 600; letter-spacing: .1em; text-transform: uppercase; }
-.contents ol { margin-top: 14px; }
-.contents li a { display: flex; align-items: center; gap: 12px; min-height: 44px; color: var(--color-body); font-size: 12px; border-radius: 6px; }
-.contents li a span { color: var(--color-muted); font: 10px var(--font-mono); font-variant-numeric: tabular-nums; }
-.contents li a:hover { color: var(--color-ink); }
-.contents li a:hover span { color: var(--color-brand); }
 .sourceLink { display: flex; align-items: center; gap: 8px; min-height: 44px; margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--color-line); color: var(--color-muted); font-size: 12px; }
 .sourceLink:hover { color: var(--color-ink); }
 .article { min-width: 0; display: grid; gap: 64px; }

--- a/app/src/components/sections/RulesGuide.module.css
+++ b/app/src/components/sections/RulesGuide.module.css
@@ -13,7 +13,8 @@
 .sourceLink:hover { color: var(--color-ink); }
 .article { min-width: 0; display: grid; gap: 64px; }
 .sectionHeading { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 24px; }
-.sectionHeading h2, .closing h2 { margin-top: 10px; color: var(--color-ink); font-size: 30px; font-weight: 600; line-height: 1.18; letter-spacing: -.035em; text-wrap: balance; }
+.sectionHeading h2, .closing h2 { color: var(--color-ink); font-size: 30px; font-weight: 600; line-height: 1.18; letter-spacing: -.035em; text-wrap: balance; }
+.sectionHeading .eyebrow, .closing .eyebrow { margin-top: 12px; font-size: 11px; font-weight: 400; letter-spacing: 0; text-transform: none; }
 .sectionHeading > p { padding-bottom: 2px; color: var(--color-muted); font-size: 12px; line-height: 1.7; }
 .steps { border-block: 1px solid var(--color-line-strong); }
 .step { display: grid; grid-template-columns: 44px minmax(0, 1fr) 124px; gap: 20px; align-items: start; position: relative; padding: 26px 0; }
@@ -29,12 +30,12 @@
 .mechanismNote > svg { flex-shrink: 0; color: var(--color-brand); }
 .mechanismNote a { display: inline-flex; align-items: center; gap: 4px; min-height: 44px; margin-left: auto; text-decoration: underline; text-decoration-color: var(--color-line-strong); text-underline-offset: 3px; }
 .mechanismNote a:hover, .platformFee a:hover, .verifiers a:hover, .contractNote a:hover { color: var(--color-ink); }
-.feePanel { display: grid; grid-template-columns: 200px minmax(0, 1fr); border: 1px solid var(--color-line); border-radius: 16px; overflow: hidden; }
-.platformFee { display: flex; flex-direction: column; align-items: flex-start; padding: 24px; background: var(--color-card); }
+.feePanel { display: grid; grid-template-columns: 200px minmax(0, 1fr); gap: 32px; border-top: 1px solid var(--color-line); padding-top: 24px; }
+.platformFee { display: flex; flex-direction: column; align-items: flex-start; }
 .platformFee > strong { color: var(--color-up); font: 700 58px var(--font-mono); font-variant-numeric: tabular-nums; line-height: 1.2; letter-spacing: -.06em; margin-top: 20px; }
 .platformFee p { margin-top: 12px; font-size: 12px; line-height: 1.7; }
 .platformFee a { display: inline-flex; align-items: center; gap: 4px; min-height: 44px; margin-top: auto; padding-top: 12px; font-size: 11px; text-decoration: underline; text-decoration-color: var(--color-line-strong); text-underline-offset: 3px; }
-.tradingFees { padding: 24px; border-left: 1px solid var(--color-line); }
+.tradingFees { min-width: 0; }
 .tradingFees dl { margin-top: 12px; }
 .tradingFees dl > div { display: grid; grid-template-columns: 74px minmax(0, 1fr); gap: 16px; padding: 16px 0; }
 .tradingFees dt { color: var(--color-ink); font: 700 13px/1.7 var(--font-mono); font-variant-numeric: tabular-nums; }
@@ -45,11 +46,11 @@
 .collectNote p { margin-top: 8px; font-size: 12px; line-height: 1.8; }
 .collectNote > p { margin-top: 0; color: var(--color-muted); }
 .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
-.fixedList { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border-top: 1px solid var(--color-line); }
-.fixedList li { display: flex; gap: 14px; padding: 22px 24px 22px 0; border-bottom: 1px solid var(--color-line); }
-.fixedList li:nth-child(even) { padding-right: 0; padding-left: 24px; border-left: 1px solid var(--color-line); }
+.fixedList { display: grid; border-top: 1px solid var(--color-line); }
+.fixedList li { display: flex; gap: 16px; padding-block: 22px; border-bottom: 1px solid var(--color-line); }
+.fixedList li > div { display: grid; grid-template-columns: 160px minmax(0, 1fr); gap: 24px; flex: 1; min-width: 0; }
 .fixedMark { color: var(--color-muted); font-size: 20px; line-height: 1.1; }
-.fixedList p { margin-top: 8px; font-size: 12px; line-height: 1.8; }
+.fixedList p { font-size: 12px; line-height: 1.8; }
 .riskIntro { max-width: 660px; padding-bottom: 24px; font-size: 14px; line-height: 1.8; }
 .questions { border-top: 1px solid var(--color-line-strong); }
 .questions details { border-bottom: 1px solid var(--color-line); }
@@ -61,10 +62,9 @@
 .questions details p + p { margin-top: 12px; }
 .contractIcon { color: var(--color-muted); flex-shrink: 0; }
 .contractIntro { margin-top: -10px; margin-bottom: 24px; color: var(--color-muted); font-size: 13px; line-height: 1.7; }
-.registry { border: 1px solid var(--color-line); border-radius: 16px; overflow: hidden; }
-.network { padding: 24px; }
-.network + .network { border-top: 1px solid var(--color-line-strong); }
-.network > header { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 20px; margin-bottom: 16px; }
+.registry { display: grid; gap: 32px; }
+.network { display: grid; grid-template-columns: 160px minmax(0, 1fr); gap: 0 24px; padding-top: 24px; border-top: 1px solid var(--color-line); }
+.network > header { display: flex; align-items: flex-start; align-content: flex-start; flex-wrap: wrap; gap: 8px 20px; }
 .network h3 { color: var(--color-ink); font-size: 16px; font-weight: 600; }
 .network > header > span { color: var(--color-muted); font-size: 10px; }
 .network > header strong { margin-left: 4px; color: var(--color-body); font: 11px var(--font-mono); font-variant-numeric: tabular-nums; }
@@ -76,7 +76,7 @@
 .addresses a:hover { color: var(--color-brand); }
 .addresses a > svg { flex-shrink: 0; color: var(--color-muted); }
 .notDeployed { display: inline-block; padding-block: 12px; font-size: 12px; color: var(--color-muted); }
-.verifiers { margin-top: 18px; padding-top: 18px; border-top: 1px solid var(--color-line); }
+.verifiers { grid-column: 2; margin-top: 18px; padding-top: 18px; border-top: 1px solid var(--color-line); }
 .verifiers > p { margin-bottom: 8px; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--color-muted); }
 .verifiers > div { display: grid; grid-template-columns: minmax(0, 1fr) 86px 78px; align-items: center; gap: 8px; font-size: 12px; }
 .verifiers a { display: inline-flex; align-items: center; gap: 5px; min-height: 44px; color: var(--color-muted); font-size: 11px; text-decoration: underline; text-decoration-color: var(--color-line-strong); text-underline-offset: 3px; }
@@ -110,26 +110,28 @@
   .mechanismNote > span { flex: 1; }
   .mechanismNote a { margin: -4px 0 0 23px; }
   .feePanel { grid-template-columns: minmax(0, 1fr); }
-  .platformFee { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 8px 20px; align-items: center; padding: 20px; }
+  .platformFee { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 8px 20px; align-items: center; }
   .platformFee > .eyebrow { grid-column: 1 / -1; }
   .platformFee > strong { font-size: 48px; margin: 0; grid-row: span 2; }
   .platformFee p { margin: 0; }
   .platformFee a { margin: 0; padding: 0; }
-  .tradingFees { padding: 20px; border-left: none; border-top: 1px solid var(--color-line); }
+  .tradingFees { padding-top: 20px; border-top: 1px solid var(--color-line); }
   .tradingFees h3 { font-size: 14px; }
   .tradingFees dl > div { grid-template-columns: 64px minmax(0, 1fr); gap: 10px; }
   .tradingFees dt { font-size: 11px; }
   .fixedList { grid-template-columns: minmax(0, 1fr); }
-  .fixedList li, .fixedList li:nth-child(even) { padding: 20px 0; border-left: none; }
+  .fixedList li { padding-block: 20px; }
+  .fixedList li > div { grid-template-columns: minmax(0, 1fr); gap: 8px; }
   .fixedList h3 { font-size: 14px; }
   .questions summary { font-size: 13px; }
   .questions details > div { padding-right: 0; font-size: 12px; }
   .riskIntro { font-size: 13px; }
   .contractIcon { display: none; }
-  .network { padding: 20px; }
+  .network { grid-template-columns: minmax(0, 1fr); gap: 16px; }
   .network > header { flex-direction: column; align-items: flex-start; }
   .addresses > div { grid-template-columns: minmax(0, 1fr); padding-top: 12px; }
   .addresses a { font-size: 11px; padding-block: 8px; }
+  .verifiers { grid-column: 1; margin-top: 0; }
   .verifiers > div { grid-template-columns: minmax(0, 1fr) 68px 61px; gap: 4px; font-size: 11px; }
   .verifiers a { font-size: 10px; }
   .closing { flex-direction: column; align-items: flex-start; }

--- a/app/src/components/sections/SectionIntro.tsx
+++ b/app/src/components/sections/SectionIntro.tsx
@@ -9,10 +9,10 @@ export default function SectionIntro({ eyebrow, title, description, children }: 
   children?: ReactNode;
 }) {
   return <header className={styles.intro}>
-    <p className={styles.eyebrow}><span aria-hidden="true" />{eyebrow}</p>
     <div className={styles.introRow}>
       <div className={styles.introCopy}>
         <h1 className={`font-display ${styles.title}`}>{title}</h1>
+        <p className={styles.eyebrow}>{eyebrow}</p>
         <p className={styles.description}>{description}</p>
       </div>
       {children ? <div className={styles.actions}>{children}</div> : null}

--- a/app/src/components/sections/SectionShell.module.css
+++ b/app/src/components/sections/SectionShell.module.css
@@ -1,18 +1,17 @@
 .page { max-width: 1152px; margin-inline: auto; padding: 40px 16px 32px; min-width: 0; }
-.intro { padding-bottom: 32px; border-bottom: 1px solid var(--color-line); margin-bottom: 32px; }
-.eyebrow { display: flex; align-items: center; gap: 9px; color: var(--color-muted); font-size: 11px; font-weight: 500; letter-spacing: .08em; text-transform: uppercase; }
-.eyebrow > span { width: 6px; height: 6px; background: var(--color-brand); border-radius: 1px; }
-.introRow { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-top: 18px; }
+.intro { margin-bottom: 48px; }
+.eyebrow { margin-top: 14px; color: var(--color-muted); font-size: 12px; line-height: 1.5; }
+.introRow { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; }
 .introCopy { min-width: 0; max-width: 740px; }
 .title { color: var(--color-ink); font-size: 32px; line-height: 1.14; font-weight: 700; letter-spacing: -.04em; text-wrap: balance; overflow-wrap: anywhere; }
-.description { max-width: 620px; margin-top: 16px; color: var(--color-body); font-size: 15px; line-height: 1.7; text-wrap: pretty; }
+.description { max-width: 620px; margin-top: 10px; color: var(--color-body); font-size: 15px; line-height: 1.7; text-wrap: pretty; }
 .actions { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; flex-shrink: 0; }
-.action { display: inline-flex; justify-content: center; align-items: center; gap: 12px; min-height: 44px; padding: 10px 17px; border: 1px solid var(--color-line-strong); border-radius: 999px; color: var(--color-ink); font-size: 13px; font-weight: 600; transition: background-color 160ms, border-color 160ms; }
-.action:hover { background: var(--color-card); border-color: var(--color-ink); }
+.action { display: inline-flex; justify-content: center; align-items: center; gap: 12px; min-height: 44px; padding: 10px 17px; border-radius: 8px; background: var(--color-line); color: var(--color-ink); font-size: 13px; font-weight: 600; transition: background-color 160ms; }
+.action:hover { background: var(--color-line-strong); }
 .textLink { display: inline-flex; align-items: center; gap: 6px; min-height: 44px; font-size: 13px; color: var(--color-body); }
 .textLink:hover { color: var(--color-ink); }
-.panel { min-width: 0; border: 1px solid var(--color-line); border-radius: 16px; background: var(--color-paper); overflow: hidden; }
-.panelHeading { min-height: 64px; padding: 16px 20px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; border-bottom: 1px solid var(--color-line); color: var(--color-ink); font-size: 14px; font-weight: 600; }
+.panel { min-width: 0; }
+.panelHeading { min-height: 64px; padding-block: 16px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; border-bottom: 1px solid var(--color-line); color: var(--color-ink); font-size: 14px; font-weight: 600; }
 .anchorSection { scroll-margin-top: 104px; }
 .page :is(a, button, summary, input, textarea):focus-visible { outline: 2px solid var(--color-brand); outline-offset: 3px; }
 @media (min-width: 640px) { .page { padding-top: 56px; } .title { font-size: 44px; } .description { font-size: 16px; } }

--- a/app/src/components/sections/agent-examples.ts
+++ b/app/src/components/sections/agent-examples.ts
@@ -1,0 +1,25 @@
+import { CHAIN_KEYS, CHAIN_LABELS, CHAINS, SITE_URL } from "@/lib/chainPublic";
+import { launchpad, NATIVE } from "@/lib/launchpad/config";
+
+export type AgentExample = { chain: string; label: string; title: string; code: string };
+
+/** Reference text only. No key, wallet connection, or transaction is created here. */
+export function agentExamples(kind: "launch" | "read" | "sync"): AgentExample[] {
+  return CHAIN_KEYS.map((chain) => {
+    const config = launchpad(chain);
+    const label = CHAIN_LABELS[chain];
+    const common = { chain, label };
+    if (kind === "read") return { ...common, title: `Read ${label} launches`, code: `GET ${SITE_URL}/api/launch/list?chain=${chain}&sort=live&window=24h&limit=50\nGET ${SITE_URL}/api/launch/feed  # both chains\nGET ${SITE_URL}/api/launch/meta/<token>?chain=${chain}\nGET ${SITE_URL}/llms.txt` };
+    if (kind === "sync") return { ...common, title: `Sync a ${label} transaction`, code: `POST ${SITE_URL}/api/launch/sync?chain=${chain}&tx=<confirmed-transaction-hash>` };
+    return { ...common, title: `Launch on ${label}`, code: JSON.stringify({
+      chainId: CHAINS[chain].id,
+      factory: config.factory ?? "<factory-not-configured>",
+      function: "launch((string,string,string,address,uint256,int24,uint24,bytes32,(address,uint16)[]))",
+      params: {
+        name: "My Token", symbol: "MYT", metadataURI: "", quote: NATIVE,
+        supply: "0", startTick: 184200, lpFee: 10000,
+        salt: "<unique-32-byte-salt>", recipients: [{ payout: "<beneficiary-wallet-address>", bps: 10000 }],
+      },
+    }, null, 2) };
+  });
+}

--- a/app/src/components/sections/agents.test.ts
+++ b/app/src/components/sections/agents.test.ts
@@ -1,32 +1,62 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { agentExamples } from "./agent-examples.ts";
+import { CHAINS, SITE_URL } from "@/lib/chainPublic";
+import { launchpad, NATIVE } from "@/lib/launchpad/config";
 
 const page = readFileSync(new URL("../../app/agents/page.tsx", import.meta.url), "utf8");
 const codePanel = readFileSync(new URL("./AgentsCodeBlock.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("./Agents.module.css", import.meta.url), "utf8");
 
-// Source contracts protect the documentation's executable text and safety
+// Source contracts protect the documentation's reference text and safety
 // boundaries. Responsive geometry and clipboard interaction get browser review.
-test("agent documentation preserves the original launch signature and example", () => {
+test("agent documentation preserves contract guidance without executable signing examples", () => {
   for (const literal of [
-    'launch((string,string,string,address,uint256,int24,uint24,bytes32,(address,uint16)[]))',
-    '(My Token,MYT,,0x0000000000000000000000000000000000000000,0,184200,10000,0x$(openssl rand -hex 32),[(0xYourWallet,10000)])',
-    '--rpc-url https://mainnet.base.org --private-key $PK',
-    'launch(params)', 'findSalt(...)', '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168',
+    'launch(params)', 'findSalt(...)',
     '10000 = 1%', '30000 = 3%', '184200 ≈ 10 ETH',
     '{chain, launcher, salt, name, symbol, description?, image_url?, website?, x_handle?}',
     'metadataURI', 'V4_SWAP', 'poolKeyOf(token)', 'collect(tokenId)',
   ]) assert.ok(page.includes(literal), `Missing contract reference: ${literal}`);
   assert.match(page, /Never share your private key/);
   assert.match(page, /Example only/);
+  assert.match(page, /not an executable transaction/);
+  assert.doesNotMatch(page, /cast send|--private-key|\$PK/);
+  assert.match(page, /launchpad\(chain\)\.quotes/);
+});
+
+test("each launch reference uses the configured factory, actual chain ID and ABI parameter names", () => {
+  const examples = agentExamples("launch");
+  assert.equal(examples.length, 2);
+  for (const chain of ["base", "robinhood"] as const) {
+    const example = examples.find((item) => item.chain === chain)!;
+    const parsed = JSON.parse(example.code);
+    assert.equal(parsed.chainId, CHAINS[chain].id);
+    assert.equal(parsed.factory, launchpad(chain).factory ?? "<factory-not-configured>");
+    assert.equal(parsed.function, "launch((string,string,string,address,uint256,int24,uint24,bytes32,(address,uint16)[]))");
+    assert.equal(parsed.params.quote, NATIVE);
+    assert.deepEqual(parsed.params.recipients, [{ payout: "<beneficiary-wallet-address>", bps: 10000 }]);
+    assert.equal(parsed.params.salt, "<unique-32-byte-salt>");
+    assert.doesNotMatch(example.code, /private.?key|sendTransaction|writeContract|cast send/i);
+  }
+});
+
+test("HTTP examples choose supported chain filters and never imply the feed is chain-filtered", () => {
+  for (const chain of ["base", "robinhood"] as const) {
+    const read = agentExamples("read").find((item) => item.chain === chain)!.code;
+    assert.ok(read.includes(`/api/launch/list?chain=${chain}&sort=live&window=24h&limit=50`));
+    assert.ok(read.includes(`/api/launch/meta/<token>?chain=${chain}`));
+    assert.ok(read.includes(`GET ${SITE_URL}/api/launch/feed  # both chains`));
+    assert.doesNotMatch(read, /feed\?chain=/);
+    assert.ok(agentExamples("sync").find((item) => item.chain === chain)!.code.includes(`/api/launch/sync?chain=${chain}&tx=<confirmed-transaction-hash>`));
+  }
 });
 
 test("agent documentation retains every public endpoint and configured chain", () => {
   for (const path of [
-    '/api/launch/list?chain=base|robinhood&sort=live|new|mcap|volume|gainers|holders&window=1h|24h|all&limit=50',
+    '/api/launch/list', '?chain=base|robinhood&sort=live|new|mcap|volume|gainers|holders&window=1h|24h|all&limit=50',
     '/api/launch/feed', '/api/launch/meta/<token>', '/llms.txt',
-    '/api/launch/meta', '/api/launch/sync?chain=base|robinhood&tx=0x…',
+    '/api/launch/meta',
   ]) assert.ok(page.includes(path), `Missing endpoint: ${path}`);
   assert.match(page, /CHAIN_KEYS\.map/);
   assert.match(page, /config = launchpad\(chain\)/);
@@ -57,7 +87,11 @@ test("agent sections have native focus targets and accessible copy-only referenc
   assert.match(page, /aria-label="Agent documentation sections"/);
   assert.match(codePanel, /<button type="button" onClick=\{copy\}/);
   assert.match(codePanel, /navigator\.clipboard\.writeText\(code\)/);
-  assert.match(codePanel, /catch\s*\{\s*setStatus\("error"\)/);
+  assert.match(codePanel, /if \(alive\.current\) setStatus\("error"\)/);
+  assert.match(codePanel, /setTimeout\(\(\) => setStatus\("idle"\), 2400\)/);
+  assert.match(codePanel, /clearTimeout\(timer\.current\)/);
+  assert.match(codePanel, /<CopyReference key=\{selected\?\.code \?\? code\}/);
+  assert.match(codePanel, /<select value=\{chain\}/);
   assert.match(codePanel, /role="status"/);
   assert.match(codePanel, /Copy unavailable\. Select and copy the code instead/);
   assert.match(codePanel, /<pre tabIndex=\{0\} role="region" aria-label=/);

--- a/app/src/components/sections/rules-guide.test.ts
+++ b/app/src/components/sections/rules-guide.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 
 const page = readFileSync(new URL("../../app/rules/page.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("./RulesGuide.module.css", import.meta.url), "utf8");
+const contents = readFileSync(new URL("./DocumentationContents.tsx", import.meta.url), "utf8");
+const contentsCss = readFileSync(new URL("./DocumentationContents.module.css", import.meta.url), "utf8");
 
 // Source contracts supplement the page's responsive and keyboard browser review.
 test("the rules guide retains native navigation and visible risk disclosures", () => {
@@ -25,6 +27,18 @@ test("the rules guide retains native navigation and visible risk disclosures", (
   assert.match(page, /UK, Canada, Australia, Singapore and Switzerland/);
   assert.match(page, /pause transfers or freeze wallets/);
   assert.doesNotMatch(page, /use client|useEffect|setInterval|onClick=/);
+});
+
+test("the active documentation marker enhances native anchors without scrolling or stealing focus", () => {
+  assert.match(page, /<DocumentationContents sections=\{CONTENT_LINKS\}/);
+  assert.match(contents, /href=\{`#\$\{id\}`\}/);
+  assert.match(contents, /aria-current=\{active === id \? "location" : undefined\}/);
+  assert.match(contents, /addEventListener\("scroll", queue, \{ passive: true \}\)/);
+  assert.match(contents, /removeEventListener\("scroll", queue\)/);
+  assert.match(contents, /cancelAnimationFrame\(frame\)/);
+  assert.doesNotMatch(contents, /\.focus\(|scrollIntoView|preventDefault|setInterval/);
+  assert.match(contentsCss, /prefers-reduced-motion/);
+  assert.match(contentsCss, /min-height: 44px/);
 });
 
 test("the launch explanation distinguishes deposited supply, tradable tokens and fee routing", () => {

--- a/app/src/components/theme.test.ts
+++ b/app/src/components/theme.test.ts
@@ -62,7 +62,7 @@ test("light is the original Clear Sky palette, unchanged, and the unclassed base
 
 test("typography is unchanged", () => {
   assert.match(themeBlock, /--font-sans:\s*var\(--font-inter\)/);
-  assert.match(themeBlock, /--font-mono:\s*var\(--font-space-mono\)/);
+  assert.match(themeBlock, /--font-mono:\s*var\(--font-geist-mono\)/);
   assert.match(themeBlock, /--font-display:\s*var\(--font-unbounded\)/);
 });
 

--- a/app/src/components/ui.ts
+++ b/app/src/components/ui.ts
@@ -1,13 +1,13 @@
 /** Shared class strings for the "Clear Sky" design system. Presentation only. */
 
 const btnBase =
-  "inline-flex items-center justify-center gap-1.5 rounded-xl font-semibold text-sm whitespace-nowrap transition-colors disabled:opacity-40 disabled:cursor-not-allowed select-none";
+  "inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold text-sm whitespace-nowrap transition-colors motion-reduce:transition-none disabled:opacity-40 disabled:cursor-not-allowed select-none";
 
 export const btn = {
   primary: `${btnBase} min-h-11 px-5 bg-brand text-inverse hover:bg-brand-strong`,
   primarySm: `${btnBase} min-h-9 px-3.5 text-[13px] bg-brand text-inverse hover:bg-brand-strong`,
-  secondary: `${btnBase} min-h-11 px-5 bg-card text-ink border border-line-strong hover:border-ink/40 hover:bg-paper`,
-  secondarySm: `${btnBase} min-h-9 px-3.5 text-[13px] bg-card text-ink border border-line-strong hover:border-ink/40`,
+  secondary: `${btnBase} min-h-11 px-5 bg-line text-ink hover:bg-line-strong`,
+  secondarySm: `${btnBase} min-h-9 px-3.5 text-[13px] bg-line text-ink hover:bg-line-strong`,
   soft: `${btnBase} min-h-11 px-5 bg-brand-soft text-brand hover:bg-brand hover:text-inverse`,
   softSm: `${btnBase} min-h-9 px-3.5 text-[13px] bg-brand-soft text-brand hover:bg-brand hover:text-inverse`,
   up: `${btnBase} min-h-11 px-5 bg-up text-inverse hover:brightness-110`,

--- a/app/src/components/ui.ts
+++ b/app/src/components/ui.ts
@@ -1,7 +1,7 @@
 /** Shared class strings for the "Clear Sky" design system. Presentation only. */
 
 const btnBase =
-  "inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold text-sm whitespace-nowrap transition-colors motion-reduce:transition-none disabled:opacity-40 disabled:cursor-not-allowed select-none";
+  "ui-pressable inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold text-sm whitespace-nowrap motion-reduce:transition-none disabled:opacity-40 disabled:cursor-not-allowed select-none";
 
 export const btn = {
   primary: `${btnBase} min-h-11 px-5 bg-brand text-inverse hover:bg-brand-strong`,

--- a/app/src/components/vendor/popover.tsx
+++ b/app/src/components/vendor/popover.tsx
@@ -14,7 +14,7 @@ export const PopoverClose = Primitive.Close;
 export function PopoverContent({ className, align = "end", ...props }: Primitive.Popup.Props & { align?: Primitive.Positioner.Props["align"] }) {
   return <Primitive.Portal>
     <Primitive.Positioner sideOffset={8} align={align} collisionPadding={12} className="z-[90]">
-      <Primitive.Popup className={cn("max-h-[var(--available-height)] w-72 max-w-[calc(100vw-24px)] origin-[var(--transform-origin)] overflow-y-auto rounded-xl border border-line-strong bg-card p-3 text-ink transition-[opacity,transform] duration-150 data-starting-style:translate-y-1 data-starting-style:opacity-0 data-ending-style:translate-y-1 data-ending-style:opacity-0 motion-reduce:transition-none", className)} {...props} />
+      <Primitive.Popup className={cn("max-h-[var(--available-height)] w-72 max-w-[calc(100vw-24px)] origin-[var(--transform-origin)] overflow-y-auto rounded-xl border border-line-strong bg-card p-3 text-ink transition-[opacity,transform] duration-(--ui-panel-duration) ease-(--ui-ease-out) data-starting-style:translate-y-1 data-starting-style:opacity-0 data-ending-style:translate-y-1 data-ending-style:opacity-0 motion-reduce:transition-none", className)} {...props} />
     </Primitive.Positioner>
   </Primitive.Portal>;
 }

--- a/app/src/components/vendor/popover.tsx
+++ b/app/src/components/vendor/popover.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// Original Openlaunch recipe using the installed Base UI primitive. Same
+// composition as Coss, with our tokens; no registry theme or extra dependency.
+import { Popover as Primitive } from "@base-ui/react/popover";
+import { cn } from "@/lib/utils";
+
+export const Popover = Primitive.Root;
+export const PopoverTrigger = Primitive.Trigger;
+export const PopoverTitle = Primitive.Title;
+export const PopoverDescription = Primitive.Description;
+export const PopoverClose = Primitive.Close;
+
+export function PopoverContent({ className, align = "end", ...props }: Primitive.Popup.Props & { align?: Primitive.Positioner.Props["align"] }) {
+  return <Primitive.Portal>
+    <Primitive.Positioner sideOffset={8} align={align} collisionPadding={12} className="z-[90]">
+      <Primitive.Popup className={cn("max-h-[var(--available-height)] w-72 max-w-[calc(100vw-24px)] origin-[var(--transform-origin)] overflow-y-auto rounded-xl border border-line-strong bg-card p-3 text-ink transition-[opacity,transform] duration-150 data-starting-style:translate-y-1 data-starting-style:opacity-0 data-ending-style:translate-y-1 data-ending-style:opacity-0 motion-reduce:transition-none", className)} {...props} />
+    </Primitive.Positioner>
+  </Primitive.Portal>;
+}

--- a/app/src/components/vendor/tabs.tsx
+++ b/app/src/components/vendor/tabs.tsx
@@ -14,7 +14,7 @@ export function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
   return <TabsPrimitive.List className={cn("flex gap-5 overflow-x-auto border-b border-line px-5 bb-scroll", className)} {...props} />;
 }
 export function TabsTab({ className, ...props }: TabsPrimitive.Tab.Props) {
-  return <TabsPrimitive.Tab className={cn("flex min-h-12 shrink-0 cursor-pointer items-center gap-2 border-b-2 border-transparent text-sm font-medium text-muted hover:text-ink data-active:border-ink data-active:text-ink", className)} {...props} />;
+  return <TabsPrimitive.Tab className={cn("flex min-h-12 shrink-0 cursor-pointer items-center gap-2 border-b-2 border-transparent text-sm font-medium text-muted transition-colors hover:text-ink data-active:border-brand data-active:text-ink motion-reduce:transition-none", className)} {...props} />;
 }
 export function TabsPanel({ className, ...props }: TabsPrimitive.Panel.Props) {
   return <TabsPrimitive.Panel className={cn("min-w-0", className)} {...props} />;

--- a/app/src/components/vendor/tabs.tsx
+++ b/app/src/components/vendor/tabs.tsx
@@ -3,18 +3,18 @@
 // Adapted from coss ui: https://coss.com/ui/r/tabs.json
 // MIT-licensed apps/ui registry source; licensing details: ./LICENSES.md.
 // LOCAL PATCH (openlaunch): one flat underline recipe, existing tokens, no
-// shadows or animated indicator. Base UI owns keyboard/ARIA tab semantics.
+// shadows. The finite indicator follows Base UI's measured tab positions.
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cn } from "@/lib/utils";
 
 export function Tabs({ className, ...props }: TabsPrimitive.Root.Props) {
   return <TabsPrimitive.Root className={cn("min-w-0", className)} {...props} />;
 }
-export function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
-  return <TabsPrimitive.List className={cn("flex gap-5 overflow-x-auto border-b border-line px-5 bb-scroll", className)} {...props} />;
+export function TabsList({ className, children, ...props }: TabsPrimitive.List.Props) {
+  return <TabsPrimitive.List className={cn("relative flex gap-5 overflow-x-auto border-b border-line px-5 bb-scroll", className)} {...props}>{children}<TabsPrimitive.Indicator className="ui-tab-indicator motion-reduce:transition-none" /></TabsPrimitive.List>;
 }
 export function TabsTab({ className, ...props }: TabsPrimitive.Tab.Props) {
-  return <TabsPrimitive.Tab className={cn("flex min-h-12 shrink-0 cursor-pointer items-center gap-2 border-b-2 border-transparent text-sm font-medium text-muted transition-colors hover:text-ink data-active:border-brand data-active:text-ink motion-reduce:transition-none", className)} {...props} />;
+  return <TabsPrimitive.Tab className={cn("flex min-h-12 shrink-0 cursor-pointer items-center gap-2 border-b-2 border-transparent text-sm font-medium text-muted transition-colors duration-150 hover:text-ink data-active:text-ink motion-reduce:transition-none", className)} {...props} />;
 }
 export function TabsPanel({ className, ...props }: TabsPrimitive.Panel.Props) {
   return <TabsPrimitive.Panel className={cn("min-w-0", className)} {...props} />;

--- a/app/src/components/vendor/toggle-group.tsx
+++ b/app/src/components/vendor/toggle-group.tsx
@@ -2,7 +2,7 @@
 
 // Adapted from coss ui: https://coss.com/ui/r/toggle-group.json and /toggle.json.
 // MIT-licensed apps/ui registry source; licensing details: ./LICENSES.md.
-// LOCAL PATCH (openlaunch): only the single-style segmented recipe is needed.
+// LOCAL PATCH (openlaunch): open, individually selected controls, no outer tray.
 // Keep Base UI's roving focus / pressed semantics, replace Coss theme tokens,
 // shadows, variants and separators with our flat, two-theme control recipe.
 import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
@@ -10,9 +10,9 @@ import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group
 import { cn } from "@/lib/utils";
 
 export function ToggleGroup({ className, ...props }: ToggleGroupPrimitive.Props) {
-  return <ToggleGroupPrimitive data-slot="toggle-group" className={cn("inline-flex max-w-full items-center gap-1 rounded-xl border border-line bg-card p-1", className)} {...props} />;
+  return <ToggleGroupPrimitive data-slot="toggle-group" className={cn("inline-flex max-w-full items-center gap-1", className)} {...props} />;
 }
 
 export function ToggleGroupItem({ className, ...props }: TogglePrimitive.Props) {
-  return <TogglePrimitive data-slot="toggle" className={cn("inline-flex min-h-9 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border border-transparent px-3 text-xs font-medium whitespace-nowrap text-muted transition-colors hover:text-ink data-pressed:border-line-strong data-pressed:bg-paper data-pressed:text-ink disabled:cursor-not-allowed disabled:opacity-40 motion-reduce:transition-none", className)} {...props} />;
+  return <TogglePrimitive data-slot="toggle" className={cn("inline-flex min-h-9 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-3 text-xs font-medium whitespace-nowrap text-muted transition-colors hover:bg-card hover:text-ink data-pressed:bg-line data-pressed:text-ink disabled:cursor-not-allowed disabled:opacity-40 motion-reduce:transition-none", className)} {...props} />;
 }

--- a/app/src/components/vendor/toggle-group.tsx
+++ b/app/src/components/vendor/toggle-group.tsx
@@ -14,5 +14,5 @@ export function ToggleGroup({ className, ...props }: ToggleGroupPrimitive.Props)
 }
 
 export function ToggleGroupItem({ className, ...props }: TogglePrimitive.Props) {
-  return <TogglePrimitive data-slot="toggle" className={cn("inline-flex min-h-9 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-3 text-xs font-medium whitespace-nowrap text-muted transition-colors hover:bg-card hover:text-ink data-pressed:bg-line data-pressed:text-ink disabled:cursor-not-allowed disabled:opacity-40 motion-reduce:transition-none", className)} {...props} />;
+  return <TogglePrimitive data-slot="toggle" className={cn("ui-pressable inline-flex min-h-9 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-3 text-xs font-medium whitespace-nowrap text-muted hover:bg-card hover:text-ink data-pressed:bg-line data-pressed:text-ink disabled:cursor-not-allowed disabled:opacity-40 motion-reduce:transition-none", className)} {...props} />;
 }

--- a/app/src/components/wallet-picker.test.ts
+++ b/app/src/components/wallet-picker.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 const picker = readFileSync(new URL("./WalletPicker.tsx", import.meta.url), "utf8");
 const button = readFileSync(new URL("./ConnectWallet.tsx", import.meta.url), "utf8");
-const src = new URL("../", import.meta.url).pathname;
+const src = fileURLToPath(new URL("../", import.meta.url));
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {
@@ -19,7 +20,7 @@ function walk(dir: string, out: string[] = []): string[] {
 // Source contracts: the picker is the only place that chooses a connector or calls connect().
 test("every connect entry point goes through the shared picker; nothing else touches useConnect", () => {
   const users = walk(src).filter((p) => /useConnect\b|connectors\[0\]|c\.id === "coinbaseWallet"/.test(readFileSync(p, "utf8")));
-  assert.deepEqual(users.map((p) => p.slice(src.length)), ["components/WalletPicker.tsx"]);
+  assert.deepEqual(users.map((p) => relative(src, p).replaceAll("\\", "/")), ["components/WalletPicker.tsx"]);
   for (const file of ["components/ConnectButton.tsx", "components/launchpad/Posts.tsx", "components/launchpad/TradePanel.tsx", "components/launchpad/MeDashboard.tsx"]) {
     assert.match(readFileSync(join(src, file), "utf8"), /<ConnectWallet className=/, file);
   }

--- a/app/src/components/workspace-layout.test.ts
+++ b/app/src/components/workspace-layout.test.ts
@@ -39,7 +39,9 @@ test("ledger header, data rows and placeholders share responsive tracks", () => 
   assert.match(row, /const columns = "launch-ledger"/);
   assert.equal(row.match(/\$\{columns\}/g)?.length, 2);
   assert.match(source("./Skeleton.tsx"), /className="launch-ledger grid/);
-  assert.match(source("../app/globals.css"), /\.launch-ledger\s*\{\s*grid-template-columns:\s*minmax\(0, 2\.2fr\)/);
+  const css = source("../app/globals.css");
+  assert.match(css, /min-width:\s*640px[\s\S]*grid-template-columns:\s*minmax\(0, 1\.65fr\) minmax\(7rem, \.72fr\) minmax\(9\.5rem, \.9fr\)/);
+  assert.match(css, /min-width:\s*1024px[\s\S]*grid-template-columns:\s*minmax\(20rem, 36rem\) minmax\(8\.5rem, 1fr\) minmax\(7\.5rem, \.8fr\) minmax\(10rem, 1fr\)/);
 });
 
 test("market navigation is docked without changing the server scroll snapshot", () => {

--- a/app/src/components/workspace-layout.test.ts
+++ b/app/src/components/workspace-layout.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+test("workspace gutters expand without imposing a desktop width cap", () => {
+  const css = source("../app/globals.css");
+  const shell = css.match(/\.workspace-shell\s*\{([^}]+)\}/)?.[1] ?? "";
+  assert.match(shell, /width:\s*100%/);
+  assert.match(shell, /min-width:\s*0/);
+  assert.match(shell, /padding-inline:\s*var\(--workspace-gutter\)/);
+  assert.doesNotMatch(shell, /max-width/);
+  assert.match(css, /--workspace-gutter:\s*16px/);
+  assert.match(css, /min-width:\s*640px[^\n]+--workspace-gutter:\s*24px/);
+  assert.match(css, /min-width:\s*1280px[^\n]+--workspace-gutter:\s*32px/);
+});
+
+test("home isolates its readable hero from the fluid market, including loading", () => {
+  for (const path of ["../app/(home)/page.tsx", "../app/(home)/loading.tsx"]) {
+    const file = source(path);
+    assert.doesNotMatch(file.match(/<main[^>]+>/)?.[0] ?? "", /max-w-/);
+    assert.match(file, /workspace-shell/);
+    assert.equal(file.match(/max-w-6xl/g)?.length, 1);
+    assert.match(file, /xl:grid-cols-\[minmax\(0,1fr\)_17rem\]/);
+  }
+});
+
+test("token market and loading preserve the fixed trade rail in a fluid shell", () => {
+  for (const path of ["../app/t/[chain]/[token]/page.tsx", "../app/t/[chain]/[token]/loading.tsx"]) {
+    const file = source(path);
+    assert.match(file, /<main className="workspace-shell/);
+    assert.match(file, /lg:grid-cols-\[minmax\(0,1fr\)_21rem\]/);
+  }
+});
+
+test("ledger header, data rows and placeholders share responsive tracks", () => {
+  const row = source("./launchpad/LaunchRow.tsx");
+  assert.match(row, /const columns = "launch-ledger"/);
+  assert.equal(row.match(/\$\{columns\}/g)?.length, 2);
+  assert.match(source("./Skeleton.tsx"), /className="launch-ledger grid/);
+  assert.match(source("../app/globals.css"), /\.launch-ledger\s*\{\s*grid-template-columns:\s*minmax\(0, 2\.2fr\)/);
+});
+
+test("market navigation is docked without changing the server scroll snapshot", () => {
+  assert.match(source("./HeaderNav.tsx"), /const workspace = pathname === "\/" \|\| pathname\.startsWith\("\/t\/"\)/);
+  assert.match(source("./HeaderNav.tsx"), /<Navbar className="top-0" docked=\{workspace\}/);
+  const shell = source("./navigation-shell.tsx");
+  assert.match(shell, /const serverIsFloating = \(\) => false/);
+  assert.match(shell, /const visible = scrolled && !docked/);
+});

--- a/app/src/lib/launchpad/community-feed.test.ts
+++ b/app/src/lib/launchpad/community-feed.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { readFileSync } from "node:fs";
-import { communityFingerprint, filterCommunityPosts, reconcileCommunityWindow } from "./community-feed.ts";
+import { runInNewContext } from "node:vm";
+import ts from "typescript";
+import { communityFingerprint, filterCommunityPosts, reconcileCommunityWindow, revealCommunityPosts } from "./community-feed.ts";
 
 const posts = [
   { id: 1, chain: "base", token: "0xAbC", wallet: "0xWallet", symbol: "SKY", name: "Clear Sky", body: "A real conversation", tag: "creator", created_at: "2026-09-07T00:00:00Z" },
@@ -66,6 +68,111 @@ test("visible and queued counts use the same chain and search filters", () => {
   assert.equal(filterCommunityPosts(buffered.pending, "robinhood", " moon ").length, 1);
   assert.equal(filterCommunityPosts(buffered.visible, "robinhood", " moon ").length, 1);
 });
+
+test("revealing one chain leaves other-chain notifications queued in server order", () => {
+  const source = [
+    { ...posts[1], id: 6 }, { ...posts[0], id: 5 },
+    { ...posts[1], id: 4 }, { ...posts[0], id: 3 }, ...posts,
+  ];
+  const queued = reconcileCommunityWindow({ visible: posts, pending: [] }, source, true);
+  const selected = filterCommunityPosts(queued.pending, "base", "");
+  const revealed = revealCommunityPosts(queued, source, selected.map((post) => post.id));
+  assert.deepEqual(revealed.visible.map((post) => post.id), [5, 3, 1, 2]);
+  assert.deepEqual(revealed.pending.map((post) => post.id), [6, 4]);
+  assert.equal(filterCommunityPosts(revealed.pending, "robinhood", "").length, 2);
+  assert.deepEqual(reconcileCommunityWindow(revealed, source, true), revealed, "a refresh keeps unrevealed notifications");
+  assert.deepEqual(queued.pending.map((post) => post.id), [6, 5, 4, 3], "the previous window is not mutated");
+  const all = revealCommunityPosts(revealed, source, revealed.pending.map((post) => post.id));
+  assert.deepEqual(all, { visible: source, pending: [] }, "clearing filters can reveal the remaining batch");
+});
+
+test("search reveals preserve nonmatching posts on the same chain and other chains", () => {
+  const source = [
+    { ...posts[1], id: 5, body: "Needle" },
+    { ...posts[0], id: 4, body: "Unrelated" },
+    { ...posts[0], id: 3, body: "Needle" }, ...posts,
+  ];
+  const queued = reconcileCommunityWindow({ visible: posts, pending: [] }, source, true);
+  for (const chain of [null, "base"]) {
+    const selected = filterCommunityPosts(queued.pending, chain, "  needle ");
+    const revealed = revealCommunityPosts(queued, source, selected.map((post) => post.id));
+    assert.equal(filterCommunityPosts(revealed.pending, chain, "needle").length, 0);
+    assert.deepEqual(revealed.pending.map((post) => post.id), chain ? [5, 4] : [4]);
+    assert.deepEqual(filterCommunityPosts(revealed.visible, chain, "needle"), selected);
+  }
+  assert.deepEqual(revealCommunityPosts(queued, source, []), queued, "an empty selection consumes nothing");
+});
+
+test("an empty filtered view reveals its matching posts without draining other views", () => {
+  const source = [{ ...posts[1], id: 4 }, { ...posts[0], id: 3 }];
+  const queued = reconcileCommunityWindow({ visible: [], pending: [] }, source, true);
+  const selected = filterCommunityPosts(queued.pending, "base", "");
+  const revealed = revealCommunityPosts(queued, source, selected.map((post) => post.id));
+  assert.deepEqual(revealed, { visible: [source[1]], pending: [source[0]] });
+});
+
+test("stale reveal IDs cannot restore moderated rows or consume later additions", () => {
+  const first = { ...posts[0], id: 3 };
+  const other = { ...posts[1], id: 4 };
+  const queued = reconcileCommunityWindow({ visible: posts, pending: [] }, [other, first, ...posts], true);
+  const latest = [{ ...posts[0], id: 5 }, { ...other, body: "Edited while queued" }, { ...first, hidden: true }, posts[1]];
+  const revealed = revealCommunityPosts(queued, latest, [3, 5, 999]);
+  assert.deepEqual(revealed.visible, [posts[1]], "server removals and moderation still apply");
+  assert.deepEqual(revealed.pending, latest.slice(0, 2), "unseen IDs cannot authorize a later addition");
+});
+
+test("partial reveals retain the bounded, deduplicated authoritative window", () => {
+  const initial = Array.from({ length: 100 }, (_, index) => ({ ...posts[0], id: 100 - index }));
+  const source = [{ ...posts[0], id: 102 }, { ...posts[0], id: 101 }, ...initial];
+  const queued = reconcileCommunityWindow({ visible: initial, pending: [] }, source, true);
+  const revealed = revealCommunityPosts(queued, source, [101, 101]);
+  assert.equal(revealed.visible.length, 99);
+  assert.deepEqual(revealed.pending.map((post) => post.id), [102]);
+  assert.equal(revealed.visible[0].id, 101);
+  assert.equal(revealed.visible.at(-1)?.id, 3);
+});
+
+test("the actual Show handler keeps filtered notifications and intervening refreshes", () => {
+  const source = readFileSync(new URL("../../components/sections/CommunityFeed.tsx", import.meta.url), "utf8");
+  const ast = ts.createSourceFile("CommunityFeed.tsx", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  let declaration = "";
+  function visit(node: ts.Node) {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === "showNewPosts") declaration = node.getText(ast);
+    ts.forEachChild(node, visit);
+  }
+  visit(ast);
+  assert.ok(declaration, "the component must provide its Show handler");
+  const authoritative = [{ ...posts[1], id: 4 }, { ...posts[0], id: 3 }, ...posts];
+  const feed = { source: authoritative, ...reconcileCommunityWindow({ visible: posts, pending: [] }, authoritative, true) };
+  type FeedState = typeof feed;
+  let update: FeedState | ((current: FeedState) => FeedState) | undefined;
+  let entering: number[] = [];
+  let clearEntry: (() => void) | undefined;
+  const { outputText } = ts.transpileModule(`(${declaration})`, { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.None } });
+  // Execute the real handler with inert React setters/timer, not a copy of it.
+  const show = runInNewContext(outputText, {
+    feed, pending: filterCommunityPosts(feed.pending, "base", ""),
+    reconcileCommunityWindow, revealCommunityPosts, entryTimer: { current: null },
+    setFeed: (next: typeof update) => { update = next; },
+    setEntering: (ids: number[]) => { entering = Array.from(ids); },
+    setTimeout: (callback: () => void, delay: number) => { assert.equal(delay, 250); clearEntry = callback; return 1; },
+    clearTimeout: () => {},
+  }) as () => void;
+  show();
+  assert.ok(update);
+  const latest = [{ ...posts[1], id: 5 }, { ...authoritative[0], body: "Edited" }, ...authoritative.slice(1)];
+  const current = { source: latest, ...reconcileCommunityWindow(feed, latest, true) };
+  const revealed = typeof update === "function" ? update(current) : update;
+  assert.equal(revealed.source, latest, "the handler must not overwrite a newer server payload");
+  assert.deepEqual(revealed.pending.map((post) => post.id), [5, 4]);
+  assert.equal(revealed.pending[1].body, "Edited");
+  assert.deepEqual(revealed.visible.map((post) => post.id), [3, 1, 2]);
+  assert.deepEqual(entering, [3], "only posts represented by the clicked button animate");
+  assert.ok(clearEntry);
+  clearEntry();
+  assert.deepEqual(entering, []);
+});
+
 test("reader-at-top updates publish the current server rows without a queue", () => {
   const next = { ...posts[1], id: 3 };
   const result = reconcileCommunityWindow({ visible: posts, pending: [] }, [next, ...posts], false);

--- a/app/src/lib/launchpad/community-feed.test.ts
+++ b/app/src/lib/launchpad/community-feed.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { readFileSync } from "node:fs";
-import { communityFingerprint, filterCommunityPosts } from "./community-feed.ts";
+import { communityFingerprint, filterCommunityPosts, reconcileCommunityWindow } from "./community-feed.ts";
 
 const posts = [
   { id: 1, chain: "base", token: "0xAbC", wallet: "0xWallet", symbol: "SKY", name: "Clear Sky", body: "A real conversation", tag: "creator", created_at: "2026-09-07T00:00:00Z" },
@@ -20,6 +20,56 @@ test("community refresh compares the shared 30-post window while retaining full 
   assert.equal(communityFingerprint(rows), communityFingerprint(rows.slice(0, 30)));
   assert.notEqual(communityFingerprint(posts), communityFingerprint(posts.slice(1)));
   assert.notEqual(communityFingerprint(posts), communityFingerprint([{ ...posts[0], body: "Changed" }, posts[1]]));
+  assert.notEqual(communityFingerprint(posts), communityFingerprint([{ ...posts[0], name: "Renamed token" }, posts[1]]));
+});
+test("feed additions wait while reading, while authoritative edits and removals apply immediately", () => {
+  const added = { ...posts[0], id: 3, body: "A new post" };
+  const edited = { ...posts[0], body: "Edited by the server" };
+  const result = reconcileCommunityWindow({ visible: posts, pending: [] }, [added, edited], true);
+  assert.deepEqual(result.visible, [edited]);
+  assert.deepEqual(result.pending, [added]);
+  assert.equal(posts[0].body, "A real conversation", "previous rows are not mutated");
+});
+test("the queue reflects the latest server window, not stale additions", () => {
+  const first = { ...posts[0], id: 3, body: "Pending" };
+  const next = { ...posts[0], id: 4, body: "More recent" };
+  const queued = reconcileCommunityWindow({ visible: posts, pending: [] }, [first, ...posts], true);
+  const updated = reconcileCommunityWindow(queued, [next, { ...first, body: "Pending, edited" }, ...posts], true);
+  assert.deepEqual(updated.pending.map((post) => post.body), ["More recent", "Pending, edited"]);
+  const moderated = reconcileCommunityWindow(updated, [next, ...posts], true);
+  assert.deepEqual(moderated.pending, [next], "moderated queued posts disappear without being revealed");
+  const revealed = reconcileCommunityWindow(moderated, [next, ...posts], false);
+  assert.deepEqual(revealed, { visible: [next, ...posts], pending: [] });
+});
+test("buffered and visible rows together preserve the authoritative 100-row window", () => {
+  const initial = Array.from({ length: 100 }, (_, index) => ({ ...posts[0], id: 100 - index }));
+  const latest = [{ ...posts[0], id: 101 }, ...initial.slice(0, 99)];
+  const buffered = reconcileCommunityWindow({ visible: initial, pending: [] }, latest, true);
+  assert.equal(buffered.visible.length, 99);
+  assert.equal(buffered.pending.length, 1);
+  assert.equal(buffered.visible.at(-1)?.id, 2, "rows outside the server window are not kept indefinitely");
+  assert.ok(buffered.visible.some((post) => post.id === 25), "older rows outside the 30-row live signal stay loaded");
+  const repeated = reconcileCommunityWindow(buffered, latest, true);
+  assert.deepEqual(repeated, buffered, "identical polls do not accumulate duplicates");
+  assert.equal(reconcileCommunityWindow(repeated, [...latest, initial[99]], false).visible.length, 100);
+});
+test("hidden rows and duplicated IDs never enter either feed window", () => {
+  const hidden = { ...posts[0], id: 3, hidden: true };
+  const result = reconcileCommunityWindow({ visible: posts, pending: [] }, [hidden, posts[0], posts[0]], true);
+  assert.deepEqual(result, { visible: [posts[0]], pending: [] });
+  assert.deepEqual(reconcileCommunityWindow(result, [], true), { visible: [], pending: [] });
+});
+test("visible and queued counts use the same chain and search filters", () => {
+  const next = { ...posts[1], id: 3 };
+  const buffered = reconcileCommunityWindow({ visible: posts, pending: [] }, [next, ...posts], true);
+  assert.equal(filterCommunityPosts(buffered.pending, "base", "").length, 0);
+  assert.equal(filterCommunityPosts(buffered.pending, "robinhood", " moon ").length, 1);
+  assert.equal(filterCommunityPosts(buffered.visible, "robinhood", " moon ").length, 1);
+});
+test("reader-at-top updates publish the current server rows without a queue", () => {
+  const next = { ...posts[1], id: 3 };
+  const result = reconcileCommunityWindow({ visible: posts, pending: [] }, [next, ...posts], false);
+  assert.deepEqual(result, { visible: [next, ...posts], pending: [] });
 });
 test("community remains read-only with token-thread links and shared refresh signals", () => {
   const source = readFileSync(new URL("../../components/sections/CommunityFeed.tsx", import.meta.url), "utf8");
@@ -30,4 +80,20 @@ test("community remains read-only with token-thread links and shared refresh sig
   assert.match(source, /Search covers only the recent posts loaded here/);
   assert.match(source, /aria-label="Search recent posts"/);
   assert.doesNotMatch(source, /signMessage|writeContract|dangerouslySetInnerHTML|setInterval/);
+});
+test("new-post UI anchors server updates, preserves filters, and animates only explicit reveals", () => {
+  const source = readFileSync(new URL("../../components/sections/CommunityFeed.tsx", import.meta.url), "utf8");
+  const css = readFileSync(new URL("../../components/sections/CommunityFeed.module.css", import.meta.url), "utf8");
+  assert.match(source, /if \(!loadError && initial !== feed\.source\)/, "load errors are not authoritative removals");
+  assert.match(source, /readingDown \|\| feed\.pending\.length > 0/, "a queued batch waits for consent even if the reader scrolls up");
+  assert.match(source, /getSnapshotBeforeUpdate/);
+  assert.match(source, /!this\.props\.preservePosition/, "the page does not scroll on an automatic update while still at the top");
+  assert.match(source, /previous\.filterKey !== this\.props\.filterKey/, "manual filters do not trigger scroll restoration");
+  assert.match(source, /row\.getBoundingClientRect\(\)\.top - anchor\.top/);
+  assert.match(source, /behavior: "instant"/, "scroll correction must not animate");
+  assert.match(source, /setTimeout\(\(\) => setEntering\(\[\]\), 250\)/, "entry state expires even with reduced motion");
+  assert.match(css, /\.newPostsSlot[^}]*height: 0/, "the notification reserves no extra document height");
+  assert.match(css, /prefers-reduced-motion: reduce[\s\S]*\.postEntering \{ animation: none;/);
+  const subscription = source.slice(source.indexOf("subscribe((snap)"), source.indexOf("const shown ="));
+  assert.doesNotMatch(subscription, /reconcileCommunityWindow|setEntering/, "the short poll is only a refresh signal and cannot replay entry motion");
 });

--- a/app/src/lib/launchpad/community-feed.ts
+++ b/app/src/lib/launchpad/community-feed.ts
@@ -33,3 +33,14 @@ export function reconcileCommunityWindow<T extends { id: number; hidden?: boolea
     pending: current.filter((post) => !visibleIds.has(post.id)),
   };
 }
+
+/** Reveal selected pending IDs without consuming other views' notifications. */
+export function revealCommunityPosts<T extends { id: number; hidden?: boolean }>(
+  previous: CommunityWindow<T>, authoritative: T[], postIds: readonly number[],
+): CommunityWindow<T> {
+  const selected = new Set(postIds);
+  return reconcileCommunityWindow({
+    visible: [...previous.visible, ...previous.pending.filter((post) => selected.has(post.id))],
+    pending: previous.pending,
+  }, authoritative, true);
+}

--- a/app/src/lib/launchpad/community-feed.ts
+++ b/app/src/lib/launchpad/community-feed.ts
@@ -6,6 +6,30 @@ export function filterCommunityPosts<T extends FeedSearchRow>(posts: T[], chain:
 }
 
 /** Shared live snapshots contain 30 posts; compare that window without losing the server's full feed. */
-export function communityFingerprint(posts: { id: number; body: string; tag: string | null; created_at: string }[]): string {
-  return JSON.stringify(posts.slice(0, 30).map(({ id, body, tag, created_at }) => [id, body, tag, created_at]));
+export function communityFingerprint(posts: { id: number; body: string; tag: string | null; created_at: string; chain?: string; token?: string; wallet?: string; symbol?: string; name?: string; hidden?: boolean }[]): string {
+  return JSON.stringify(posts.slice(0, 30).map(({ id, body, tag, created_at, chain, token, wallet, symbol, name, hidden }) => [id, body, tag, created_at, chain, token, wallet, symbol, name, hidden]));
+}
+
+export type CommunityWindow<T> = { visible: T[]; pending: T[] };
+
+/**
+ * Only call with the authoritative /feed response, never the 30-row live signal.
+ * Delay additions, not moderation or edits. Both lists together remain within the
+ * current 100-row server window, including when pending posts are later removed.
+ */
+export function reconcileCommunityWindow<T extends { id: number; hidden?: boolean }>(
+  previous: CommunityWindow<T>, authoritative: T[], bufferAdditions: boolean,
+): CommunityWindow<T> {
+  const seen = new Set<number>();
+  const current = authoritative.slice(0, 100).filter((post) => {
+    if (post.hidden || seen.has(post.id)) return false;
+    seen.add(post.id);
+    return true;
+  });
+  if (!bufferAdditions) return { visible: current, pending: [] };
+  const visibleIds = new Set(previous.visible.map((post) => post.id));
+  return {
+    visible: current.filter((post) => visibleIds.has(post.id)),
+    pending: current.filter((post) => !visibleIds.has(post.id)),
+  };
 }

--- a/app/src/lib/launchpad/queries-burn.test.ts
+++ b/app/src/lib/launchpad/queries-burn.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import postgres from "postgres";
+
+const databaseUrl = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
+const source = readFileSync(new URL("./queries.ts", import.meta.url), "utf8");
+const dead = "0x000000000000000000000000000000000000dead";
+
+// Runs the actual predicate in PostgreSQL over in-memory input values. No
+// application tables, schema changes or stored fixtures are needed.
+test("burn SQL excludes malformed recipient JSON without losing valid burn pools", {
+  skip: !databaseUrl && "Set TEST_DATABASE_URL or DATABASE_URL for the read-only SQL regression",
+}, async () => {
+  const predicate = source.match(/if \(opts\.filter === "burn"\) conds\.push\(db`([^`]+)`\);/)?.[1];
+  assert.ok(predicate, "the launch query exposes its burn predicate");
+  const cases = [
+    { label: "burn", lp_fee: 10000, recipients: [{ payout: dead, bps: 10000 }] },
+    { label: "uppercase", lp_fee: 10000, recipients: [{ payout: dead.toUpperCase(), bps: 10000 }] },
+    { label: "free", lp_fee: 0, recipients: [{ payout: dead, bps: 10000 }] },
+    { label: "split", lp_fee: 10000, recipients: [{ payout: dead, bps: 5000 }, { payout: "0x123", bps: 5000 }] },
+    { label: "beneficiary", lp_fee: 10000, recipients: [{ payout: "0x123", bps: 10000 }] },
+    ...[null, {}, "[]", JSON.stringify([{ payout: dead, bps: 10000 }]), 1, true, []].map((recipients, i) => ({ label: `malformed-${i}`, lp_fee: 10000, recipients })),
+  ];
+  const sql = postgres(databaseUrl!, { max: 1, connect_timeout: 5, onnotice: () => {} });
+  try {
+    const rows = await sql.unsafe<{ label: string }[]>(
+      `SELECT l.label FROM jsonb_to_recordset($2::text::jsonb) AS l(label text, lp_fee integer, recipients jsonb) WHERE ${predicate.replace("${DEAD_ADDR}", "$1")} ORDER BY l.label`,
+      [dead, JSON.stringify(cases)],
+    );
+    assert.deepEqual(rows.map((row) => row.label), ["burn", "uppercase"]);
+  } finally {
+    await sql.end();
+  }
+});

--- a/app/src/lib/launchpad/queries.ts
+++ b/app/src/lib/launchpad/queries.ts
@@ -237,7 +237,7 @@ export async function listLaunchesPage(opts: ListOpts = {}): Promise<ListPage> {
   if (opts.chain) conds.push(db`l.chain_id = ${chainIdOf(opts.chain)}`);
   if (opts.launcher) conds.push(db`l.launcher = ${opts.launcher.toLowerCase()}`);
   if (opts.filter === "fee0") conds.push(db`l.lp_fee = 0`);
-  if (opts.filter === "burn") conds.push(db`l.lp_fee > 0 AND jsonb_array_length(l.recipients) = 1 AND lower(l.recipients->0->>'payout') = ${DEAD_ADDR}`);
+  if (opts.filter === "burn") conds.push(db`l.lp_fee > 0 AND jsonb_array_length(CASE WHEN jsonb_typeof(l.recipients) = 'array' THEN l.recipients ELSE '[]'::jsonb END) = 1 AND lower(l.recipients->0->>'payout') = ${DEAD_ADDR}`);
   if (opts.filter === "usdg") conds.push(db`l.quote = ${USDG_ADDR}`);
   // GITLAWB has a different address per chain; each match is chain-scoped so a same-address token elsewhere is never GITLAWB
   const isGitlawb = () => db`((l.chain_id = ${BASE_ID} AND l.quote = ${GITLAWB_ADDRESS}) OR (l.chain_id = ${RH_ID} AND l.quote = ${GITLAWB_ADDRESS_ROBINHOOD}))`;
@@ -300,6 +300,22 @@ export async function getLaunch(chain: ChainKey, token: string, ethUsd: number |
   await withStocks();
   const rows = await db<Raw[]>`${db.unsafe(SELECT)} WHERE l.chain_id = ${chainIdOf(chain)} AND l.token = ${token.toLowerCase()}`;
   return rows[0] ? shape(rows[0], ethUsd) : null;
+}
+
+/** A bounded watchlist lookup shares the market read model without one query per token. */
+export async function getLaunchesByRefs(refs: readonly { chain: ChainKey; token: string }[], ethUsd: number | null = null): Promise<{ launch: LaunchRow; holders: number | null }[]> {
+  if (refs.length > 50) throw new Error("too many launch references");
+  const db = maybeDb();
+  if (!db || refs.length === 0) return [];
+  await withStocks();
+  const matches = refs.map((ref) => db`(l.chain_id = ${chainIdOf(ref.chain)} AND l.token = ${ref.token.toLowerCase()})`);
+  const rows = await db<(Raw & { holders_synced_block: bigint | null })[]>`
+    ${db.unsafe(SELECT)} WHERE ${matches.reduce((a, b) => db`${a} OR ${b}`)}`;
+  return rows.map((r) => ({
+    launch: shape(r, ethUsd),
+    // Same completed-backfill sentinel as getHolderPanel. An unfinished index is not zero holders.
+    holders: r.holders_synced_block !== null && BigInt(r.holders_synced_block) > BigInt(r.block_number) + 1_000_000n ? Number(r.holders) : null,
+  }));
 }
 
 /** Find which chain a token lives on (for the legacy /t/<token> redirect). */

--- a/app/src/lib/launchpad/watchlist.test.ts
+++ b/app/src/lib/launchpad/watchlist.test.ts
@@ -1,0 +1,291 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createWatchlistStore, markWatchlistSeen, parseWatchlist, serializeWatchlist, toggleWatchlistEntry,
+  WATCHLIST_LIMIT, WATCHLIST_SERVER_SNAPSHOT, watchlistKey,
+  type WatchlistEntry, type WatchlistIdentity,
+} from "./watchlist.ts";
+
+const NOW = 1_800_000_000_000;
+const token = (n = 1, chain: "base" | "robinhood" = "base"): WatchlistIdentity => ({
+  chain, token: `0x${n.toString(16).padStart(40, "0")}`, name: `Token ${n}`, symbol: `T${n}`,
+});
+const entry = (n = 1): WatchlistEntry => ({ ...token(n), addedAt: NOW - 1_000, seenAt: null, holders: null });
+const payload = (entries: unknown[], version = 1) => JSON.stringify({ version, entries });
+
+test("normalizes identity and keeps the same address on different chains distinct", () => {
+  const base = { ...entry(10), token: token(10).token.toUpperCase(), name: " Token A ", symbol: " A " };
+  const robinhood = { ...base, chain: "robinhood" };
+  const result = parseWatchlist(payload([base, robinhood]), NOW);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].token, token(10).token);
+  assert.equal(result[0].name, "Token A");
+  assert.equal(result[0].symbol, "A");
+  assert.notEqual(watchlistKey(result[0]), watchlistKey(result[1]));
+});
+
+test("corrupt and unsupported payloads are empty rather than throwing", () => {
+  for (const raw of [null, "", "{", "null", "[]", payload([entry()], 2), JSON.stringify({ version: 1 }), "x".repeat(128_001)]) {
+    assert.deepEqual(parseWatchlist(raw, NOW), []);
+  }
+});
+
+test("rejects malformed identities, timestamps and holder counts independently", () => {
+  const bad = [
+    null, [], {}, { ...entry(), chain: "ethereum" }, { ...entry(), token: "0x1" },
+    { ...entry(), token: `0x${"z".repeat(40)}` }, { ...entry(), name: " " }, { ...entry(), symbol: 1 },
+    { ...entry(), addedAt: "123" }, { ...entry(), addedAt: -1 }, { ...entry(), addedAt: 1.5 },
+    { ...entry(), seenAt: NOW + 300_001 }, { ...entry(), holders: -1 }, { ...entry(), holders: 1.5 },
+    { ...entry(), holders: Number.MAX_SAFE_INTEGER + 1 },
+  ];
+  assert.deepEqual(parseWatchlist(payload([...bad, entry(2)]), NOW), [entry(2)]);
+});
+
+test("preserves timestamps within clock-skew tolerance and rejects far-future timestamps", () => {
+  const result = parseWatchlist(payload([
+    { ...entry(), addedAt: NOW + 1, seenAt: NOW + 300_000, holders: 0 },
+    { ...entry(2), addedAt: NOW + 300_001 },
+  ]), NOW);
+  assert.deepEqual(result, [{ ...entry(), addedAt: NOW + 1, seenAt: NOW + 300_000, holders: 0 }]);
+});
+
+test("a server clock one minute ahead keeps the reviewed cutoff through reload", () => {
+  const storage = memory();
+  const store = createWatchlistStore(storage, () => NOW);
+  const serverAt = NOW + 60_000;
+  store.toggle(token());
+  store.markSeen([{ ...token(), seenAt: serverAt, holders: 0 }]);
+  assert.equal(store.getSnapshot().entries[0].seenAt, serverAt);
+  const reloaded = createWatchlistStore(storage, () => NOW);
+  reloaded.refresh();
+  const cutoff = reloaded.getSnapshot().entries[0].seenAt!;
+  assert.equal(cutoff, serverAt);
+  // API counts strictly after the cutoff: none of this reviewed minute may reappear.
+  const reviewedTrades = [NOW + 1, NOW + 30_000, serverAt];
+  assert.deepEqual(reviewedTrades.filter((time) => time > cutoff), []);
+});
+
+test("deduplicates a token without rolling its baseline back", () => {
+  const fresh = { ...entry(), seenAt: NOW - 10, holders: 2 };
+  const old = { ...entry(), addedAt: NOW - 2_000, seenAt: NOW - 50, holders: 9 };
+  for (const entries of [[fresh, old], [old, fresh]]) {
+    assert.deepEqual(parseWatchlist(payload(entries), NOW), [{ ...fresh, addedAt: old.addedAt }]);
+  }
+});
+
+test("limits stored entries to 50, caps metadata and clears holders with no baseline", () => {
+  const entries = Array.from({ length: 55 }, (_, i) => entry(i));
+  const result = parseWatchlist(payload(entries), NOW);
+  assert.equal(result.length, WATCHLIST_LIMIT);
+  const [bounded] = parseWatchlist(payload([{ ...entry(), name: "a".repeat(200), symbol: "b".repeat(60), holders: 100 }]), NOW);
+  assert.equal(bounded.name.length, 128);
+  assert.equal(bounded.symbol.length, 32);
+  assert.equal(bounded.holders, null);
+  assert.deepEqual(parseWatchlist(serializeWatchlist(result), NOW), result);
+});
+
+test("toggle adds unreviewed entries, removes by normalized address, and never silently evicts at the cap", () => {
+  const added = toggleWatchlistEntry([], token(10), NOW);
+  assert.equal(added.result, "added");
+  assert.deepEqual(added.entries, [{ ...token(10), addedAt: NOW, seenAt: null, holders: null }]);
+  assert.deepEqual(toggleWatchlistEntry(added.entries, { ...token(10), token: token(10).token.toUpperCase() }, NOW), { entries: [], result: "removed" });
+  const full = Array.from({ length: 50 }, (_, i) => entry(i));
+  assert.deepEqual(toggleWatchlistEntry(full, token(100), NOW), { entries: full, result: "limit" });
+  assert.equal(toggleWatchlistEntry(full, token(1), NOW).result, "removed");
+  assert.equal(toggleWatchlistEntry([], { ...token(), token: "invalid" }, NOW).result, "invalid");
+});
+
+test("mark seen updates only supplied saved tokens and distinguishes null from zero", () => {
+  const entries = [entry(1), entry(2), entry(3)];
+  const next = markWatchlistSeen(entries, [
+    { ...token(1), seenAt: NOW, holders: 0 },
+    { ...token(2), seenAt: NOW, holders: null },
+    { ...token(99), seenAt: NOW, holders: 10 },
+  ], NOW);
+  assert.deepEqual(next, [{ ...entries[0], seenAt: NOW, holders: 0 }, { ...entries[1], seenAt: NOW, holders: null }, entries[2]]);
+  assert.equal(next[2], entries[2]);
+  assert.deepEqual(entries, [entry(1), entry(2), entry(3)]);
+});
+
+test("older or repeated responses cannot overwrite a reviewed baseline", () => {
+  const entries = [{ ...entry(), seenAt: NOW, holders: 12 }];
+  for (const seenAt of [NOW - 1, NOW, null, NOW + 300_001]) {
+    assert.equal(markWatchlistSeen(entries, [{ ...token(), seenAt, holders: 0 }], NOW), entries);
+  }
+});
+
+test("duplicate observations use the newest valid observation", () => {
+  const next = markWatchlistSeen([entry()], [
+    { ...token(), seenAt: NOW, holders: 0 }, { ...token(), seenAt: NOW - 1, holders: 1 },
+    { ...token(), seenAt: NOW + 300_001, holders: 2 },
+  ], NOW);
+  assert.deepEqual(next, [{ ...entry(), seenAt: NOW, holders: 0 }]);
+});
+
+function memory() {
+  let raw: string | null = null;
+  return { read: () => raw, write: (value: string) => { raw = value; } };
+}
+
+test("store is SSR-safe and snapshots stay referentially stable until a real update", () => {
+  let reads = 0;
+  const store = createWatchlistStore({ read: () => { reads++; return null; }, write: () => {} }, () => NOW);
+  assert.equal(store.getSnapshot(), WATCHLIST_SERVER_SNAPSHOT);
+  assert.equal(reads, 0);
+  let notifications = 0;
+  const unsubscribe = store.subscribe(() => { notifications++; });
+  store.refresh();
+  const hydrated = store.getSnapshot();
+  assert.deepEqual(hydrated, { entries: [], savedKeys: [], ready: true, storageError: false });
+  store.refresh();
+  assert.equal(store.getSnapshot(), hydrated);
+  assert.equal(notifications, 1);
+  unsubscribe();
+  store.toggle(token());
+  assert.equal(notifications, 1);
+});
+
+test("same-store subscribers observe changes and reload restores the saved list", () => {
+  const storage = memory();
+  const store = createWatchlistStore(storage, () => NOW);
+  let first = 0, second = 0;
+  store.subscribe(() => { first++; });
+  store.subscribe(() => { second++; });
+  store.toggle(token());
+  store.markSeen([{ ...token(), seenAt: NOW, holders: 0 }]);
+  assert.ok(first > 0);
+  assert.equal(first, second);
+  const reloaded = createWatchlistStore(storage, () => NOW);
+  reloaded.refresh();
+  assert.deepEqual(reloaded.getSnapshot(), store.getSnapshot());
+});
+
+test("stale tabs read latest storage before mutating and refresh handles removals", () => {
+  const storage = memory();
+  const a = createWatchlistStore(storage, () => NOW);
+  const b = createWatchlistStore(storage, () => NOW);
+  a.refresh(); b.refresh();
+  a.toggle(token(1));
+  b.toggle(token(2));
+  assert.equal(b.getSnapshot().entries.length, 2);
+  a.refresh();
+  assert.deepEqual(a.getSnapshot(), b.getSnapshot());
+  b.toggle(token(1));
+  a.refresh();
+  assert.deepEqual(a.getSnapshot().entries.map(watchlistKey), [watchlistKey(token(2))]);
+});
+
+test("storage read and write failures leave an ephemeral usable list", () => {
+  const store = createWatchlistStore({ read: () => { throw new Error("denied"); }, write: () => { throw new Error("denied"); } }, () => NOW);
+  store.refresh();
+  assert.deepEqual(store.getSnapshot(), { entries: [], savedKeys: [], ready: true, storageError: true });
+  store.toggle(token());
+  store.markSeen([{ ...token(), seenAt: NOW, holders: 0 }]);
+  assert.equal(store.getSnapshot().entries[0].holders, 0);
+  store.refresh();
+  assert.equal(store.getSnapshot().entries.length, 1);
+  store.toggle(token());
+  assert.equal(store.getSnapshot().entries.length, 0);
+});
+
+test("quota failures preserve pending additions and removals across refresh and recover on next write", () => {
+  const disk = memory();
+  disk.write(serializeWatchlist([entry(1)]));
+  let blocked = true;
+  const store = createWatchlistStore({ read: disk.read, write: (raw) => { if (blocked) throw new Error("quota"); disk.write(raw); } }, () => NOW);
+  store.toggle(token(1)); // Local removal must not reappear from the old disk snapshot.
+  store.toggle(token(2));
+  store.refresh();
+  assert.deepEqual(store.getSnapshot().entries.map(watchlistKey), [watchlistKey(token(2))]);
+  disk.write(serializeWatchlist([entry(1), entry(3)])); // Another tab's unrelated addition survives.
+  store.refresh();
+  assert.deepEqual(new Set(store.getSnapshot().entries.map(watchlistKey)), new Set([watchlistKey(token(2)), watchlistKey(token(3))]));
+  assert.equal(store.getSnapshot().storageError, true);
+  blocked = false;
+  store.markSeen([{ ...token(2), seenAt: NOW, holders: 0 }]);
+  assert.equal(store.getSnapshot().storageError, false);
+  assert.deepEqual(parseWatchlist(disk.read(), NOW), store.getSnapshot().entries);
+});
+
+test("a stale tab cannot restore a removed token by marking it reviewed", () => {
+  const storage = memory();
+  const a = createWatchlistStore(storage, () => NOW);
+  const b = createWatchlistStore(storage, () => NOW);
+  a.toggle(token()); b.refresh(); a.toggle(token());
+  b.markSeen([{ ...token(), seenAt: NOW, holders: 10 }]);
+  assert.deepEqual(b.getSnapshot().entries, []);
+});
+
+test("quota conflicts at capacity keep the local addition and never persist a clipped remote list", () => {
+  const disk = memory();
+  const original = Array.from({ length: 49 }, (_, i) => entry(i));
+  disk.write(serializeWatchlist(original));
+  let blocked = true;
+  let writes = 0;
+  const store = createWatchlistStore({ read: disk.read, write: (raw) => {
+    writes++;
+    if (blocked) throw new Error("quota");
+    disk.write(raw);
+  } }, () => NOW);
+  store.toggle(token(49)); // Local 50th addition is pending.
+  const remote = serializeWatchlist([...original, entry(50)]);
+  disk.write(remote); // A different tab successfully adds a different 50th token.
+  store.refresh();
+  assert.equal(store.getSnapshot().entries.length, 50);
+  assert.ok(store.getSnapshot().entries.some((item) => watchlistKey(item) === watchlistKey(token(49))));
+
+  blocked = false;
+  const writesBeforeReview = writes;
+  store.markSeen([{ ...token(49), seenAt: NOW, holders: 0 }]);
+  assert.equal(writes, writesBeforeReview, "review must not write while merged preferences exceed capacity");
+  assert.equal(disk.read(), remote, "remote preferences remain untouched");
+  assert.equal(store.getSnapshot().storageError, true);
+  store.refresh();
+  assert.ok(store.getSnapshot().entries.some((item) => watchlistKey(item) === watchlistKey(token(49))));
+
+  store.toggle(token(1)); // An explicit removal makes room for both pending and remote additions.
+  const persisted = parseWatchlist(disk.read(), NOW);
+  assert.equal(persisted.length, 50);
+  assert.ok(persisted.some((item) => item.token === token(49).token));
+  assert.ok(persisted.some((item) => item.token === token(50).token));
+  assert.ok(!persisted.some((item) => item.token === token(1).token));
+  assert.equal(store.getSnapshot().storageError, false);
+});
+
+test("membership remains accurate for a persisted token hidden by the conflict display cap", () => {
+  const disk = memory();
+  const original = Array.from({ length: 49 }, (_, i) => entry(i));
+  disk.write(serializeWatchlist(original));
+  let blocked = true;
+  const store = createWatchlistStore({ read: disk.read, write: (raw) => {
+    if (blocked) throw new Error("quota");
+    disk.write(raw);
+  } }, () => NOW);
+  store.toggle(token(49));
+  disk.write(serializeWatchlist([...original, entry(50)]));
+  store.refresh();
+  const snapshot = store.getSnapshot();
+  assert.equal(snapshot.entries.length, 50);
+  assert.ok(!snapshot.entries.some((item) => item.token === token(50).token));
+  assert.ok(snapshot.savedKeys.includes(watchlistKey(token(50))), "the star must still present the Remove action");
+  assert.equal(snapshot.savedKeys.length, 51);
+  store.refresh();
+  assert.equal(store.getSnapshot(), snapshot, "unchanged membership keeps a stable external-store snapshot");
+
+  let notifications = 0;
+  store.subscribe(() => { notifications++; });
+  disk.write(serializeWatchlist([...original, entry(51)]));
+  store.refresh();
+  assert.deepEqual(store.getSnapshot().entries, snapshot.entries, "the capped display rows have not changed");
+  assert.ok(!store.getSnapshot().savedKeys.includes(watchlistKey(token(50))));
+  assert.ok(store.getSnapshot().savedKeys.includes(watchlistKey(token(51))));
+  assert.equal(notifications, 1, "membership-only changes must notify stars outside the watchlist panel");
+  disk.write(serializeWatchlist([...original, entry(50)]));
+  store.refresh();
+
+  blocked = false;
+  assert.equal(store.toggle(token(50)), "removed");
+  assert.ok(!store.getSnapshot().savedKeys.includes(watchlistKey(token(50))));
+  assert.ok(store.getSnapshot().savedKeys.includes(watchlistKey(token(49))));
+  assert.ok(!parseWatchlist(disk.read(), NOW).some((item) => item.token === token(50).token));
+});

--- a/app/src/lib/launchpad/watchlist.ts
+++ b/app/src/lib/launchpad/watchlist.ts
@@ -1,0 +1,187 @@
+/** Browser-local preferences only. No wallet, trading, or server-side identity. */
+export const WATCHLIST_STORAGE_KEY = "openlaunch:watchlist:v1";
+export const WATCHLIST_LIMIT = 50;
+const CLOCK_SKEW_MS = 5 * 60 * 1_000;
+
+export type WatchlistIdentity = { chain: "base" | "robinhood"; token: string; name: string; symbol: string };
+export type WatchlistEntry = WatchlistIdentity & { addedAt: number; seenAt: number | null; holders: number | null };
+export type WatchlistSeen = Pick<WatchlistEntry, "chain" | "token" | "seenAt" | "holders">;
+export type WatchlistSnapshot = { entries: WatchlistEntry[]; savedKeys: string[]; ready: boolean; storageError: boolean };
+export type WatchlistToggleResult = "added" | "removed" | "limit" | "invalid";
+
+export const WATCHLIST_SERVER_SNAPSHOT: WatchlistSnapshot = { entries: [], savedKeys: [], ready: false, storageError: false };
+
+export function watchlistKey(identity: { chain: string; token: string }): string {
+  return `${identity.chain}:${identity.token.toLowerCase()}`;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function identity(value: unknown): WatchlistIdentity | null {
+  if (!record(value) || (value.chain !== "base" && value.chain !== "robinhood") ||
+    typeof value.token !== "string" || !/^0x[\da-f]{40}$/i.test(value.token) ||
+    typeof value.name !== "string" || !value.name.trim() ||
+    typeof value.symbol !== "string" || !value.symbol.trim()) return null;
+  return { chain: value.chain, token: value.token.toLowerCase(), name: value.name.trim().slice(0, 128), symbol: value.symbol.trim().slice(0, 32) };
+}
+
+function validTime(value: unknown, now: number): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && value <= now + CLOCK_SKEW_MS;
+}
+
+function validHolders(value: unknown): value is number | null {
+  return value === null || (typeof value === "number" && Number.isSafeInteger(value) && value >= 0);
+}
+
+/** Reject malformed entries; tolerate small clock differences without rewriting server checkpoints. */
+export function parseWatchlist(raw: string | null, now = Date.now()): WatchlistEntry[] {
+  if (!raw || raw.length > 128_000) return [];
+  try {
+    const payload: unknown = JSON.parse(raw);
+    if (!record(payload) || payload.version !== 1 || !Array.isArray(payload.entries)) return [];
+    const entries = new Map<string, WatchlistEntry>();
+    for (const value of payload.entries) {
+      const token = identity(value);
+      if (!token || !record(value) || !validTime(value.addedAt, now) ||
+        (value.seenAt !== null && !validTime(value.seenAt, now)) || !validHolders(value.holders)) continue;
+      const entry: WatchlistEntry = {
+        ...token, addedAt: value.addedAt,
+        seenAt: value.seenAt as number | null,
+        holders: value.seenAt === null ? null : value.holders,
+      };
+      const key = watchlistKey(entry);
+      const existing = entries.get(key);
+      if (existing) {
+        // A duplicate must never roll a reviewed snapshot backward.
+        const latest = (entry.seenAt ?? -1) > (existing.seenAt ?? -1) ? entry : existing;
+        entries.set(key, { ...latest, addedAt: Math.min(entry.addedAt, existing.addedAt) });
+      } else if (entries.size < WATCHLIST_LIMIT) entries.set(key, entry);
+    }
+    return [...entries.values()];
+  } catch {
+    return [];
+  }
+}
+
+export function serializeWatchlist(entries: readonly WatchlistEntry[]): string {
+  return JSON.stringify({ version: 1, entries });
+}
+
+export function toggleWatchlistEntry(entries: WatchlistEntry[], value: WatchlistIdentity, now = Date.now()): { entries: WatchlistEntry[]; result: WatchlistToggleResult } {
+  const token = identity(value);
+  if (!token) return { entries, result: "invalid" };
+  const key = watchlistKey(token);
+  if (entries.some((entry) => watchlistKey(entry) === key)) {
+    return { entries: entries.filter((entry) => watchlistKey(entry) !== key), result: "removed" };
+  }
+  if (entries.length >= WATCHLIST_LIMIT) return { entries, result: "limit" };
+  return { entries: [{ ...token, addedAt: now, seenAt: null, holders: null }, ...entries], result: "added" };
+}
+
+/** Only explicit, successful observations advance a baseline. Null holders mean unavailable, not zero. */
+export function markWatchlistSeen(entries: WatchlistEntry[], observations: readonly WatchlistSeen[], now = Date.now()): WatchlistEntry[] {
+  const updates = new Map<string, WatchlistSeen>();
+  for (const observation of observations) {
+    if (!record(observation) || (observation.chain !== "base" && observation.chain !== "robinhood") ||
+      typeof observation.token !== "string" || !/^0x[\da-f]{40}$/i.test(observation.token) ||
+      !validTime(observation.seenAt, now) || !validHolders(observation.holders)) continue;
+    const key = watchlistKey(observation);
+    const previous = updates.get(key);
+    if (!previous || observation.seenAt > (previous.seenAt ?? -1)) {
+      updates.set(key, observation);
+    }
+  }
+  let changed = false;
+  const next = entries.map((entry) => {
+    const update = updates.get(watchlistKey(entry));
+    if (!update || (update.seenAt ?? -1) <= (entry.seenAt ?? -1)) return entry;
+    changed = true;
+    return { ...entry, seenAt: update.seenAt, holders: update.holders };
+  });
+  return changed ? next : entries;
+}
+
+/** Injectable storage keeps quota failures and stale-tab merges testable without a browser. */
+export function createWatchlistStore(storage: { read: () => string | null; write: (value: string) => void }, now = Date.now) {
+  let snapshot = WATCHLIST_SERVER_SNAPSHOT;
+  // Keep a full conflict set internally even when the UI is capped at 50. Otherwise a later
+  // review could persist the clipped list and silently delete another tab's saved token.
+  let workingEntries: WatchlistEntry[] = [];
+  const listeners = new Set<() => void>();
+  // Retain explicit local edits after a failed write while still accepting other tabs' unrelated edits.
+  const pending = new Map<string, WatchlistEntry | null>();
+
+  function publish(entries: WatchlistEntry[], storageError: boolean) {
+    workingEntries = entries;
+    // Membership is not a display concern: a remote token hidden by the conflict cap must
+    // still render as watched everywhere, and its action must remain "Remove", not "Save".
+    const savedKeys = entries.map(watchlistKey);
+    const visible = entries.length > WATCHLIST_LIMIT
+      ? [...entries].sort((a, b) => Number(pending.has(watchlistKey(b))) - Number(pending.has(watchlistKey(a)))).slice(0, WATCHLIST_LIMIT)
+      : entries;
+    if (snapshot.ready && snapshot.storageError === storageError && serializeWatchlist(snapshot.entries) === serializeWatchlist(visible) && JSON.stringify(snapshot.savedKeys) === JSON.stringify(savedKeys)) return;
+    snapshot = { entries: visible, savedKeys, ready: true, storageError };
+    for (const listener of listeners) listener();
+  }
+
+  function refresh() {
+    try {
+      const latest = parseWatchlist(storage.read(), now());
+      const merged = new Map(latest.map((entry) => [watchlistKey(entry), entry]));
+      for (const [key, local] of pending) {
+        const remote = merged.get(key);
+        if (local === null) merged.delete(key);
+        else if (!remote || (local.seenAt ?? -1) >= (remote.seenAt ?? -1)) merged.set(key, local);
+      }
+      publish([...merged.values()], pending.size > 0);
+    } catch {
+      publish(workingEntries, true);
+    }
+  }
+
+  function save(entries: WatchlistEntry[]) {
+    if (entries.length > WATCHLIST_LIMIT) {
+      // A failed local save plus another tab's addition can exceed the limit. Preserve both
+      // intents in memory and leave disk untouched until an explicit removal resolves it.
+      publish(entries, true);
+      return;
+    }
+    try {
+      storage.write(serializeWatchlist(entries));
+      pending.clear();
+      publish(entries, false);
+    } catch {
+      publish(entries, true);
+    }
+  }
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+    refresh,
+    toggle(value: WatchlistIdentity): WatchlistToggleResult {
+      refresh(); // Read latest immediately before applying a local intent; localStorage has no atomic CAS.
+      const next = toggleWatchlistEntry(workingEntries, value, now());
+      if (next.result === "added" || next.result === "removed") {
+        const key = watchlistKey(value);
+        pending.set(key, next.entries.find((entry) => watchlistKey(entry) === key) ?? null);
+        save(next.entries);
+      }
+      return next.result;
+    },
+    markSeen(observations: readonly WatchlistSeen[]) {
+      refresh();
+      const next = markWatchlistSeen(workingEntries, observations, now());
+      if (next === workingEntries) return;
+      for (let i = 0; i < next.length; i++) {
+        if (next[i] !== workingEntries[i]) pending.set(watchlistKey(next[i]), next[i]);
+      }
+      save(next);
+    },
+  };
+}

--- a/app/src/lib/launchpad/watchlistData.test.ts
+++ b/app/src/lib/launchpad/watchlistData.test.ts
@@ -1,0 +1,240 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import type { WatchlistData, WatchlistRequestItem } from "./watchlistData";
+
+const source = readFileSync(new URL("./watchlistData.ts", import.meta.url), "utf8");
+const route = readFileSync(new URL("../../app/api/launch/watchlist/route.ts", import.meta.url), "utf8");
+const queries = readFileSync(new URL("./queries.ts", import.meta.url), "utf8");
+const NOW = 1_800_000_000_000;
+const TOKEN = `0x${"ab".repeat(20)}`;
+const OTHER = `0x${"cd".repeat(20)}`;
+
+function compile(source: string, imports: Record<string, unknown>, date = Date) {
+  const output = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 } }).outputText;
+  const exported: Record<string, unknown> = {};
+  new Function("require", "exports", "Date", output)((id: string) => {
+    assert.ok(Object.hasOwn(imports, id), `unexpected import: ${id}`);
+    return imports[id];
+  }, exported, date);
+  return exported;
+}
+
+function isolatedData(configured = true) {
+  const calls = { launch: [] as unknown[][], sql: [] as { sql: string; values: unknown[] }[] };
+  const launches = [
+    { launch: { chain: "base", token: TOKEN, name: "Base token" }, holders: 0 },
+    { launch: { chain: "robinhood", token: TOKEN, name: "Robinhood token" }, holders: null },
+  ];
+  const counts = [
+    { chain_id: 8453, token: TOKEN, trades: "0", creator_posts: "2" },
+    { chain_id: 4663, token: TOKEN, trades: "8", creator_posts: "0" },
+  ];
+  const db = Object.assign(async (parts: TemplateStringsArray, ...values: unknown[]) => {
+    calls.sql.push({ sql: parts.join("?"), values });
+    return counts;
+  }, { json: (value: unknown) => value });
+  const imported = compile(source, {
+    "server-only": {},
+    "@/lib/db": { maybeDb: () => configured ? db : null },
+    "@/lib/chainPublic": { chainIdOf: (chain: string) => chain === "base" ? 8453 : 4663, isChainKey: (chain: unknown) => chain === "base" || chain === "robinhood" },
+    "./queries": { getLaunchesByRefs: async (...args: unknown[]) => { calls.launch.push(args); return launches; } },
+  });
+  const api = imported as unknown as {
+    WATCHLIST_BODY_MAX_BYTES: number;
+    WATCHLIST_WINDOW_MS: number;
+    WatchlistInputError: new (message: string, status?: number) => Error & { status: number };
+    parseWatchlistRequest: (value: unknown, at: number) => WatchlistRequestItem[];
+    readWatchlistBody: (req: Request) => Promise<unknown>;
+    getWatchlistData: (items: WatchlistRequestItem[], at: number, usd: number | null) => Promise<WatchlistData>;
+  };
+  return { ...api, calls, launches, counts };
+}
+
+test("watchlist input normalizes addresses, deduplicates within a chain, and preserves cross-chain identity", () => {
+  const { parseWatchlistRequest } = isolatedData();
+  assert.deepEqual(parseWatchlistRequest({ items: [
+    { chain: "base", token: TOKEN.toUpperCase(), since: NOW - 1 },
+    { chain: "base", token: TOKEN, since: NOW - 50 },
+    { chain: "robinhood", token: TOKEN },
+  ] }, NOW), [
+    { chain: "base", token: TOKEN, since: NOW - 1 },
+    { chain: "robinhood", token: TOKEN, since: null },
+  ]);
+});
+
+test("watchlist rejects malformed, oversized, and future-dated input before reads", async () => {
+  const { parseWatchlistRequest, getWatchlistData, calls } = isolatedData();
+  for (const body of [null, [], {}, { items: "no" }, { items: [null] }, { items: [{ chain: "ethereum", token: TOKEN }] }, { items: [{ chain: "base", token: "0x123" }] }]) {
+    assert.throws(() => parseWatchlistRequest(body, NOW));
+  }
+  for (const since of [NaN, Infinity, -Infinity, -1, 3.1, "1800000000", NOW + 300_001, Number.MAX_SAFE_INTEGER + 1]) {
+    assert.throws(() => parseWatchlistRequest({ items: [{ chain: "base", token: TOKEN, since }] }, NOW));
+  }
+  const ref = { chain: "base" as const, token: TOKEN, since: null };
+  assert.equal(parseWatchlistRequest({ items: Array(50).fill(ref) }, NOW).length, 1);
+  assert.throws(() => parseWatchlistRequest({ items: Array(51).fill(ref) }, NOW));
+  await assert.rejects(getWatchlistData([{ ...ref, since: NOW + 300_001 }], NOW, null));
+  assert.deepEqual(calls, { launch: [], sql: [] });
+});
+
+test("small device clock skew clamps to the server cutoff without creating a future window", async () => {
+  const { parseWatchlistRequest, getWatchlistData, calls } = isolatedData();
+  for (const since of [NOW + 1, NOW + 300_000]) {
+    assert.deepEqual(parseWatchlistRequest({ items: [{ chain: "base", token: TOKEN, since }] }, NOW), [{ chain: "base", token: TOKEN, since: NOW }]);
+  }
+  const data = await getWatchlistData([{ chain: "base", token: TOKEN, since: NOW + 300_000 }], NOW, null);
+  assert.equal(data.items[0].since, NOW);
+  assert.equal(data.items[0].windowClamped, false);
+  assert.deepEqual(calls.sql[0].values, [[{ chain_id: 8453, token: TOKEN, since: new Date(NOW).toISOString() }], NOW / 1_000, NOW / 1_000]);
+});
+
+test("watchlist body reads enforce byte limits without trusting Content-Length", async () => {
+  const { readWatchlistBody, WATCHLIST_BODY_MAX_BYTES } = isolatedData();
+  const request = (body: string, extra: Record<string, string> = {}) => new Request("https://example.test", { method: "POST", headers: { "content-type": "application/json", ...extra }, body });
+  assert.deepEqual(await readWatchlistBody(request('{"items":[]}')), { items: [] });
+  await assert.rejects(readWatchlistBody(request("{}", { "content-length": String(WATCHLIST_BODY_MAX_BYTES + 1) })), { status: 413 });
+  await assert.rejects(readWatchlistBody(request(JSON.stringify({ text: "界".repeat(6_000) }), { "content-length": "1" })), { status: 413 });
+  await assert.rejects(readWatchlistBody(request("not-json")), { status: 400 });
+  await assert.rejects(readWatchlistBody(request("{}", { "content-type": "text/plain" })), { status: 415 });
+  const bytes = new TextEncoder().encode('{"items":[]}');
+  const streamed = new Request("https://example.test", { method: "POST", headers: { "content-type": "application/json" }, duplex: "half", body: new ReadableStream({ start(controller) { controller.enqueue(bytes.slice(0, 5)); controller.enqueue(bytes.slice(5)); controller.close(); } }) } as RequestInit);
+  assert.deepEqual(await readWatchlistBody(streamed), { items: [] });
+});
+
+test("unconfigured indexes and unknown launches never masquerade as zero activity", async () => {
+  const ref = { chain: "base" as const, token: TOKEN, since: NOW - 1_000 };
+  const unavailable = isolatedData(false);
+  const response = await unavailable.getWatchlistData([ref], NOW, null);
+  assert.equal(response.indexed, false);
+  assert.deepEqual(response.items[0], { ...ref, windowClamped: false, launch: null, holders: null, trades: null, creatorPosts: null });
+  assert.deepEqual(unavailable.calls, { launch: [], sql: [] });
+  const { getWatchlistData } = isolatedData();
+  const missing = await getWatchlistData([{ ...ref, token: OTHER }], NOW, null);
+  assert.equal(missing.items[0].launch, null);
+  assert.equal(missing.items[0].holders, null);
+  assert.equal(missing.items[0].trades, null);
+  assert.equal(missing.items[0].creatorPosts, null);
+});
+
+test("batch snapshots retain request order, exact zero counts, first-visit nulls, and one cutoff", async () => {
+  const { getWatchlistData, calls } = isolatedData();
+  const items: WatchlistRequestItem[] = [
+    { chain: "robinhood", token: TOKEN, since: NOW - 500 },
+    { chain: "base", token: TOKEN, since: NOW - 1_000 },
+    { chain: "base", token: OTHER, since: null },
+  ];
+  const response = await getWatchlistData(items, NOW, 3_000);
+  assert.equal(response.at, NOW);
+  assert.equal(response.indexed, true);
+  assert.deepEqual(response.items.map(({ chain, token, trades, creatorPosts, holders }) => ({ chain, token, trades, creatorPosts, holders })), [
+    { chain: "robinhood", token: TOKEN, trades: 8, creatorPosts: 0, holders: null },
+    { chain: "base", token: TOKEN, trades: 0, creatorPosts: 2, holders: 0 },
+    { chain: "base", token: OTHER, trades: null, creatorPosts: null, holders: null },
+  ]);
+  assert.deepEqual(calls.launch, [[items, 3_000]]);
+  assert.equal(calls.sql.length, 1);
+  assert.deepEqual(calls.sql[0].values, [[
+    { chain_id: 4663, token: TOKEN, since: new Date(NOW - 500).toISOString() },
+    { chain_id: 8453, token: TOKEN, since: new Date(NOW - 1_000).toISOString() },
+  ], NOW / 1_000, NOW / 1_000]);
+  assert.match(calls.sql[0].sql, /s\.chain_id = w\.chain_id AND s\.token = w\.token/);
+  assert.match(calls.sql[0].sql, /s\.block_time > w\.since AND s\.block_time <= to_timestamp\(\?\)/);
+  assert.match(calls.sql[0].sql, /p\.chain_id = w\.chain_id AND p\.token = w\.token AND p\.wallet = l\.launcher/);
+  assert.match(calls.sql[0].sql, /NOT p\.hidden AND p\.parent_id IS NULL/);
+  assert.match(calls.sql[0].sql, /p\.created_at > w\.since AND p\.created_at <= to_timestamp\(\?\)/);
+  assert.doesNotMatch(calls.sql[0].sql, /\b(?:INSERT|UPDATE|DELETE)\b/);
+});
+
+test("old catchup windows are explicitly clamped to 30 days and first visits skip activity scans", async () => {
+  const { getWatchlistData, calls, WATCHLIST_WINDOW_MS } = isolatedData();
+  const old = await getWatchlistData([{ chain: "base", token: TOKEN, since: 0 }], NOW, null);
+  assert.equal(old.items[0].windowClamped, true);
+  assert.equal(old.items[0].since, NOW - WATCHLIST_WINDOW_MS);
+  const fresh = await getWatchlistData([{ chain: "base", token: TOKEN, since: null }], NOW, null);
+  assert.equal(fresh.items[0].launch?.token, TOKEN);
+  assert.equal(fresh.items[0].holders, 0);
+  assert.equal(fresh.items[0].trades, null);
+  assert.equal(fresh.items[0].creatorPosts, null);
+  assert.equal(calls.sql.length, 1);
+  assert.deepEqual(await getWatchlistData([], NOW, null), { at: NOW, indexed: true, items: [] });
+  assert.equal(calls.launch.length, 2);
+});
+
+function isolatedRoute(opts: { configured?: boolean; limited?: boolean; fail?: boolean } = {}) {
+  const data = isolatedData();
+  let reads = 0;
+  class SnapshotDate extends Date { static now() { return NOW; } }
+  const exported = compile(route, {
+    "next/server": { NextResponse: { json: (body: unknown, init: ResponseInit) => Response.json(body, init) } },
+    "@/lib/db": { dbConfigured: () => opts.configured !== false },
+    "@/lib/launchpad/editServer": { rateLimited: () => Boolean(opts.limited) },
+    "@/lib/launchpad/ethPrice": { ethUsd: async () => { reads++; return null; } },
+    "@/lib/launchpad/watchlistData": {
+      ...data,
+      getWatchlistData: async (...args: Parameters<typeof data.getWatchlistData>) => {
+        if (opts.fail) throw new Error("private backend diagnostic");
+        return data.getWatchlistData(...args);
+      },
+    },
+  }, SnapshotDate) as unknown as { POST: (req: Request) => Promise<Response> };
+  const request = (items: unknown) => new Request("https://example.test/api/launch/watchlist", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ items }) });
+  return { post: exported.POST, request, reads: () => reads };
+}
+
+test("watchlist route is uncached, uses server milliseconds, and avoids reads for bad input", async () => {
+  const { post, request, reads } = isolatedRoute();
+  const response = await post(request([{ chain: "base", token: TOKEN, since: NOW - 100 }]));
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal((await response.json()).at, NOW);
+  const invalid = await post(request([{ chain: "base", token: TOKEN, since: NOW + 300_001 }]));
+  assert.equal(invalid.status, 400);
+  assert.equal(reads(), 1);
+});
+
+test("watchlist route has explicit retryable outages and rate limits without leaking errors", async () => {
+  for (const opts of [{ configured: false }, { fail: true }]) {
+    const { post, request } = isolatedRoute(opts);
+    const response = await post(request([{ chain: "base", token: TOKEN, since: null }]));
+    assert.equal(response.status, 503);
+    const body = await response.json();
+    assert.equal(body.indexed, false);
+    assert.doesNotMatch(body.error, /private backend diagnostic/);
+    assert.equal(response.headers.get("cache-control"), "no-store");
+  }
+  const { post, request, reads } = isolatedRoute({ limited: true });
+  const response = await post(request([]));
+  assert.equal(response.status, 429);
+  assert.equal(response.headers.get("retry-after"), "60");
+  assert.equal(reads(), 0);
+});
+
+test("launch lookup reuses shaping in one bounded query and gates holder counts on complete backfill", async () => {
+  const helper = queries.slice(queries.indexOf("export async function getLaunchesByRefs("), queries.indexOf("/** Find which chain"));
+  const calls: { parts: string; values: unknown[] }[] = [];
+  let warmed = 0;
+  const raw = [
+    { chain_id: 8453, token: TOKEN, block_number: 10n, holders_synced_block: null, holders: 6 },
+    { chain_id: 4663, token: TOKEN, block_number: 10n, holders_synced_block: 1_000_010n, holders: 5 },
+    { chain_id: 8453, token: OTHER, block_number: 10n, holders_synced_block: 1_000_011n, holders: 0 },
+  ];
+  const db = Object.assign((parts: TemplateStringsArray, ...values: unknown[]) => {
+    calls.push({ parts: parts.join("?"), values });
+    return parts.join("").includes("WHERE") ? Promise.resolve(raw) : { parts, values };
+  }, { unsafe: (value: string) => value });
+  const output = ts.transpileModule(helper, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 } }).outputText;
+  const exported = {} as { getLaunchesByRefs: (refs: { chain: string; token: string }[], usd?: number | null) => Promise<{ holders: number | null; launch: unknown }[]> };
+  new Function("exports", "maybeDb", "withStocks", "chainIdOf", "shape", "SELECT", output)(exported, () => db, async () => { warmed++; }, (chain: string) => chain === "base" ? 8453 : 4663, (row: unknown) => row, "SELECT l.* FROM bb_launches l");
+  const ref = { chain: "base", token: TOKEN.toUpperCase() };
+  assert.deepEqual(await exported.getLaunchesByRefs([]), []);
+  await assert.rejects(exported.getLaunchesByRefs(Array(51).fill(ref)));
+  assert.equal(warmed, 0);
+  const result = await exported.getLaunchesByRefs([ref, { chain: "robinhood", token: TOKEN }]);
+  assert.equal(warmed, 1);
+  assert.deepEqual(result.map((item) => item.holders), [null, null, 0]);
+  assert.equal(calls.filter((call) => call.parts.includes("WHERE")).length, 1);
+  assert.deepEqual(calls[0].values, [8453, TOKEN]);
+  assert.deepEqual(calls[1].values, [4663, TOKEN]);
+});

--- a/app/src/lib/launchpad/watchlistData.ts
+++ b/app/src/lib/launchpad/watchlistData.ts
@@ -1,0 +1,141 @@
+import "server-only";
+import { maybeDb } from "@/lib/db";
+import { chainIdOf, isChainKey, type ChainKey } from "@/lib/chainPublic";
+import { getLaunchesByRefs, type LaunchRow } from "./queries";
+
+export const WATCHLIST_MAX_ITEMS = 50;
+export const WATCHLIST_WINDOW_MS = 30 * 24 * 60 * 60 * 1_000;
+export const WATCHLIST_BODY_MAX_BYTES = 16_384;
+const WATCHLIST_CLOCK_SKEW_MS = 5 * 60 * 1_000;
+
+/** All timestamps crossing this API boundary are integer Unix milliseconds. */
+export type WatchlistRequestItem = { chain: ChainKey; token: string; since: number | null };
+export type WatchlistDataItem = WatchlistRequestItem & {
+  launch: LaunchRow | null;
+  /** Null until transfer backfill is complete, or when this launch is unavailable. */
+  holders: number | null;
+  /** Indexed swaps and visible top-level creator posts in (since, at]. Null on a first visit. */
+  trades: number | null;
+  creatorPosts: number | null;
+  /** The returned `since` is the effective 30-day cutoff when this is true. */
+  windowClamped: boolean;
+};
+export type WatchlistData = { at: number; indexed: boolean; items: WatchlistDataItem[] };
+
+export class WatchlistInputError extends Error {
+  constructor(message: string, readonly status = 400) { super(message); }
+}
+
+/** Reject malformed lists before reads. Clamp small device-clock skew; never query a future baseline. */
+export function parseWatchlistRequest(value: unknown, at: number): WatchlistRequestItem[] {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { items?: unknown }).items)) {
+    throw new WatchlistInputError("expected a watchlist items array");
+  }
+  const items = (value as { items: unknown[] }).items;
+  if (items.length > WATCHLIST_MAX_ITEMS) throw new WatchlistInputError(`watch up to ${WATCHLIST_MAX_ITEMS} tokens`);
+  const seen = new Set<string>();
+  return items.map((value): WatchlistRequestItem => {
+    if (!value || typeof value !== "object") throw new WatchlistInputError("invalid watchlist item");
+    const { chain, token, since } = value as Record<string, unknown>;
+    if (!isChainKey(chain) || typeof token !== "string" || !/^0x[0-9a-f]{40}$/i.test(token)) {
+      throw new WatchlistInputError("invalid token reference");
+    }
+    if (since !== null && since !== undefined && (typeof since !== "number" || !Number.isSafeInteger(since) || since < 0 || since > at + WATCHLIST_CLOCK_SKEW_MS)) {
+      throw new WatchlistInputError("since must be a timestamp in milliseconds within the allowed clock skew");
+    }
+    return { chain, token: token.toLowerCase(), since: since == null ? null : Math.min(since as number, at) };
+  }).filter((item) => {
+    const key = `${item.chain}:${item.token}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/** Enforce the byte limit even on chunked bodies or an inaccurate Content-Length. */
+export async function readWatchlistBody(req: Request): Promise<unknown> {
+  if (req.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() !== "application/json") {
+    throw new WatchlistInputError("send application/json", 415);
+  }
+  if (Number(req.headers.get("content-length")) > WATCHLIST_BODY_MAX_BYTES) {
+    throw new WatchlistInputError("watchlist request is too large", 413);
+  }
+  const reader = req.body?.getReader();
+  if (!reader) throw new WatchlistInputError("empty request");
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > WATCHLIST_BODY_MAX_BYTES) {
+        await reader.cancel();
+        throw new WatchlistInputError("watchlist request is too large", 413);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return JSON.parse(text);
+  } catch (error) {
+    if (error instanceof WatchlistInputError) throw error;
+    throw new WatchlistInputError("invalid JSON body");
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Two bounded batch reads, no wallet identity or off-chain write. Counts reflect indexed history only. */
+export async function getWatchlistData(items: readonly WatchlistRequestItem[], at: number, ethUsd: number | null): Promise<WatchlistData> {
+  // Keep this server helper safe if a future caller bypasses the route parser.
+  const refs = parseWatchlistRequest({ items }, at);
+  const bounded = refs.map((item) => ({
+    ...item,
+    since: item.since === null ? null : Math.max(item.since, at - WATCHLIST_WINDOW_MS),
+    windowClamped: item.since !== null && item.since < at - WATCHLIST_WINDOW_MS,
+  }));
+  const blank = (): WatchlistDataItem[] => bounded.map((item) => ({ ...item, launch: null, holders: null, trades: null, creatorPosts: null }));
+  const db = maybeDb();
+  if (!db) return { at, indexed: false, items: blank() };
+  if (!refs.length) return { at, indexed: true, items: [] };
+  const windows = bounded.filter((item) => item.since !== null).map((item) => ({ chain_id: chainIdOf(item.chain), token: item.token, since: new Date(item.since!).toISOString() }));
+  type Counts = { chain_id: number; token: string; trades: string; creator_posts: string };
+  const [launches, counts] = await Promise.all([
+    getLaunchesByRefs(refs, ethUsd),
+    windows.length ? db<Counts[]>`
+      WITH watched AS (
+        SELECT * FROM jsonb_to_recordset(${db.json(windows)}) AS r(chain_id integer, token text, since timestamptz)
+      )
+      SELECT w.chain_id, w.token, s.trades, p.creator_posts
+        FROM watched w JOIN bb_launches l ON l.chain_id = w.chain_id AND l.token = w.token
+        LEFT JOIN LATERAL (
+          SELECT count(*)::text AS trades FROM bb_launch_swaps s
+           WHERE s.chain_id = w.chain_id AND s.token = w.token
+             AND s.block_time > w.since AND s.block_time <= to_timestamp(${at / 1_000})
+        ) s ON true
+        LEFT JOIN LATERAL (
+          SELECT count(*)::text AS creator_posts FROM bb_posts p
+           WHERE p.chain_id = w.chain_id AND p.token = w.token AND p.wallet = l.launcher
+             AND NOT p.hidden AND p.parent_id IS NULL
+             AND p.created_at > w.since AND p.created_at <= to_timestamp(${at / 1_000})
+        ) p ON true` : Promise.resolve([] as Counts[]),
+  ]);
+  const launchByKey = new Map(launches.map((item) => [`${item.launch.chain}:${item.launch.token}`, item]));
+  const countByKey = new Map(counts.map((item) => [`${item.chain_id}:${item.token}`, item]));
+  return {
+    at,
+    indexed: true,
+    items: bounded.map((item) => {
+      const found = launchByKey.get(`${item.chain}:${item.token}`);
+      const activity = countByKey.get(`${chainIdOf(item.chain)}:${item.token}`);
+      return {
+        ...item,
+        launch: found?.launch ?? null,
+        holders: found?.holders ?? null,
+        trades: found && item.since !== null && activity ? Number(activity.trades) : null,
+        creatorPosts: found && item.since !== null && activity ? Number(activity.creator_posts) : null,
+      };
+    }),
+  };
+}


### PR DESCRIPTION
## What changed

The market now uses the available screen width instead of nesting the launch list inside another card. The latest pass replaces the old instrument-table treatment with a calmer market tape and carries the same open layout through Posts, Me, How it works, Agents, token details and the launch form.

- Add a browser-local watchlist for up to 50 tokens, with chain-aware identities, cross-tab updates and saved checkpoints for catching up on indexed trades, creator posts and holder changes. No wallet connection or signature is needed.
- Add a bounded, read-only watchlist activity endpoint. Unknown or incomplete indexing stays explicit rather than becoming a misleading zero.
- Replace stacked filter trays with compact, keyboard-accessible Base UI chain and filter popovers. Keep search, sort, pagination and stable live ordering intact.
- Rebuild launches as an open market tape: underline Market/Saved tabs, 88px hairline rows, one dominant market-cap figure, factual order flow and a single first-trade divider. Use three aligned decision tracks on tablets and four on desktop; phone rows collapse to roughly 122px without clipping values or horizontal overflow.
- Remove row cards, avatar rings, ratio rails and repeated empty-state copy. Hover/focus now use only a calm wash and a fixed 2px Base-blue marker; reduced-motion behavior remains static.
- Refine the launch sequence, Posts, Me, How it works and Agents surfaces, including accessible documentation navigation and loading-state parity.
- Buffer new community-post additions while someone is reading without delaying authoritative edits or removals, and harden Me transaction actions around wallet changes and reverted receipts.
- Keep boundaries around inputs, code blocks and transaction controls; remove redundant section frames. No new dependencies or changes to transaction/signature logic.
- Guard the burn-filter query against non-array recipient JSON so malformed rows cannot crash the list. This excludes malformed rows; it does not rewrite stored data.

## Validation

- Production build and TypeScript pass.
- ESLint: no errors; two existing OG-image warnings remain.
- Full test suite: 397 tests, 396 passed and one opt-in database test skipped. The final focused market suite passes 18/18.
- Added watchlist, responsive-layout, market hierarchy, activity accessibility, community-refresh, transaction-safety and malformed-recipient regression coverage.
- Browser checked at 360px, 720px and 1528px across the responsive tape. The 360px state has no horizontal overflow, keeps values such as `$228.74` visible, and uses 44px Market/Saved and sort targets.
- A fresh independent finish review returned `SHIP`; no P0/P1/P2 release blockers remain.

## Review notes

This is a draft for product review. Please focus on market density at tablet width, the mobile information hierarchy, watchlist catch-up semantics, and the open layouts on the supporting pages.

No contracts or database schema changed. No wallet connection, signing, trading, launching or post submission was performed during UI verification. Build retains the existing dynamic-filesystem tracing warnings in `imageStore.ts`.

The preview is local only; no new hosted deployment is attached to this draft. Local agent configs, historical design notes, screenshots and the development-only public-posts review route are intentionally excluded from the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Market and Saved views with local watchlists, watch controls, activity summaries, and review status.
  - Added chain-aware filtering, search, sorting, responsive launch rows, and launch-stage visuals.
  - Added configurable slippage, token and quote-fee collection, and network-specific documentation examples.
  - Added watchlist activity data, refresh support, and community-feed updates with pending-post notifications.

- **UI Improvements**
  - Introduced a flatter, responsive workspace design across launch, market, feed, and documentation pages.
  - Improved loading states, navigation, typography, accessibility, and reduced-motion support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->