### PR TITLE
feat(security): per-IP rate limits on sync/meta/presence POST endpoints

### DIFF
--- a/app/src/app/api/launch/meta/route.ts
+++ b/app/src/app/api/launch/meta/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { rateLimited } from "@/lib/launchpad/editServer";
 import { MetaConflict, saveMeta, validateMeta } from "@/lib/launchpad/meta";
 import { LAUNCHPAD_CONFIGURED } from "@/lib/launchpad/config";
 
@@ -7,6 +8,10 @@ export const dynamic = "force-dynamic";
 /** POST — store off-chain metadata for a launch about to be sent; returns the metadataURI + predicted token. */
 export async function POST(req: Request) {
   if (!LAUNCHPAD_CONFIGURED) return NextResponse.json({ error: "launchpad unconfigured" }, { status: 503 });
+  // Unsigned by design (salt secrecy decides conflicts), so the IP bucket is
+  // the only thing stopping junk-row sprays and predictToken RPC burn.
+  const ip = (req.headers.get("fly-client-ip") || req.headers.get("x-forwarded-for") || "").split(",")[0].trim() || "0.0.0.0";
+  if (rateLimited(`meta:ip:${ip}`, 20)) return NextResponse.json({ error: "slow down" }, { status: 429 });
   let body: unknown;
   try {
     body = await req.json();

--- a/app/src/app/api/launch/sync/route.ts
+++ b/app/src/app/api/launch/sync/route.ts
@@ -1,11 +1,17 @@
 import { NextResponse } from "next/server";
 import { isChainKey } from "@/lib/chainPublic";
+import { rateLimited } from "@/lib/launchpad/editServer";
 import { applyLaunchTx, pollAll } from "@/lib/launchpad/indexer";
 
 export const dynamic = "force-dynamic";
 
 /** POST /api/launch/sync?chain=base|robinhood&tx=0x…  → apply one receipt now. No tx → poll every configured chain. */
 export async function POST(req: Request) {
+  // Unauthenticated and the most expensive route in the app (a tx-less call
+  // fans out over every configured chain: log ranges, heals and backfills),
+  // so it gets the same per-IP bucket as the other write endpoints.
+  const ip = (req.headers.get("fly-client-ip") || req.headers.get("x-forwarded-for") || "").split(",")[0].trim() || "0.0.0.0";
+  if (rateLimited(`sync:ip:${ip}`, 10)) return NextResponse.json({ error: "slow down" }, { status: 429 });
   const u = new URL(req.url);
   const tx = u.searchParams.get("tx");
   const chain = u.searchParams.get("chain") ?? "base";

--- a/app/src/app/api/presence/route.ts
+++ b/app/src/app/api/presence/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { rateLimited } from "@/lib/launchpad/editServer";
 import { looksLikeBot, prunePresence, readPulse, recordBeacon, visitorHash } from "@/lib/launchpad/presence";
 import { memo } from "@/lib/launchpad/memo";
 
@@ -16,6 +17,10 @@ export async function POST(req: Request) {
   const ua = req.headers.get("user-agent") ?? "";
   if (looksLikeBot(ua)) return NextResponse.json(await readPulse(), { headers: { "cache-control": "no-store" } });
   const ip = (req.headers.get("fly-client-ip") || req.headers.get("x-forwarded-for") || "").split(",")[0].trim() || "0.0.0.0";
+  // The visitor hash mixes in the UA, which the caller fully controls: without
+  // a bucket, rotating UAs mints a fresh bb_presence row per request and
+  // inflates visits. 30/min leaves normal beaconing (~every few seconds) alone.
+  if (rateLimited(`presence:ip:${ip}`, 30)) return NextResponse.json({ error: "slow down" }, { status: 429 });
   const pulse = await recordBeacon(visitorHash(ip, ua));
   if (Date.now() - lastPrune > 3_600_000) {
     lastPrune = Date.now();

--- a/app/src/app/api/write-limits.test.ts
+++ b/app/src/app/api/write-limits.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+/**
+ * Pin the per-IP rate-limit wiring on the unauthenticated write endpoints.
+ * The limiter behavior itself is unit-tested in editServer.test.ts; these
+ * assertions fail if anyone drops the check from a route (the same
+ * source-structural pattern as the preparing-controls test in
+ * transaction-safety.test.ts, since importing Next routes into node --test
+ * is not supported).
+ */
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+for (
+  const { file, bucket, mustPrecede } of [
+    { file: "./launch/sync/route.ts", bucket: "sync:ip", mustPrecede: "pollAll()" },
+    { file: "./launch/meta/route.ts", bucket: "meta:ip", mustPrecede: "req.json()" },
+    { file: "./presence/route.ts", bucket: "presence:ip", mustPrecede: "recordBeacon(" },
+  ]
+) {
+  test(`${file} rate-limits by IP before doing work`, () => {
+    const src = source(file);
+    assert.match(src, /from "@\/lib\/launchpad\/editServer"/, "imports the shared limiter");
+    assert.ok(src.includes("rateLimited(`" + bucket + ":${ip}`"), `calls rateLimited with a ${bucket} key`);
+    assert.match(src, /\{\s*error:\s*"slow down"\s*\},\s*\{\s*status:\s*429\s*\}/, "answers 429 like the sibling write routes");
+    assert.ok(
+      src.indexOf("rateLimited(`" + bucket) < src.indexOf(mustPrecede),
+      `the limit runs before ${mustPrecede}`,
+    );
+  });
+}
+
+test("presence still short-circuits bots before counting the bucket", () => {
+  const src = source("./presence/route.ts");
+  assert.ok(src.indexOf("looksLikeBot(ua)") < src.indexOf("rateLimited(`presence:ip"), "bot beacons never touch the limiter or the DB");
+});
+
+test("sync still validates tx/chain shapes with 400s", () => {
+  const src = source("./launch/sync/route.ts");
+  assert.match(src, /\{\s*error:\s*"bad tx"\s*\},\s*\{\s*status:\s*400\s*\}/);
+  assert.match(src, /\{\s*error:\s*"bad chain"\s*\},\s*\{\s*status:\s*400\s*\}/);
+});


### PR DESCRIPTION
Three unauthenticated write endpoints had no rate limit while every sibling does: sync is the most expensive route in the app (10/min), meta is unsigned by design so the IP bucket is the only spam defense (20/min), and presence hashes caller-controlled UA into a DB row per variant (30/min after the bot short-circuit). All follow the existing edit/posts 429 slow-down pattern. New write-limits.test.ts pins the wiring; limiter behavior is covered in editServer.test.ts. Verified: full app suite 338/338, lint, typecheck, build.